### PR TITLE
Add robust HTTP parser and Docker tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Build artifacts
+build/
+*.o
+*.a
+*.so
+*.dylib
+
+# Git
+.git/
+.gitignore
+.github/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Documentation (include in image but not needed for build cache)
+# README.md
+# TODO.md
+# CONTRIBUTING.md
+
+# Test outputs
+test_results/
+*.log
+
+# macOS
+.DS_Store
+
+# Coverage reports
+coverage/
+*.gcov
+*.gcda
+*.gcno

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,324 @@
+# Modern C Web Library - AI Agent Instructions
+
+## Project Philosophy: Pure C Implementation
+
+This is a **strict pure C project** with zero external dependencies. All contributions must align with this core principle:
+
+- **Language**: ISO C (C99/C11) only - no Python, JavaScript, or other languages
+- **Dependencies**: None - implement everything from scratch in C
+- **Libraries**: Only standard C library + platform APIs (POSIX, Windows API)
+- **Goal**: Demonstrate that modern web backends can be built entirely in self-sufficient C
+
+**Critical**: Never suggest external libraries (OpenSSL, libcurl, cJSON, etc.). If a feature needs implementation, write it in pure C.
+
+## Architecture Overview
+
+### Component Structure
+
+The library follows a modular design with four core components:
+
+1. **HTTP Server** (`src/http_server.c`): Handles both threaded and async I/O modes
+   - Threaded mode: `pthread` for concurrent connections
+   - Async mode: Event loop for non-blocking I/O (see below)
+   - Connection handling: `MAX_CONNECTIONS=128`, `BUFFER_SIZE=8192`
+
+2. **Event Loop** (`src/event_loop.c`): Platform-specific async I/O backends
+   - Linux: `epoll` (high performance)
+   - macOS/BSD: `kqueue` (high performance) 
+   - Fallback: `poll` (portable)
+   - Compile-time selection via preprocessor directives
+   - Max events: 1024, Max timers: 64
+
+3. **Router** (`src/router.c`): Request routing with middleware chain
+   - Static limits: `MAX_ROUTES=256`, `MAX_MIDDLEWARES=32`
+   - Route parameters: `/users/:id` pattern matching
+   - Middleware: Boolean return (true=continue, false=stop)
+
+4. **JSON Parser** (`src/json.c`): Hand-written JSON parser/serializer
+   - No external JSON library - custom implementation
+   - Linked list structures for objects/arrays
+   - Memory management: All JSON must be freed with `json_value_free()`
+
+### Operating Modes
+
+The server supports two modes that affect I/O handling:
+
+**Threaded Mode** (default):
+- `pthread` creates thread per connection
+- Blocking I/O operations
+- Simpler programming model
+- Example: `examples/simple_server.c`
+
+**Async Mode** (via `http_server_set_async(true)`):
+- Event loop with non-blocking I/O
+- Single-threaded, handles thousands of connections
+- Requires event-driven programming
+- Example: `examples/async_server.c`
+
+## Development Workflows
+
+### Building and Testing
+
+**Using Docker (Recommended for Contributors):**
+```bash
+# Run all tests in consistent environment
+./docker-run.sh test
+
+# Start development container with volume mount
+./docker-run.sh dev
+
+# Inside container: build, test, debug
+cd build
+cmake .. && make
+make test
+./tests/test_weblib
+valgrind --leak-check=full ./tests/test_weblib
+```
+
+**Native Build:**
+```bash
+# Initial build
+mkdir build && cd build
+cmake ..
+make
+
+# Run tests (custom test framework, no external test libs)
+make test
+./tests/test_weblib
+
+# Run examples
+./examples/simple_server [port]    # Default: 8080
+./examples/async_server [port]
+```
+
+**Docker Quick Reference:**
+- `./docker-run.sh test` - Run tests
+- `./docker-run.sh dev` - Development shell
+- `./docker-run.sh async` - Run server
+- See `DOCKER.md` for complete guide
+
+### Platform-Specific Compilation
+
+The project uses preprocessor directives for platform detection:
+
+```c
+#ifdef __linux__
+    // Linux-specific (epoll)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+    // macOS/BSD-specific (kqueue)
+#elif defined(_WIN32)
+    // Windows-specific
+#else
+    // Portable fallback (poll)
+#endif
+```
+
+CMake sets `PLATFORM_LIBS` automatically:
+- Linux/macOS: `pthread`
+- Windows: `ws2_32`
+
+## Coding Conventions
+
+### Naming and Style
+
+- **Functions**: `snake_case` → `http_server_create()`, `event_loop_run()`
+- **Types**: `snake_case_t` suffix → `http_server_t`, `json_value_t`
+- **Enums**: `UPPER_SNAKE_CASE` → `HTTP_GET`, `HTTP_OK`, `EVENT_READ`
+- **Internal/Static**: Prefix `_` → `_internal_helper()`
+- **Indentation**: 4 spaces (no tabs)
+- **Braces**: K&R style (opening brace on same line)
+
+### Memory Management Patterns
+
+**Critical**: All allocations must have corresponding frees. Common patterns:
+
+```c
+// Server lifecycle
+http_server_t *server = http_server_create();  // malloc
+// ... use server ...
+http_server_destroy(server);                   // free
+
+// JSON lifecycle
+json_value_t *json = json_object_create();
+json_object_set(json, "key", json_string_create("value"));
+http_response_send_json(res, HTTP_OK, json);
+json_value_free(json);  // MUST free after use
+
+// Router lifecycle
+router_t *router = router_create();
+router_add_route(router, HTTP_GET, "/", handler);
+http_server_set_router(server, router);
+// ... 
+router_destroy(router);  // Separate from server
+```
+
+### Error Handling Pattern
+
+Return codes follow POSIX convention:
+- Success: `0`
+- Failure: `-1` (check `errno` for system errors)
+- Pointers: `NULL` on failure
+
+```c
+int result = http_server_listen(server, port);
+if (result < 0) {
+    perror("Failed to start server");
+    return 1;
+}
+```
+
+### Route Handler Signature
+
+All route handlers must match this signature:
+
+```c
+void handler_name(http_request_t *req, http_response_t *res) {
+    // Extract data
+    const char *param = http_request_get_param(req, "id");
+    const char *header = http_request_get_header(req, "Content-Type");
+    
+    // Send response (marks res->sent = true internally)
+    http_response_send_text(res, HTTP_OK, "Response body");
+    // OR
+    json_value_t *json = json_object_create();
+    http_response_send_json(res, HTTP_OK, json);
+    json_value_free(json);
+}
+```
+
+### Middleware Pattern
+
+Middleware chains execute before route handlers:
+
+```c
+bool middleware_name(http_request_t *req, http_response_t *res) {
+    // Modify request/response
+    http_response_set_header(res, "X-Custom", "value");
+    
+    // Control flow
+    return true;   // Continue to next middleware/handler
+    return false;  // Stop processing (e.g., auth failure)
+}
+
+// Registration (executes in order added)
+router_use_middleware(router, logging_middleware);
+router_use_middleware(router, cors_middleware);
+```
+
+## Common Implementation Patterns
+
+### Adding New Routes
+
+When adding endpoints, follow the example pattern:
+
+1. Define handler function
+2. Register in `main()` with `router_add_route()`
+3. Use `http_request_get_param()` for URL parameters
+4. Always send response via `http_response_send_text()` or `http_response_send_json()`
+
+### Async I/O Implementation
+
+When working with async mode:
+
+1. Call `http_server_set_async(server, true)` before `http_server_listen()`
+2. Get event loop: `event_loop_t *loop = http_server_get_event_loop(server)`
+3. The server internally uses event callbacks for read/write operations
+4. Signal handlers should call `event_loop_stop(loop)` for graceful shutdown
+
+### Platform-Specific Features
+
+When adding platform-specific code:
+
+1. Use `#ifdef` guards matching existing patterns
+2. Provide fallback implementation for unsupported platforms
+3. Test on Linux, macOS, and Windows (if possible)
+4. Document platform limitations in code comments
+
+## Testing Strategy
+
+Custom test framework (no external libraries like CUnit):
+
+```c
+// Test structure
+void test_feature_name(void) {
+    TEST("feature_name");
+    
+    // Setup
+    feature_t *f = feature_create();
+    ASSERT(f != NULL);
+    
+    // Test logic
+    ASSERT(some_condition);
+    
+    // Cleanup
+    feature_destroy(f);
+    
+    PASS();
+}
+```
+
+Add new tests to `tests/test_weblib.c` and call from `main()`. No CTest configuration changes needed.
+
+## Integration Points
+
+### Server-Router Interaction
+
+The server holds a pointer to the router but doesn't own it:
+
+```c
+http_server_t *server = http_server_create();
+router_t *router = router_create();
+http_server_set_router(server, router);  // Server stores reference only
+// Must destroy both separately
+router_destroy(router);
+http_server_destroy(server);
+```
+
+### Event Loop Integration
+
+In async mode, the server creates and manages the event loop internally:
+- `http_server_set_async()` → creates `event_loop_t`
+- `http_server_listen()` → runs event loop (blocking)
+- `event_loop_stop()` → breaks from loop
+- `http_server_destroy()` → destroys event loop
+
+Don't create separate event loops unless implementing custom async patterns.
+
+## Key Files Reference
+
+- **API Surface**: `include/weblib.h` - all public declarations
+- **Examples**: `examples/simple_server.c` (threaded), `examples/async_server.c` (event loop)
+- **Build Config**: `CMakeLists.txt` - platform detection, compiler flags
+- **Roadmap**: `TODO.md` - planned features prioritized by 🎯/🔧/💡
+- **Contributing**: `CONTRIBUTING.md` - detailed style guide and philosophy
+
+## Common Pitfalls to Avoid
+
+1. **Never suggest external dependencies** - implement in pure C
+2. **Don't mix async/threaded patterns** - server uses one mode at a time
+3. **Memory leaks**: Always pair create/destroy, especially JSON objects
+4. **Platform assumptions**: Test `#ifdef` guards on multiple platforms
+5. **Buffer sizes**: Respect `BUFFER_SIZE=8192` and static array limits
+6. **Response handling**: Don't send response multiple times (check `res->sent`)
+7. **Threading**: Only threaded mode uses `pthread`, async mode is single-threaded
+
+## When Adding New Features
+
+Before implementing new functionality:
+
+1. Check `TODO.md` for planned approach and priority
+2. Verify it can be implemented in pure C without dependencies
+3. Consider platform portability (Linux/macOS/Windows)
+4. Write tests following existing test patterns
+5. Add example usage to `examples/` if user-facing
+6. Update `README.md` API reference section
+7. Follow memory management patterns (create/destroy pairing)
+
+## Quick Reference
+
+**Start server**: `http_server_create()` → `http_server_set_router()` → `http_server_listen()` → cleanup  
+**Add route**: `router_add_route(router, method, path, handler)`  
+**JSON creation**: `json_object_create()` → `json_object_set()` → `json_value_free()`  
+**Async mode**: `http_server_set_async(true)` before `http_server_listen()`  
+**Event loop backends**: epoll (Linux) > kqueue (BSD/macOS) > poll (fallback)  
+**Static limits**: 128 connections, 256 routes, 32 middlewares, 1024 events, 64 timers

--- a/DOCKER-QUICKREF.md
+++ b/DOCKER-QUICKREF.md
@@ -1,0 +1,170 @@
+# Docker Quick Reference
+
+## Essential Commands for Contributors
+
+### First Time Setup
+```bash
+# 1. Install Docker Desktop
+# Download from: https://docs.docker.com/get-docker/
+
+# 2. Clone repository
+git clone https://github.com/kamrankhan78694/modern-c-web-library.git
+cd modern-c-web-library
+
+# 3. Make scripts executable
+chmod +x docker-run.sh docker-verify.sh
+
+# 4. Verify Docker setup
+./docker-verify.sh
+```
+
+### Daily Development Workflow
+
+```bash
+# Start development container (opens shell)
+./docker-run.sh dev
+
+# Inside container:
+cd build
+make                    # Build
+make test              # Run tests
+./examples/async_server # Run server
+valgrind --leak-check=full ./tests/test_weblib  # Check memory
+```
+
+### Quick Commands
+
+| Command | Purpose |
+|---------|---------|
+| `./docker-run.sh test` | Run all tests |
+| `./docker-run.sh dev` | Start dev shell |
+| `./docker-run.sh async` | Run async server |
+| `./docker-run.sh threaded 3000` | Run threaded server on port 3000 |
+| `./docker-run.sh build` | Build images only |
+
+### Docker Compose Commands
+
+```bash
+# Run async server (default)
+docker-compose up weblib-async
+
+# Run threaded server
+docker-compose --profile threaded up weblib-threaded
+
+# Development mode
+docker-compose --profile dev up weblib-dev
+
+# Stop all services
+docker-compose down
+```
+
+### Manual Docker Commands
+
+```bash
+# Build development image
+docker build -f Dockerfile.dev -t modern-c-weblib:dev .
+
+# Build production image
+docker build -t modern-c-weblib:latest .
+
+# Run dev container with volume mount
+docker run -it -v $(pwd):/workspace -p 8080:8080 modern-c-weblib:dev
+
+# Run production server
+docker run -p 8080:8080 modern-c-weblib:latest
+
+# Run tests only
+docker run --rm modern-c-weblib:dev /bin/bash -c "cd build && make test"
+```
+
+### Troubleshooting
+
+```bash
+# Docker not running
+# → Start Docker Desktop
+
+# Port already in use
+./docker-run.sh async 8081  # Use different port
+
+# Rebuild without cache
+docker build --no-cache -f Dockerfile.dev -t modern-c-weblib:dev .
+
+# View logs
+docker logs <container-name>
+
+# Clean up
+docker system prune          # Remove unused containers/images
+docker container prune       # Remove stopped containers
+docker image prune          # Remove unused images
+```
+
+### Testing Checklist
+
+Before submitting a PR:
+- [ ] `./docker-run.sh test` - All tests pass
+- [ ] `./docker-run.sh dev` then `cd build && make 2>&1 | grep -i warning` - No warnings
+- [ ] `valgrind --leak-check=full ./tests/test_weblib` - No memory leaks
+- [ ] Code follows style guide (see CONTRIBUTING.md)
+
+### Development Tips
+
+1. **Edit Locally, Build in Docker**
+   - Use your favorite editor on your machine
+   - Files are automatically synced via volume mount
+   - Build and test in consistent Docker environment
+
+2. **Debugging**
+   ```bash
+   ./docker-run.sh dev
+   cd build
+   gdb ./examples/async_server
+   ```
+
+3. **Memory Leak Detection**
+   ```bash
+   ./docker-run.sh dev
+   cd build
+   valgrind --leak-check=full --show-leak-kinds=all ./tests/test_weblib
+   ```
+
+4. **Check Build Warnings**
+   ```bash
+   docker run modern-c-weblib:dev /bin/bash -c "cd build && cmake .. && make 2>&1 | grep -i warning"
+   ```
+
+### File Structure
+
+```
+modern-c-web-library/
+├── Dockerfile              # Production image (multi-stage)
+├── Dockerfile.dev          # Development image (full toolchain)
+├── docker-compose.yml      # Service orchestration
+├── docker-run.sh           # Helper script
+├── docker-verify.sh        # Verification script
+├── .dockerignore          # Files to exclude from build
+└── DOCKER.md              # Complete Docker guide
+```
+
+### Environment Details
+
+**Development Container:**
+- Base: GCC 11
+- Tools: cmake, make, gdb, valgrind, git, vim
+- Size: ~1.2GB
+- Default command: bash shell
+
+**Production Container:**
+- Base: Debian Bullseye Slim
+- Size: ~150MB
+- Contains: Compiled executables only
+- Default command: Run async_server
+
+### Support
+
+- **Full Documentation**: See [DOCKER.md](DOCKER.md)
+- **Contributing Guide**: See [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Issues**: https://github.com/kamrankhan78694/modern-c-web-library/issues
+
+---
+
+**Remember**: Docker is for development/CI only. The library itself remains pure C with zero dependencies!

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,400 @@
+# Docker Guide for Modern C Web Library
+
+This guide helps contributors build, test, and develop the Modern C Web Library using Docker for a consistent, reproducible environment.
+
+## Quick Start for Contributors
+
+### Prerequisites
+- Docker installed ([Get Docker](https://docs.docker.com/get-docker/))
+- Git (to clone the repository)
+
+### Build and Test in One Command
+
+```bash
+# Clone the repository
+git clone https://github.com/kamrankhan78694/modern-c-web-library.git
+cd modern-c-web-library
+
+# Build and run tests
+./docker-run.sh test
+```
+
+That's it! Docker will handle all dependencies, build the library, and run tests.
+
+## Docker Images
+
+### Production Image (`Dockerfile`)
+- **Purpose**: Lightweight runtime image for deployment
+- **Size**: ~150MB
+- **Contains**: Only compiled executables (no build tools)
+- **Use case**: Running the server in production
+
+### Development Image (`Dockerfile.dev`)
+- **Purpose**: Full development environment
+- **Size**: ~1.2GB  
+- **Contains**: GCC, CMake, Make, GDB, Valgrind, Git
+- **Use case**: Building, testing, debugging, contributing
+
+## Common Development Workflows
+
+### 1. Run Tests
+
+```bash
+./docker-run.sh test
+```
+
+This will:
+1. Build the development Docker image
+2. Compile the library inside the container
+3. Run all tests
+4. Display test results
+
+### 2. Interactive Development
+
+Start a development container with your code mounted:
+
+```bash
+./docker-run.sh dev
+```
+
+Inside the container:
+```bash
+# Navigate to build directory
+cd build
+
+# Build the project
+cmake ..
+make
+
+# Run tests
+make test
+./tests/test_weblib
+
+# Run example server
+./examples/simple_server
+# or
+./examples/async_server
+
+# Debug with GDB
+gdb ./examples/async_server
+
+# Check for memory leaks
+valgrind --leak-check=full ./tests/test_weblib
+```
+
+Your local code changes are immediately available in the container via volume mount.
+
+### 3. Quick Build Verification
+
+```bash
+# Build images only (no run)
+./docker-run.sh build
+```
+
+### 4. Run the Server
+
+```bash
+# Run async server on port 8080
+./docker-run.sh async
+
+# Run threaded server on custom port
+./docker-run.sh threaded 3000
+```
+
+## Using Docker Compose
+
+### Run Async Server (Default)
+```bash
+docker-compose up weblib-async
+```
+Access at: http://localhost:8080
+
+### Run Threaded Server
+```bash
+docker-compose --profile threaded up weblib-threaded
+```
+Access at: http://localhost:8081
+
+### Development Mode
+```bash
+docker-compose --profile dev up weblib-dev
+```
+Opens interactive shell with your code mounted.
+
+## Manual Docker Commands
+
+### Build Development Image
+```bash
+docker build -f Dockerfile.dev -t modern-c-weblib:dev .
+```
+
+### Run Development Container
+```bash
+docker run -it -v $(pwd):/workspace -p 8080:8080 modern-c-weblib:dev
+```
+
+### Build Production Image
+```bash
+docker build -t modern-c-weblib:latest .
+```
+
+### Run Production Container
+```bash
+docker run -p 8080:8080 modern-c-weblib:latest
+```
+
+## Testing Workflow
+
+### Run All Tests
+```bash
+./docker-run.sh test
+```
+
+Expected output:
+```
+Testing router_create... PASSED
+Testing router_add_route... PASSED
+Testing json_object_create... PASSED
+Testing json_string_create... PASSED
+...
+All tests passed! (X/X)
+```
+
+### Run Tests Manually
+```bash
+# Start dev container
+docker run -it modern-c-weblib:dev
+
+# Inside container
+cd build
+make test
+./tests/test_weblib
+```
+
+### Run Tests with Valgrind
+```bash
+# Start dev container
+docker run -it modern-c-weblib:dev
+
+# Inside container
+cd build
+valgrind --leak-check=full --show-leak-kinds=all ./tests/test_weblib
+```
+
+## Contributing with Docker
+
+### Step 1: Fork and Clone
+```bash
+git clone https://github.com/YOUR_USERNAME/modern-c-web-library.git
+cd modern-c-web-library
+```
+
+### Step 2: Start Development Container
+```bash
+./docker-run.sh dev
+```
+
+### Step 3: Make Changes
+Edit files on your local machine using your preferred editor. Changes are reflected immediately in the container via volume mount.
+
+### Step 4: Build and Test
+Inside the container:
+```bash
+cd build
+cmake ..
+make
+make test
+```
+
+### Step 5: Verify No Warnings
+```bash
+cd build
+cmake .. && make 2>&1 | grep -i warning
+# Should show no output
+```
+
+### Step 6: Check Memory Leaks
+```bash
+cd build
+valgrind --leak-check=full ./tests/test_weblib
+# Should show "no leaks are possible"
+```
+
+### Step 7: Commit and Push
+```bash
+git add .
+git commit -m "Your changes"
+git push origin your-branch-name
+```
+
+## Troubleshooting
+
+### Port Already in Use
+```bash
+# Use a different port
+./docker-run.sh async 8081
+```
+
+### Build Cache Issues
+```bash
+# Rebuild without cache
+docker build --no-cache -f Dockerfile.dev -t modern-c-weblib:dev .
+```
+
+### Container Permission Issues
+If you get permission errors with volume mounts:
+```bash
+# Run with your user ID
+docker run -it -v $(pwd):/workspace -u $(id -u):$(id -g) modern-c-weblib:dev
+```
+
+### View Container Logs
+```bash
+# If using docker-compose
+docker-compose logs weblib-async
+
+# If using docker run with -d flag
+docker logs <container-id>
+```
+
+### Clean Up Containers
+```bash
+# Stop all containers
+docker stop $(docker ps -aq)
+
+# Remove all stopped containers
+docker container prune
+
+# Remove unused images
+docker image prune
+```
+
+## Environment Details
+
+### Installed Tools (Development Image)
+- **Compiler**: GCC 11 (C11 standard)
+- **Build System**: CMake 3.18+
+- **Build Tool**: GNU Make
+- **Debugger**: GDB
+- **Memory Checker**: Valgrind
+- **Editor**: Vim (basic)
+- **Version Control**: Git
+
+### Platform Information
+Docker containers run Linux (Debian Bullseye), which means:
+- Event loop uses **epoll** backend (Linux high-performance I/O)
+- Threading uses **pthread** (POSIX threads)
+- All tests run in a consistent Linux environment
+
+### Build Configuration
+Default CMake configuration:
+- C Standard: C11
+- Compiler Flags: `-Wall -Wextra -pedantic`
+- Build Type: Default (no optimization flags for debugging)
+
+## CI/CD Integration
+
+### GitHub Actions Example
+```yaml
+name: Docker Build and Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Build and Test
+        run: |
+          chmod +x docker-run.sh
+          ./docker-run.sh test
+```
+
+### GitLab CI Example
+```yaml
+docker-test:
+  image: docker:latest
+  services:
+    - docker:dind
+  script:
+    - chmod +x docker-run.sh
+    - ./docker-run.sh test
+```
+
+## Docker Helper Script Reference
+
+The `docker-run.sh` script provides convenient shortcuts:
+
+```bash
+./docker-run.sh [MODE] [PORT]
+```
+
+**Modes:**
+- `async` - Run async server (default port: 8080)
+- `threaded` - Run threaded server
+- `dev` - Start development container with shell
+- `build` - Build Docker images only
+- `test` - Build and run all tests
+- `help` - Show usage information
+
+**Examples:**
+```bash
+./docker-run.sh                  # Run async server on 8080
+./docker-run.sh async 3000       # Run async server on 3000
+./docker-run.sh dev              # Start dev container
+./docker-run.sh test             # Run tests
+./docker-run.sh build            # Build images
+```
+
+## Best Practices for Contributors
+
+1. **Always run tests before committing:**
+   ```bash
+   ./docker-run.sh test
+   ```
+
+2. **Check for memory leaks in new code:**
+   ```bash
+   docker run -it modern-c-weblib:dev
+   cd build && valgrind --leak-check=full ./tests/test_weblib
+   ```
+
+3. **Verify no compiler warnings:**
+   ```bash
+   docker run modern-c-weblib:dev /bin/bash -c "cd build && cmake .. && make 2>&1 | grep -i warning"
+   ```
+
+4. **Test on fresh environment:**
+   Docker ensures a clean build environment every time, catching dependency issues.
+
+5. **Use volume mounts for development:**
+   Edit locally, build in container - best of both worlds.
+
+## Why Docker for This Project?
+
+1. **Zero Setup**: Contributors don't need to install GCC, CMake, or other tools
+2. **Consistent Environment**: Same build environment for everyone
+3. **Platform Independent**: Works on Windows, macOS, Linux
+4. **CI/CD Ready**: Same Docker setup works in automated pipelines
+5. **Isolation**: Doesn't interfere with your system tools/libraries
+6. **Pure C Philosophy**: Docker is only for development; the library remains dependency-free
+
+## Resources
+
+- **Docker Documentation**: https://docs.docker.com
+- **Project Repository**: https://github.com/kamrankhan78694/modern-c-web-library
+- **Contributing Guide**: See [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Issues**: https://github.com/kamrankhan78694/modern-c-web-library/issues
+
+## Questions?
+
+If you have questions about the Docker setup:
+1. Check this guide's troubleshooting section
+2. Review Docker documentation
+3. Open an issue on GitHub with the `docker` label
+
+---
+
+Happy coding! 🐳

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# Multi-stage Dockerfile for Modern C Web Library
+
+# Stage 1: Builder
+FROM gcc:11 as builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    cmake \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /build
+
+# Copy source code
+COPY . .
+
+# Build the library and examples
+RUN mkdir -p build && cd build && \
+    cmake .. && \
+    make
+
+# Stage 2: Runtime
+FROM debian:bullseye-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    libpthread-stubs0-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR /app
+
+# Copy built executables from builder stage
+COPY --from=builder /build/build/examples/simple_server /app/simple_server
+COPY --from=builder /build/build/examples/async_server /app/async_server
+
+# Expose default port
+EXPOSE 8080
+
+# Default to running the async server (better for production)
+CMD ["/app/async_server", "8080"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,31 @@
+# Development Dockerfile for Modern C Web Library
+# This image includes all build tools for development and testing
+
+FROM gcc:11
+
+# Install development dependencies
+RUN apt-get update && apt-get install -y \
+    cmake \
+    make \
+    gdb \
+    valgrind \
+    vim \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /workspace
+
+# Copy source code (will be overridden by volume mount in dev)
+COPY . .
+
+# Build the project
+RUN mkdir -p build && cd build && \
+    cmake .. && \
+    make
+
+# Expose default port
+EXPOSE 8080
+
+# Default command opens a shell for development
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -79,7 +79,30 @@ This policy emphasizes **C craftsmanship** over convenience through other ecosys
 
 ## Quick Start
 
-### Building the Library
+### Option 1: Using Docker (Recommended for Contributors)
+
+Docker provides a consistent build environment without installing dependencies:
+
+```bash
+# Clone the repository
+git clone https://github.com/kamrankhan78694/modern-c-web-library.git
+cd modern-c-web-library
+
+# Build and run tests
+./docker-run.sh test
+
+# Start development environment
+./docker-run.sh dev
+
+# Run the server
+./docker-run.sh async
+```
+
+See [DOCKER.md](DOCKER.md) for complete Docker documentation.
+
+### Option 2: Building Locally
+
+#### Building the Library
 
 ```bash
 # Create build directory
@@ -95,7 +118,7 @@ make
 make test
 ```
 
-### Running the Example Server
+#### Running the Example Server
 
 ```bash
 # From build directory
@@ -315,7 +338,26 @@ modern-c-web-library/
 
 ## Building on Different Platforms
 
-### Linux/macOS
+### Using Docker (All Platforms)
+
+Docker provides the easiest way to build and test on any platform:
+
+```bash
+# Build and test
+./docker-run.sh test
+
+# Development environment
+./docker-run.sh dev
+
+# Run server
+./docker-run.sh async
+```
+
+See [DOCKER.md](DOCKER.md) for detailed Docker usage.
+
+### Native Builds
+
+#### Linux/macOS
 
 ```bash
 mkdir build && cd build
@@ -323,7 +365,7 @@ cmake ..
 make
 ```
 
-### Windows (Visual Studio)
+#### Windows (Visual Studio)
 
 ```bash
 mkdir build && cd build
@@ -331,7 +373,7 @@ cmake .. -G "Visual Studio 16 2019"
 cmake --build .
 ```
 
-### Windows (MinGW)
+#### Windows (MinGW)
 
 ```bash
 mkdir build && cd build
@@ -340,6 +382,18 @@ mingw32-make
 ```
 
 ## Testing
+
+### Using Docker (Recommended)
+
+```bash
+# Run all tests in Docker
+./docker-run.sh test
+
+# Or with docker-compose
+docker-compose --profile dev run --rm weblib-dev /bin/bash -c "cd build && make test"
+```
+
+### Native Testing
 
 Run the test suite:
 
@@ -351,13 +405,48 @@ make test
 ./tests/test_weblib
 ```
 
+### Memory Leak Testing with Valgrind (Docker)
+
+```bash
+# Start dev container
+./docker-run.sh dev
+
+# Inside container
+cd build
+valgrind --leak-check=full ./tests/test_weblib
+```
+
 ## Requirements
 
+### For Docker Users (Recommended)
+- Docker Desktop (Windows/macOS) or Docker Engine (Linux)
+- Git
+- **No other dependencies needed!**
+
+### For Native Builds
 - C11 compatible compiler (GCC, Clang, MSVC)
 - CMake 3.10 or higher
 - POSIX threads (Linux/macOS) or Windows threads
 
 **No External Dependencies**: This library uses only standard C library functions and platform-specific system libraries and APIs (such as POSIX threads, Windows API for sockets and threading, etc.). No third-party libraries are required or used.
+
+## Docker Support
+
+The project includes full Docker support for development and deployment:
+
+- **Development Environment**: Full toolchain with GCC, CMake, GDB, Valgrind
+- **Production Image**: Minimal runtime image (~150MB)
+- **Easy Testing**: Run tests with a single command
+- **Consistent Builds**: Same environment for all contributors
+
+**Quick Start:**
+```bash
+./docker-run.sh test    # Run tests
+./docker-run.sh dev     # Start development container
+./docker-run.sh async   # Run server
+```
+
+**Documentation**: See [DOCKER.md](DOCKER.md) for complete Docker guide.
 
 ## License
 
@@ -366,6 +455,15 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Contributing
 
 Contributions are welcome! We appreciate your interest in improving the Modern C Web Library.
+
+**Quick Start for Contributors:**
+```bash
+# Using Docker (recommended)
+git clone https://github.com/kamrankhan78694/modern-c-web-library.git
+cd modern-c-web-library
+./docker-run.sh test    # Verify everything works
+./docker-run.sh dev     # Start development environment
+```
 
 Please read our [Contributing Guidelines](CONTRIBUTING.md) for details on:
 - Development setup and workflow

--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,22 @@ This document tracks planned features, enhancements, and improvements for the Mo
 
 ### Request/Response Handling
 
+- [ ] 🎯 **Complete HTTP Parser** - Fully parse and validate incoming requests
+  - Method support beyond GET with explicit error responses
+  - Header parsing, canonicalization, and lookup APIs
+  - Content-Length and chunked body handling with size safeguards
+  - Clear rejection of malformed or oversized payloads
+
+- [ ] 🎯 **Header & Parameter Storage** - Back middleware and handlers with real data
+  - Implement request header access and mutation
+  - Persist route parameters for `/path/:id` patterns
+  - Support response header setting and serialization
+
+- [ ] 🎯 **Robust Connection Handling** - Hardening for sync and async servers
+  - Looping reads/writes with back-pressure awareness
+  - HTTP/1.1 keep-alive negotiation and cleanup
+  - Deterministic connection teardown on timeouts and errors
+
 - [ ] 🎯 **Request Body Parsing** - Handle different content types
   - URL-encoded form data
   - Multipart form data
@@ -60,6 +76,13 @@ This document tracks planned features, enhancements, and improvements for the Mo
   - deflate compression
   - brotli compression
   - Automatic content negotiation
+
+### JSON Handling
+
+- [ ] 🎯 **Complete JSON Support** - Finish parser/serializer edge cases
+  - Implement array parsing and serialization
+  - Escape control characters and Unicode consistently
+  - Harden number parsing and error signaling
 
 ### Static Content
 
@@ -132,6 +155,13 @@ This document tracks planned features, enhancements, and improvements for the Mo
   - Sanitization functions
   - Type checking
 
+### Server Lifecycle
+
+- [ ] 🎯 **Graceful Shutdown & Thread Management** - Reliable server teardown
+  - Close listening sockets before joining worker threads
+  - Introduce bounded thread pool or async-only execution mode
+  - Platform-specific guards for POSIX-only paths vs. Windows
+
 ### Performance
 
 - [ ] 🔧 **Caching Layer** - Performance optimization
@@ -194,6 +224,11 @@ This document tracks planned features, enhancements, and improvements for the Mo
   - Production deployment
 
 ### Testing & Quality
+
+- [ ] 🎯 **Networking Integration Tests** - Exercise live socket workflows
+  - Automated sync/async request regression suite
+  - Coverage for malformed input, timeouts, and partial I/O
+  - Baseline load and concurrency smoke tests
 
 - [ ] 🔧 **Comprehensive Test Suite** - Expand test coverage
   - Unit tests for all modules

--- a/complete HTTP Parse.md
+++ b/complete HTTP Parse.md
@@ -1,0 +1,100 @@
+# Complete HTTP Parser Implementation Plan
+
+## Goals
+- Replace the placeholder `parse_request` with a robust HTTP/1.1 parser that supports headers, query strings, request bodies (Content-Length + chunked), and method validation.
+- Ensure both threaded and async I/O paths share the same parsing logic with incremental buffering and graceful error handling.
+- Populate request/response header maps and route parameters so middleware and handlers observe real data.
+- Maintain the pure C, dependency-free philosophy while keeping code understandable for future contributors.
+
+## Context & Constraints
+- Current request structs (`http_request`, `http_response`) expose `void *headers` and `void *params` but nothing is wired.
+- Both sync (`handle_connection`) and async (`async_read_handler`) assume the entire request fits in a single read; the new parser must operate incrementally.
+- Buffer size is fixed at 8192 bytes. Add safeguards for larger payloads (reject rather than overflow) and allow streaming bodies for handlers later.
+- Router currently expects `http_request_get_param` to return values; plan should unblock `TODO` items by the end.
+- Tests presently cover only basic object construction. New tests must exercise parsing behaviour end-to-end via sockets wherever possible.
+
+## Deliverables Overview
+1. Request/response header storage utilities (simple hash table or linked list lookup).
+2. Incremental HTTP parser with clear states: start line, headers, body (length-based or chunked), completion.
+3. Connection management updates to loop on `recv`/`send`, handle keep-alive, and surface parser results.
+4. Error handling paths (400, 413, 414, 426 etc.) with informative logs.
+5. Updated router parameter extraction + helpers.
+6. Documentation and tests (unit + integration) covering all code paths.
+
+## Phase 1 – Groundwork
+1. **Audit Structures**: Revisit `http_request`/`http_response` definitions in `include/weblib.h`. Decide on internal header representation (e.g., linked list of `key/value` pairs with case-insensitive comparison). Document expectations in comments for future maintainers.
+2. **Utility Module**: Either extend `http_server.c` with static helpers or add a new internal file (`src/http_headers.c`) to store/retrieve headers, normalize keys, and free resources. Keep this internal (no public API changes beyond the existing helper functions).
+3. **Memory Helpers**: Define functions for request lifecycle (init/reset/free partial state) to reuse between sync/async code paths.
+
+## Phase 2 – Parser Design
+1. **State Machine Definition**: Draft an enum capturing parsing stages (`REQUEST_LINE`, `HEADERS`, `BODY`, `COMPLETE`, `ERROR`).
+2. **Parser Context**: Introduce a struct (`http_parser_t`) hung off the connection (both sync and async) that tracks current state, buffer offsets, header counts, method, path, etc.
+3. **API**: Implement `int http_parser_execute(http_parser_t *parser, const char *data, size_t len)` returning bytes consumed, completion flag, or error code.
+4. **Request Line Parsing**: Validate method tokens, enforce HTTP version (`HTTP/1.0` and `HTTP/1.1`), limit path length (e.g., 4096), and capture query string. Reject invalid methods with 405/501.
+
+## Phase 3 – Header Handling
+1. **Header Canonicalization**: Convert incoming header keys to lowercase (or store original + lowercase copy) for case-insensitive lookup.
+2. **Storage**: Insert key/value into request header list; detect duplicates requiring merging (e.g., `Cookie`) or override.
+3. **Essential Headers**: Track `Host`, `Content-Length`, `Transfer-Encoding`, `Connection`, `Expect`, etc. Validate numeric values and conflicting directives.
+4. **`http_request_get_header`**: Implement lookup using the new storage. Update header setter for response to allocate storage and include in `send_response`.
+
+## Phase 4 – Body Parsing
+1. **Content-Length**: When present, read exactly N bytes into `req->body`. Enforce configurable maximum (initially reuse `BUFFER_SIZE`, but plan for future streaming by letting parser mark `body_incomplete`).
+2. **Chunked Encoding**: Implement chunk size parsing, accumulate until final zero chunk, handle extensions and CRLF validation.
+3. **Unsupported Cases**: Reject message bodies for methods that should not have them when `Content-Length > 0` (e.g., GET unless `Expect: 100-continue`).
+4. **Expect Header**: For `Expect: 100-continue`, respond with 100 interim when we support streaming; until then, reject with 417 to keep behaviour explicit.
+
+## Phase 5 – Connection Lifecycle Updates
+1. **Sync Path**: Replace single `recv` call in `handle_connection` with loop calling `http_parser_execute` until request complete, error, or client closes. Introduce timeouts (e.g., configurable idle limit) to avoid hanging threads.
+2. **Async Path**: Store parser context in `async_connection_t`; feed data chunks as they arrive. Once complete, transition to write state.
+3. **Keep-Alive**: Honour `Connection: keep-alive` for HTTP/1.1 default. After sending response, either reuse connection (loop back to parser reset) or close on `Connection: close`. Keep initial implementation simple (close after each response) but document path for future improvement.
+4. **Send Loop**: Replace single `send` calls with loops handling partial writes and `EAGAIN` for async mode.
+
+## Phase 6 – Error Handling & Responses
+1. Map parser errors to HTTP status codes with short explanations:
+	- Malformed start line → 400
+	- Unsupported method → 405 / 501
+	- Header line too long / total headers exceed cap → 431
+	- Body size exceeds limit → 413
+	- Missing Host in HTTP/1.1 → 400
+2. Ensure errors set `res->sent` and close connection. Log with `fprintf(stderr, ...)` for now.
+3. Provide consistent default headers (Date, Connection) in error replies; ensure `Content-Length` matches body.
+
+## Phase 7 – Router & Middleware Integration
+1. **Route Params**: Implement `extract_params` to populate `req->params` using a small key/value list. Update `http_request_get_param` to read from this storage.
+2. **Query String Helpers**: Optionally add helper to parse query string into map (future enhancement). Document expectation but keep out of parser scope to maintain focus.
+3. **Response Headers**: Implement `http_response_set_header` to store headers for serialization in `send_response`. Ensure duplicates (e.g., `Set-Cookie`) are supported.
+
+## Phase 8 – Testing Strategy
+1. **Unit Tests** (`tests/test_weblib.c` or new file):
+	- Parse valid GET/POST requests with headers and bodies.
+	- Reject malformed start lines, invalid Content-Length, mixed chunked + length, oversize headers.
+	- Validate response header setting.
+2. **Integration Tests**: Spin up the threaded server on random port, send raw HTTP requests via socket, assert responses. Cover keep-alive, 400/413 errors, and chunked body.
+3. **Async Path Smoke Test**: Start async example, send request to ensure parser works in event loop path (one or two cases to avoid long runtime).
+4. **Valgrind**: Run under valgrind (via existing Docker scripts) to confirm no leaks from header storage.
+
+## Phase 9 – Documentation & Cleanup
+1. Update `README.md` usage examples to reflect available headers/params and limitations.
+2. Revise `TODO.md` once features land (mark “Complete HTTP Parser” task as done).
+3. Add inline comments near non-obvious logic (state transitions, chunked parsing) per project guidance (keep concise).
+4. Ensure public API comments in `weblib.h` mention header lookup behaviour and error responses for malformed requests.
+
+## Dependencies & Sequencing Notes
+- Phase 1 must precede parser work so shared data structures exist.
+- Parser (Phase 2–4) should be developed alongside connection loop changes to validate assumptions early.
+- Router/middleware changes depend on parser populating headers/params; coordinate to avoid broken tests mid-way.
+- Test suite can be built incrementally but defer network integration tests until parser + connection updates are stable.
+- Keep commits scoped per phase so rollbacks are easy for future maintainers or AI agents.
+
+## Risk Mitigations
+- Establish maximum limits (header count, header line length, body size) and enforce via constants to avoid DoS vectors.
+- Validate all allocations; on failure, send 500 and close connection to avoid undefined behaviour.
+- Keep parser self-contained to simplify future refactors or streaming body support.
+
+## Out of Scope (Future Work)
+- HTTP/2, TLS, upgraded protocols.
+- Full streaming body support with handler callbacks.
+- Request pipelining and connection pooling.
+
+Following this plan sequentially will provide a production-ready HTTP parsing layer while leaving clear extension hooks for advanced features.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.8'
+
+services:
+  # Production-like deployment using async server
+  weblib-async:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: modern-c-weblib-async
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    networks:
+      - weblib-network
+    # Uncomment to limit resources
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '1.0'
+    #       memory: 512M
+
+  # Threaded server (alternative)
+  weblib-threaded:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: modern-c-weblib-threaded
+    command: ["/app/simple_server", "8080"]
+    ports:
+      - "8081:8080"
+    restart: unless-stopped
+    networks:
+      - weblib-network
+    profiles:
+      - threaded
+
+  # Development container with volume mount
+  weblib-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: modern-c-weblib-dev
+    volumes:
+      - .:/workspace
+    ports:
+      - "8082:8080"
+    networks:
+      - weblib-network
+    stdin_open: true
+    tty: true
+    profiles:
+      - dev
+
+networks:
+  weblib-network:
+    driver: bridge

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Helper script to run Modern C Web Library in Docker
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+print_usage() {
+    echo "Usage: $0 [MODE] [PORT]"
+    echo ""
+    echo "MODE:"
+    echo "  async      - Run async server (default)"
+    echo "  threaded   - Run threaded server"
+    echo "  dev        - Run development container with shell"
+    echo "  build      - Build Docker image only"
+    echo "  test       - Build and run tests in container"
+    echo ""
+    echo "PORT: Port to expose (default: 8080)"
+    echo ""
+    echo "Examples:"
+    echo "  $0                    # Run async server on port 8080"
+    echo "  $0 async 3000         # Run async server on port 3000"
+    echo "  $0 dev                # Start development container"
+    echo "  $0 test               # Run tests in container"
+}
+
+MODE="${1:-async}"
+PORT="${2:-8080}"
+
+case "$MODE" in
+    async)
+        echo -e "${BLUE}Building and running async server...${NC}"
+        docker build -t modern-c-weblib:latest .
+        echo -e "${GREEN}Starting async server on port $PORT${NC}"
+        docker run --rm -p "$PORT:8080" --name modern-c-weblib-async modern-c-weblib:latest /app/async_server 8080
+        ;;
+    
+    threaded)
+        echo -e "${BLUE}Building and running threaded server...${NC}"
+        docker build -t modern-c-weblib:latest .
+        echo -e "${GREEN}Starting threaded server on port $PORT${NC}"
+        docker run --rm -p "$PORT:8080" --name modern-c-weblib-threaded modern-c-weblib:latest /app/simple_server 8080
+        ;;
+    
+    dev)
+        echo -e "${BLUE}Building development container...${NC}"
+        docker build -f Dockerfile.dev -t modern-c-weblib:dev .
+        echo -e "${GREEN}Starting development container (access at localhost:$PORT)${NC}"
+        echo -e "${YELLOW}Container includes: cmake, make, gdb, valgrind${NC}"
+        docker run --rm -it -v "$(pwd):/workspace" -p "$PORT:8080" --name modern-c-weblib-dev modern-c-weblib:dev
+        ;;
+    
+    build)
+        echo -e "${BLUE}Building Docker images...${NC}"
+        docker build -t modern-c-weblib:latest .
+        docker build -f Dockerfile.dev -t modern-c-weblib:dev .
+        echo -e "${GREEN}Build complete!${NC}"
+        ;;
+    
+    test)
+        echo -e "${BLUE}Building and running tests...${NC}"
+        docker build -f Dockerfile.dev -t modern-c-weblib:dev .
+        echo -e "${GREEN}Running tests...${NC}"
+        docker run --rm modern-c-weblib:dev /bin/bash -c "cd build && make test && ./tests/test_weblib"
+        ;;
+    
+    -h|--help|help)
+        print_usage
+        exit 0
+        ;;
+    
+    *)
+        echo -e "${YELLOW}Unknown mode: $MODE${NC}"
+        print_usage
+        exit 1
+        ;;
+esac

--- a/docker-verify.sh
+++ b/docker-verify.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Verification script for Docker setup
+# Run this after building the Docker image to verify everything works
+
+set -e
+
+echo "=========================================="
+echo "Modern C Web Library - Docker Verification"
+echo "=========================================="
+echo ""
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo "❌ Error: Docker is not running"
+    echo "Please start Docker Desktop and try again"
+    exit 1
+fi
+
+echo "✓ Docker is running"
+echo ""
+
+# Build development image
+echo "Building development Docker image..."
+docker build -f Dockerfile.dev -t modern-c-weblib:dev . > /dev/null 2>&1
+echo "✓ Development image built successfully"
+echo ""
+
+# Run tests in container
+echo "Running tests in Docker container..."
+TEST_OUTPUT=$(docker run --rm modern-c-weblib:dev /bin/bash -c "cd build && ./tests/test_weblib" 2>&1)
+echo "$TEST_OUTPUT"
+
+if echo "$TEST_OUTPUT" | grep -q "Tests failed: 0"; then
+    echo ""
+    echo "✓ All tests passed in Docker environment"
+else
+    echo ""
+    echo "❌ Tests failed - see output above"
+    exit 1
+fi
+
+echo ""
+
+# Verify examples can be built and started
+echo "Verifying examples are built..."
+docker run --rm modern-c-weblib:dev /bin/bash -c "test -f build/examples/simple_server && test -f build/examples/async_server"
+echo "✓ Example executables are present"
+echo ""
+
+# Build production image
+echo "Building production Docker image..."
+docker build -t modern-c-weblib:latest . > /dev/null 2>&1
+echo "✓ Production image built successfully"
+echo ""
+
+# Verify production image contains executables
+echo "Verifying production image..."
+docker run --rm modern-c-weblib:latest /bin/bash -c "test -f /app/simple_server && test -f /app/async_server"
+echo "✓ Production image verified"
+echo ""
+
+# Summary
+echo "=========================================="
+echo "✓ Docker Setup Verification Complete!"
+echo "=========================================="
+echo ""
+echo "Your Docker environment is ready for:"
+echo "  • Building the library"
+echo "  • Running tests"
+echo "  • Development with volume mounts"
+echo "  • Production deployment"
+echo ""
+echo "Next steps:"
+echo "  ./docker-run.sh dev     # Start development environment"
+echo "  ./docker-run.sh test    # Run tests"
+echo "  ./docker-run.sh async   # Run server"
+echo ""
+echo "See DOCKER.md for complete documentation."
+echo ""

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1,16 +1,77 @@
 #include "weblib.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
+#include <time.h>
 #include <unistd.h>
-#include <pthread.h>
-#include <errno.h>
-#include <fcntl.h>
+#include <ctype.h>
+#include <strings.h>
 
 #define MAX_CONNECTIONS 128
-#define BUFFER_SIZE 8192
+#define READ_BUFFER_SIZE 8192
+#define MAX_REQUEST_LINE_LEN 4096
+#define MAX_HEADER_LINE_LEN 8192
+#define MAX_HEADER_COUNT 100
+#define MAX_HEADER_BYTES 16384
+#define MAX_BODY_BYTES (1024 * 1024) /* 1 MiB */
+#define MAX_REQUEST_BUFFER (MAX_BODY_BYTES + MAX_HEADER_BYTES)
+
+typedef struct http_header_node {
+    char *name;      /* lower-case for lookup */
+    char *raw_name;  /* original casing for serialization */
+    char *value;
+    struct http_header_node *next;
+} http_header_node_t;
+
+typedef struct http_param_node {
+    char *key;
+    char *value;
+    struct http_param_node *next;
+} http_param_node_t;
+
+typedef enum {
+    PARSE_STATE_REQUEST_LINE,
+    PARSE_STATE_HEADERS,
+    PARSE_STATE_BODY,
+    PARSE_STATE_CHUNK_SIZE,
+    PARSE_STATE_CHUNK_DATA,
+    PARSE_STATE_CHUNK_CRLF,
+    PARSE_STATE_CHUNK_TRAILERS,
+    PARSE_STATE_COMPLETE,
+    PARSE_STATE_ERROR
+} parse_state_t;
+
+typedef enum {
+    PARSER_INCOMPLETE = 0,
+    PARSER_COMPLETE,
+    PARSER_ERROR
+} parser_result_t;
+
+typedef struct http_parser {
+    parse_state_t state;
+    http_request_t *req;
+    char *buffer;
+    size_t buffer_len;
+    size_t buffer_cap;
+    size_t total_bytes;
+    size_t header_count;
+    size_t content_length;
+    size_t body_received;
+    size_t body_capacity;
+    bool chunked;
+    size_t current_chunk_size;
+    size_t current_chunk_received;
+    bool keep_alive;
+    bool seen_host;
+    http_status_t error_status;
+    const char *error_message;
+} http_parser_t;
 
 /* Internal server structure */
 struct http_server {
@@ -29,33 +90,58 @@ struct http_server {
 typedef struct {
     int client_fd;
     http_server_t *server;
+    http_parser_t parser;
+    http_request_t *request;
+    http_response_t *response;
 } connection_t;
 
 /* Async connection context */
 typedef struct async_connection {
     int client_fd;
     http_server_t *server;
-    char buffer[BUFFER_SIZE];
-    size_t buffer_pos;
+    http_parser_t parser;
     http_request_t *request;
     http_response_t *response;
-    bool request_complete;
+    char *header_buf;
+    size_t header_len;
+    size_t header_sent;
+    size_t body_sent;
+    bool parser_initialized;
+    bool response_ready;
+    bool keep_alive;
+    bool closing;
 } async_connection_t;
 
 /* Forward declarations */
 static void *accept_connections(void *arg);
 static void *handle_connection(void *arg);
-static http_request_t *parse_request(const char *buffer);
-static void send_response(int client_fd, http_response_t *res);
-static void free_request(http_request_t *req);
-static void free_response(http_response_t *res);
+static bool response_forces_close(http_response_t *res);
+static void send_response(int client_fd, http_response_t *res, bool keep_alive);
+static void send_error_response(int client_fd, http_status_t status, const char *message);
+static http_request_t *http_request_create(void);
+static void http_request_destroy(http_request_t *req);
+static http_response_t *http_response_create(void);
+static void http_response_destroy(http_response_t *res);
 
-/* Async I/O functions */
+static void http_parser_init(http_parser_t *parser, http_request_t *req);
+static void http_parser_reset(http_parser_t *parser, http_request_t *req, bool preserve_buffer);
+static void http_parser_destroy(http_parser_t *parser);
+static parser_result_t http_parser_execute(http_parser_t *parser, const char *data, size_t len);
+
+static void header_list_free(http_header_node_t *head);
+static http_header_node_t *header_list_find(http_header_node_t *head, const char *name);
+static int header_list_add(http_header_node_t **head_ref, const char *name, const char *raw_name, const char *value, bool replace_existing);
+static int append_body_data(http_parser_t *parser, const char *data, size_t len);
+static void param_list_free(http_param_node_t *head);
+static const char *param_list_get(http_param_node_t *head, const char *key);
+static int param_list_set(http_param_node_t **head_ref, const char *key, const char *value);
+
 static int set_nonblocking(int fd);
 static void async_accept_handler(int fd, int events, void *user_data);
 static void async_read_handler(int fd, int events, void *user_data);
 static void async_write_handler(int fd, int events, void *user_data);
 static void free_async_connection(async_connection_t *conn);
+static bool async_on_parser_result(async_connection_t *conn, int fd, parser_result_t result);
 
 /* Create HTTP server */
 http_server_t *http_server_create(void) {
@@ -221,7 +307,7 @@ static void *accept_connections(void *arg) {
         }
         
         /* Create connection handler thread */
-        connection_t *conn = (connection_t *)malloc(sizeof(connection_t));
+        connection_t *conn = (connection_t *)calloc(1, sizeof(connection_t));
         if (conn) {
             conn->client_fd = client_fd;
             conn->server = server;
@@ -245,213 +331,1057 @@ static void *accept_connections(void *arg) {
 /* Handle single connection */
 static void *handle_connection(void *arg) {
     connection_t *conn = (connection_t *)arg;
-    char buffer[BUFFER_SIZE];
-    
-    /* Read request */
-    ssize_t bytes_read = recv(conn->client_fd, buffer, BUFFER_SIZE - 1, 0);
-    if (bytes_read > 0) {
-        buffer[bytes_read] = '\0';
-        
-        /* Check for oversized request */
-        if (bytes_read == BUFFER_SIZE - 1) {
-            /* Request too large, send 413 Payload Too Large */
-            http_response_t *res = (http_response_t *)calloc(1, sizeof(http_response_t));
-            if (res) {
-                http_response_send_text(res, 413, "Payload Too Large");
-                send_response(conn->client_fd, res);
-                free_response(res);
+    int client_fd = conn->client_fd;
+    http_server_t *server = conn->server;
+    bool parser_initialized = false;
+    bool connection_open = true;
+    char read_buf[READ_BUFFER_SIZE];
+
+    while (connection_open) {
+        parser_result_t result = PARSER_INCOMPLETE;
+        bool keep_alive = false;
+
+        conn->request = http_request_create();
+        conn->response = http_response_create();
+        if (!conn->request || !conn->response) {
+            send_error_response(client_fd, HTTP_INTERNAL_ERROR, "Internal Server Error");
+            connection_open = false;
+            goto iteration_cleanup;
+        }
+
+        if (!parser_initialized) {
+            http_parser_init(&conn->parser, conn->request);
+            parser_initialized = true;
+            if (conn->parser.state == PARSE_STATE_ERROR) {
+                send_error_response(client_fd, conn->parser.error_status, conn->parser.error_message);
+                connection_open = false;
+                goto iteration_cleanup;
             }
         } else {
-            /* Parse request */
-            http_request_t *req = parse_request(buffer);
-            if (req) {
-                /* Create response */
-                http_response_t *res = (http_response_t *)calloc(1, sizeof(http_response_t));
-                if (res) {
-                    res->status = HTTP_OK;
-                    
-                    /* Route request */
-                    if (conn->server->router) {
-                        router_route(conn->server->router, req, res);
-                    } else {
-                        /* No router configured, send 404 */
-                        http_response_send_text(res, HTTP_NOT_FOUND, "Not Found");
-                    }
-                    
-                    /* Send response */
-                    send_response(conn->client_fd, res);
-                    free_response(res);
+            http_parser_reset(&conn->parser, conn->request, true);
+        }
+
+        if (conn->parser.buffer_len > 0) {
+            result = http_parser_execute(&conn->parser, NULL, 0);
+        }
+
+        while (result == PARSER_INCOMPLETE) {
+            ssize_t bytes_read = recv(client_fd, read_buf, sizeof(read_buf), 0);
+            if (bytes_read < 0) {
+                if (errno == EINTR) {
+                    continue;
                 }
-                
-                free_request(req);
+                perror("recv failed");
+                send_error_response(client_fd, HTTP_INTERNAL_ERROR, "Socket read error");
+                connection_open = false;
+                goto iteration_cleanup;
             }
+            if (bytes_read == 0) {
+                connection_open = false;
+                goto iteration_cleanup;
+            }
+
+            result = http_parser_execute(&conn->parser, read_buf, (size_t)bytes_read);
+        }
+
+        if (result == PARSER_ERROR) {
+            http_status_t status = conn->parser.error_status ? conn->parser.error_status : HTTP_BAD_REQUEST;
+            send_error_response(client_fd, status, conn->parser.error_message);
+            connection_open = false;
+            goto iteration_cleanup;
+        }
+
+        if (server->router) {
+            if (router_route(server->router, conn->request, conn->response) < 0) {
+                http_response_send_text(conn->response, HTTP_NOT_FOUND, "Not Found");
+            }
+        } else {
+            http_response_send_text(conn->response, HTTP_NOT_FOUND, "Not Found");
+        }
+
+        keep_alive = conn->parser.keep_alive && !response_forces_close(conn->response);
+        send_response(client_fd, conn->response, keep_alive);
+
+        if (!keep_alive) {
+            connection_open = false;
+        }
+
+    iteration_cleanup:
+        http_request_destroy(conn->request);
+        http_response_destroy(conn->response);
+        conn->request = NULL;
+        conn->response = NULL;
+
+        if (!connection_open) {
+            break;
         }
     }
-    
-    close(conn->client_fd);
+
+    if (parser_initialized) {
+        http_parser_destroy(&conn->parser);
+    }
+    close(client_fd);
     free(conn);
-    
     return NULL;
 }
 
 /* Parse HTTP request */
-static http_request_t *parse_request(const char *buffer) {
-    http_request_t *req = (http_request_t *)calloc(1, sizeof(http_request_t));
-    if (!req) {
+static char *lowercase_dup(const char *src) {
+    if (!src) {
         return NULL;
     }
-    
-    /* Parse first line: METHOD /path HTTP/1.1 */
-    char method_str[16];
-    char path[1024];
-    
-    if (sscanf(buffer, "%15s %1023s", method_str, path) != 2) {
-        free(req);
+    size_t len = strlen(src);
+    char *dest = (char *)malloc(len + 1);
+    if (!dest) {
         return NULL;
     }
-    
-    /* Parse method */
-    if (strcmp(method_str, "GET") == 0) {
-        req->method = HTTP_GET;
-    } else if (strcmp(method_str, "POST") == 0) {
-        req->method = HTTP_POST;
-    } else if (strcmp(method_str, "PUT") == 0) {
-        req->method = HTTP_PUT;
-    } else if (strcmp(method_str, "DELETE") == 0) {
-        req->method = HTTP_DELETE;
-    } else if (strcmp(method_str, "PATCH") == 0) {
-        req->method = HTTP_PATCH;
-    } else if (strcmp(method_str, "HEAD") == 0) {
-        req->method = HTTP_HEAD;
-    } else if (strcmp(method_str, "OPTIONS") == 0) {
-        req->method = HTTP_OPTIONS;
-    } else {
-        req->method = HTTP_GET;
+    for (size_t i = 0; i < len; i++) {
+        dest[i] = (char)tolower((unsigned char)src[i]);
     }
-    
-    /* Parse path and query string */
-    char *query_start = strchr(path, '?');
-    if (query_start) {
-        *query_start = '\0';
-        req->query_string = strdup(query_start + 1);
-        if (!req->query_string) {
-            free(req);
-            return NULL;
+    dest[len] = '\0';
+    return dest;
+}
+
+static const char *status_reason_phrase(http_status_t status) {
+    switch (status) {
+        case HTTP_OK: return "OK";
+        case HTTP_CREATED: return "Created";
+        case HTTP_ACCEPTED: return "Accepted";
+        case HTTP_NO_CONTENT: return "No Content";
+        case HTTP_BAD_REQUEST: return "Bad Request";
+        case HTTP_UNAUTHORIZED: return "Unauthorized";
+        case HTTP_FORBIDDEN: return "Forbidden";
+        case HTTP_NOT_FOUND: return "Not Found";
+        case HTTP_METHOD_NOT_ALLOWED: return "Method Not Allowed";
+        case HTTP_INTERNAL_ERROR: return "Internal Server Error";
+        case HTTP_NOT_IMPLEMENTED: return "Not Implemented";
+        case HTTP_BAD_GATEWAY: return "Bad Gateway";
+        case HTTP_SERVICE_UNAVAILABLE: return "Service Unavailable";
+        default: return "OK";
+    }
+}
+
+static void header_list_free(http_header_node_t *head) {
+    while (head) {
+        http_header_node_t *next = head->next;
+        free(head->name);
+        free(head->raw_name);
+        free(head->value);
+        free(head);
+        head = next;
+    }
+}
+
+static http_header_node_t *header_list_find(http_header_node_t *head, const char *name_lower) {
+    for (http_header_node_t *node = head; node; node = node->next) {
+        if (strcmp(node->name, name_lower) == 0) {
+            return node;
         }
     }
-    
-    req->path = strdup(path);
-    if (!req->path) {
-        free(req->query_string);
-        free(req);
-        return NULL;
+    return NULL;
+}
+
+static int header_list_add(http_header_node_t **head_ref, const char *name, const char *raw_name, const char *value, bool replace_existing) {
+    if (!head_ref || !name || !value) {
+        return -1;
     }
-    
-    /* TODO: Parse headers and body */
-    
+
+    char *lower = lowercase_dup(name);
+    if (!lower) {
+        return -1;
+    }
+
+    http_header_node_t *existing = header_list_find(*head_ref, lower);
+    if (existing && replace_existing) {
+        char *new_value = strdup(value);
+        if (!new_value) {
+            free(lower);
+            return -1;
+        }
+        free(existing->value);
+        existing->value = new_value;
+        if (raw_name) {
+            char *new_raw = strdup(raw_name);
+            if (!new_raw) {
+                free(lower);
+                return -1;
+            }
+            free(existing->raw_name);
+            existing->raw_name = new_raw;
+        }
+        free(lower);
+        return 0;
+    }
+
+    http_header_node_t *node = (http_header_node_t *)calloc(1, sizeof(http_header_node_t));
+    if (!node) {
+        free(lower);
+        return -1;
+    }
+
+    node->name = lower;
+    node->raw_name = raw_name ? strdup(raw_name) : strdup(name);
+    if (!node->raw_name) {
+        free(node->name);
+        free(node);
+        return -1;
+    }
+    node->value = strdup(value);
+    if (!node->value) {
+        free(node->raw_name);
+        free(node->name);
+        free(node);
+        return -1;
+    }
+
+    node->next = NULL;
+
+    if (!*head_ref) {
+        *head_ref = node;
+    } else {
+        http_header_node_t *tail = *head_ref;
+        while (tail->next) {
+            tail = tail->next;
+        }
+        tail->next = node;
+    }
+    return 0;
+}
+
+static void param_list_free(http_param_node_t *head) {
+    while (head) {
+        http_param_node_t *next = head->next;
+        free(head->key);
+        free(head->value);
+        free(head);
+        head = next;
+    }
+}
+
+static const char *param_list_get(http_param_node_t *head, const char *key) {
+    for (http_param_node_t *node = head; node; node = node->next) {
+        if (strcmp(node->key, key) == 0) {
+            return node->value;
+        }
+    }
+    return NULL;
+}
+
+static int param_list_set(http_param_node_t **head_ref, const char *key, const char *value) {
+    if (!head_ref || !key || !value) {
+        return -1;
+    }
+
+    for (http_param_node_t *node = *head_ref; node; node = node->next) {
+        if (strcmp(node->key, key) == 0) {
+            char *new_val = strdup(value);
+            if (!new_val) {
+                return -1;
+            }
+            free(node->value);
+            node->value = new_val;
+            return 0;
+        }
+    }
+
+    http_param_node_t *node = (http_param_node_t *)calloc(1, sizeof(http_param_node_t));
+    if (!node) {
+        return -1;
+    }
+
+    node->key = strdup(key);
+    node->value = strdup(value);
+    if (!node->key || !node->value) {
+        free(node->key);
+        free(node->value);
+        free(node);
+        return -1;
+    }
+
+    node->next = *head_ref;
+    *head_ref = node;
+    return 0;
+}
+
+static http_request_t *http_request_create(void) {
+    http_request_t *req = (http_request_t *)calloc(1, sizeof(http_request_t));
     return req;
 }
 
-/* Send HTTP response */
-static void send_response(int client_fd, http_response_t *res) {
-    if (!res || res->sent) {
-        return;
-    }
-    
-    /* Get status text based on status code */
-    const char *status_text = "OK";
-    switch (res->status) {
-        case HTTP_OK: status_text = "OK"; break;
-        case HTTP_CREATED: status_text = "Created"; break;
-        case HTTP_ACCEPTED: status_text = "Accepted"; break;
-        case HTTP_NO_CONTENT: status_text = "No Content"; break;
-        case HTTP_BAD_REQUEST: status_text = "Bad Request"; break;
-        case HTTP_UNAUTHORIZED: status_text = "Unauthorized"; break;
-        case HTTP_FORBIDDEN: status_text = "Forbidden"; break;
-        case HTTP_NOT_FOUND: status_text = "Not Found"; break;
-        case HTTP_METHOD_NOT_ALLOWED: status_text = "Method Not Allowed"; break;
-        case HTTP_INTERNAL_ERROR: status_text = "Internal Server Error"; break;
-        case HTTP_NOT_IMPLEMENTED: status_text = "Not Implemented"; break;
-        case HTTP_BAD_GATEWAY: status_text = "Bad Gateway"; break;
-        case HTTP_SERVICE_UNAVAILABLE: status_text = "Service Unavailable"; break;
-        default: status_text = "OK"; break;
-    }
-    
-    char header[BUFFER_SIZE];
-    int header_len = snprintf(header, BUFFER_SIZE,
-        "HTTP/1.1 %d %s\r\n"
-        "Content-Length: %zu\r\n"
-        "Connection: close\r\n"
-        "\r\n",
-        res->status,
-        status_text,
-        res->body_length);
-    
-    send(client_fd, header, header_len, 0);
-    
-    if (res->body && res->body_length > 0) {
-        send(client_fd, res->body, res->body_length, 0);
-    }
-    
-    res->sent = true;
-}
-
-/* Free request */
-static void free_request(http_request_t *req) {
+static void http_request_destroy(http_request_t *req) {
     if (!req) {
         return;
     }
-    
     free(req->path);
     free(req->query_string);
     free(req->body);
+    header_list_free((http_header_node_t *)req->headers);
+    param_list_free((http_param_node_t *)req->params);
     free(req);
 }
 
-/* Free response */
-static void free_response(http_response_t *res) {
+static http_response_t *http_response_create(void) {
+    http_response_t *res = (http_response_t *)calloc(1, sizeof(http_response_t));
+    if (res) {
+        res->status = HTTP_OK;
+    }
+    return res;
+}
+
+static void http_response_destroy(http_response_t *res) {
     if (!res) {
         return;
     }
-    
+    header_list_free((http_header_node_t *)res->headers);
     free(res->body);
     free(res);
 }
 
-/* Response helpers */
+static int send_all(int fd, const char *buf, size_t len) {
+    size_t sent_total = 0;
+    while (sent_total < len) {
+        ssize_t sent = send(fd, buf + sent_total, len - sent_total, 0);
+        if (sent < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        sent_total += (size_t)sent;
+    }
+    return 0;
+}
+
+static int serialize_response(http_response_t *res, bool keep_alive, char **header_out, size_t *header_len_out) {
+    if (!res || !header_out || !header_len_out) {
+        return -1;
+    }
+
+    if (res->status == 0) {
+        res->status = HTTP_OK;
+    }
+
+    http_header_node_t **headers_ref = (http_header_node_t **)&res->headers;
+
+    char date_buf[64];
+    time_t now = time(NULL);
+    struct tm tm_buf;
+    struct tm *tm_info = gmtime_r(&now, &tm_buf);
+    if (tm_info) {
+        strftime(date_buf, sizeof(date_buf), "%a, %d %b %Y %H:%M:%S GMT", tm_info);
+        if (header_list_add(headers_ref, "date", "Date", date_buf, true) < 0) {
+            return -1;
+        }
+    }
+
+    char content_length_buf[32];
+    snprintf(content_length_buf, sizeof(content_length_buf), "%zu", res->body_length);
+    if (header_list_add(headers_ref, "content-length", "Content-Length", content_length_buf, true) < 0) {
+        return -1;
+    }
+
+    if (header_list_add(headers_ref, "connection", "Connection", keep_alive ? "keep-alive" : "close", true) < 0) {
+        return -1;
+    }
+
+    size_t header_capacity = 256;
+    size_t header_len = 0;
+    char *header_buf = (char *)malloc(header_capacity);
+    if (!header_buf) {
+        return -1;
+    }
+
+    const char *reason = status_reason_phrase(res->status);
+    int written = snprintf(header_buf, header_capacity, "HTTP/1.1 %d %s\r\n", res->status, reason);
+    if (written < 0) {
+        free(header_buf);
+        return -1;
+    }
+    header_len = (size_t)written;
+
+    for (http_header_node_t *node = *headers_ref; node; node = node->next) {
+        size_t need = header_len + strlen(node->raw_name) + strlen(node->value) + 4;
+        if (need >= header_capacity) {
+            size_t new_cap = header_capacity * 2;
+            while (need >= new_cap) {
+                new_cap *= 2;
+            }
+            char *tmp = (char *)realloc(header_buf, new_cap);
+            if (!tmp) {
+                free(header_buf);
+                return -1;
+            }
+            header_buf = tmp;
+            header_capacity = new_cap;
+        }
+        header_len += (size_t)sprintf(header_buf + header_len, "%s: %s\r\n", node->raw_name, node->value);
+    }
+
+    if (header_len + 2 >= header_capacity) {
+        char *tmp = (char *)realloc(header_buf, header_capacity + 2);
+        if (!tmp) {
+            free(header_buf);
+            return -1;
+        }
+        header_buf = tmp;
+        header_capacity += 2;
+    }
+    memcpy(header_buf + header_len, "\r\n", 2);
+    header_len += 2;
+
+    *header_out = header_buf;
+    *header_len_out = header_len;
+    return 0;
+}
+
+static bool response_forces_close(http_response_t *res) {
+    if (!res || !res->headers) {
+        return false;
+    }
+    for (http_header_node_t *node = (http_header_node_t *)res->headers; node; node = node->next) {
+        if (strcmp(node->name, "connection") == 0) {
+            if (strcasecmp(node->value, "close") == 0) {
+                return true;
+            }
+            if (strcasecmp(node->value, "keep-alive") == 0) {
+                return false;
+            }
+        }
+    }
+    return false;
+}
+
+static void send_response(int client_fd, http_response_t *res, bool keep_alive) {
+    if (!res || res->sent) {
+        return;
+    }
+
+    char *header_buf = NULL;
+    size_t header_len = 0;
+    if (serialize_response(res, keep_alive, &header_buf, &header_len) < 0) {
+        return;
+    }
+
+    if (send_all(client_fd, header_buf, header_len) == 0) {
+        if (res->body && res->body_length > 0) {
+            send_all(client_fd, res->body, res->body_length);
+        }
+    }
+
+    free(header_buf);
+    res->sent = true;
+}
+
+static void send_error_response(int client_fd, http_status_t status, const char *message) {
+    http_response_t *res = http_response_create();
+    if (!res) {
+        return;
+    }
+    const char *body = message ? message : "";
+    http_response_send_text(res, status, body);
+    send_response(client_fd, res, false);
+    http_response_destroy(res);
+}
+
 void http_response_send_text(http_response_t *res, http_status_t status, const char *text) {
     if (!res || !text) {
         return;
     }
-    
-    res->status = status;
-    res->body = strdup(text);
-    if (res->body) {
-        res->body_length = strlen(text);
-    } else {
-        res->body_length = 0;
+    char *copy = strdup(text);
+    if (!copy) {
+        return;
     }
+    free(res->body);
+    res->body = copy;
+    res->body_length = strlen(text);
+    res->status = status;
 }
 
 void http_response_set_header(http_response_t *res, const char *key, const char *value) {
-    /* TODO: Implement header storage */
-    (void)res;
-    (void)key;
-    (void)value;
+    if (!res || !key || !value) {
+        return;
+    }
+    header_list_add((http_header_node_t **)&res->headers, key, key, value, true);
 }
 
 const char *http_request_get_header(http_request_t *req, const char *key) {
-    /* TODO: Implement header retrieval */
-    (void)req;
-    (void)key;
-    return NULL;
+    if (!req || !key) {
+        return NULL;
+    }
+    char *lower = lowercase_dup(key);
+    if (!lower) {
+        return NULL;
+    }
+    http_header_node_t *node = header_list_find((http_header_node_t *)req->headers, lower);
+    free(lower);
+    return node ? node->value : NULL;
 }
 
 const char *http_request_get_param(http_request_t *req, const char *key) {
-    /* TODO: Implement parameter retrieval */
-    (void)req;
-    (void)key;
-    return NULL;
+    if (!req || !key) {
+        return NULL;
+    }
+    return param_list_get((http_param_node_t *)req->params, key);
+}
+
+static void parser_set_error(http_parser_t *parser, http_status_t status, const char *message) {
+    parser->state = PARSE_STATE_ERROR;
+    parser->error_status = status;
+    parser->error_message = message;
+}
+
+static int ensure_buffer_capacity(http_parser_t *parser, size_t additional) {
+    size_t required = parser->buffer_len + additional;
+    if (required > MAX_REQUEST_BUFFER) {
+        parser_set_error(parser, (http_status_t)413, "Payload Too Large");
+        return -1;
+    }
+
+    if (required <= parser->buffer_cap) {
+        return 0;
+    }
+
+    size_t new_cap = parser->buffer_cap ? parser->buffer_cap : READ_BUFFER_SIZE;
+    while (new_cap < required) {
+        new_cap *= 2;
+        if (new_cap > MAX_REQUEST_BUFFER) {
+            new_cap = MAX_REQUEST_BUFFER;
+            break;
+        }
+    }
+
+    char *tmp = (char *)realloc(parser->buffer, new_cap);
+    if (!tmp) {
+        parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
+        return -1;
+    }
+
+    parser->buffer = tmp;
+    parser->buffer_cap = new_cap;
+    return 0;
+}
+
+static ssize_t find_crlf(const char *buf, size_t len) {
+    for (size_t i = 0; i + 1 < len; i++) {
+        if (buf[i] == '\r' && buf[i + 1] == '\n') {
+            return (ssize_t)i;
+        }
+    }
+    return -1;
+}
+
+static void parser_consume(http_parser_t *parser, size_t count) {
+    if (count == 0) {
+        return;
+    }
+    if (count >= parser->buffer_len) {
+        parser->buffer_len = 0;
+        return;
+    }
+    memmove(parser->buffer, parser->buffer + count, parser->buffer_len - count);
+    parser->buffer_len -= count;
+}
+
+static bool assign_http_method(http_request_t *req, const char *method) {
+    static const struct {
+        const char *name;
+        http_method_t value;
+    } methods[] = {
+        {"GET", HTTP_GET},
+        {"POST", HTTP_POST},
+        {"PUT", HTTP_PUT},
+        {"DELETE", HTTP_DELETE},
+        {"PATCH", HTTP_PATCH},
+        {"HEAD", HTTP_HEAD},
+        {"OPTIONS", HTTP_OPTIONS}
+    };
+
+    for (size_t i = 0; i < sizeof(methods) / sizeof(methods[0]); i++) {
+        if (strcmp(methods[i].name, method) == 0) {
+            req->method = methods[i].value;
+            return true;
+        }
+    }
+    return false;
+}
+
+static int parse_request_line(http_parser_t *parser) {
+    ssize_t crlf_index = find_crlf(parser->buffer, parser->buffer_len);
+    if (crlf_index < 0) {
+        return 0;
+    }
+
+    if ((size_t)crlf_index > MAX_REQUEST_LINE_LEN) {
+        parser_set_error(parser, (http_status_t)414, "Request-URI Too Long");
+        return -1;
+    }
+
+    char *line = (char *)malloc((size_t)crlf_index + 1);
+    if (!line) {
+        parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
+        return -1;
+    }
+    memcpy(line, parser->buffer, (size_t)crlf_index);
+    line[crlf_index] = '\0';
+
+    char *method = line;
+    char *sp1 = strchr(line, ' ');
+    if (!sp1) {
+        free(line);
+        parser_set_error(parser, HTTP_BAD_REQUEST, "Malformed request line");
+        return -1;
+    }
+    *sp1 = '\0';
+    char *target = sp1 + 1;
+    while (*target == ' ') {
+        target++;
+    }
+    char *sp2 = strchr(target, ' ');
+    if (!sp2) {
+        free(line);
+        parser_set_error(parser, HTTP_BAD_REQUEST, "Malformed request line");
+        return -1;
+    }
+    *sp2 = '\0';
+    char *version = sp2 + 1;
+    while (*version == ' ') {
+        version++;
+    }
+
+    if (!assign_http_method(parser->req, method)) {
+        free(line);
+        parser_set_error(parser, HTTP_NOT_IMPLEMENTED, "Unsupported HTTP method");
+        return -1;
+    }
+
+    if (strlen(target) == 0 || target[0] != '/') {
+        free(line);
+        parser_set_error(parser, HTTP_BAD_REQUEST, "Invalid request target");
+        return -1;
+    }
+
+    if (strlen(target) > MAX_REQUEST_LINE_LEN) {
+        free(line);
+        parser_set_error(parser, (http_status_t)414, "Request-URI Too Long");
+        return -1;
+    }
+
+    char *query = strchr(target, '?');
+    if (query) {
+        *query = '\0';
+        query++;
+        free(parser->req->query_string);
+        parser->req->query_string = strdup(query);
+        if (!parser->req->query_string) {
+            free(line);
+            parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
+            return -1;
+        }
+    }
+
+    free(parser->req->path);
+    parser->req->path = strdup(target);
+    if (!parser->req->path) {
+        free(line);
+        parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
+        return -1;
+    }
+
+    if (strcmp(version, "HTTP/1.1") == 0) {
+        parser->keep_alive = true;
+    } else if (strcmp(version, "HTTP/1.0") == 0) {
+        parser->keep_alive = false;
+    } else {
+        free(line);
+        parser_set_error(parser, HTTP_BAD_REQUEST, "Unsupported HTTP version");
+        return -1;
+    }
+
+    free(line);
+    parser_consume(parser, (size_t)crlf_index + 2);
+    parser->state = PARSE_STATE_HEADERS;
+    return 1;
+}
+
+static int parse_header_line(http_parser_t *parser, const char *line, size_t len) {
+    const char *colon = memchr(line, ':', len);
+    if (!colon) {
+        parser_set_error(parser, HTTP_BAD_REQUEST, "Malformed header line");
+        return -1;
+    }
+
+    size_t name_len = (size_t)(colon - line);
+    while (name_len > 0 && isspace((unsigned char)line[name_len - 1])) {
+        name_len--;
+    }
+    if (name_len == 0) {
+        parser_set_error(parser, HTTP_BAD_REQUEST, "Empty header name");
+        return -1;
+    }
+
+    const char *value_start = colon + 1;
+    while ((size_t)(value_start - line) < len && (*value_start == ' ' || *value_start == '\t')) {
+        value_start++;
+    }
+    const char *value_end = line + len;
+    while (value_end > value_start && isspace((unsigned char)value_end[-1])) {
+        value_end--;
+    }
+
+    size_t value_len = (size_t)(value_end - value_start);
+
+    char *name_buf = (char *)malloc(name_len + 1);
+    char *value_buf = (char *)malloc(value_len + 1);
+    if (!name_buf || !value_buf) {
+        free(name_buf);
+        free(value_buf);
+        parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
+        return -1;
+    }
+
+    memcpy(name_buf, line, name_len);
+    name_buf[name_len] = '\0';
+    memcpy(value_buf, value_start, value_len);
+    value_buf[value_len] = '\0';
+
+    bool replace = (strcasecmp(name_buf, "set-cookie") != 0);
+    if (header_list_add((http_header_node_t **)&parser->req->headers, name_buf, name_buf, value_buf, replace) < 0) {
+        free(name_buf);
+        free(value_buf);
+        parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
+        return -1;
+    }
+
+    if (strcasecmp(name_buf, "content-length") == 0) {
+        char *endptr = NULL;
+        unsigned long long val = strtoull(value_buf, &endptr, 10);
+        if (endptr == value_buf || *endptr != '\0') {
+            parser_set_error(parser, HTTP_BAD_REQUEST, "Invalid Content-Length header");
+            return -1;
+        }
+        if (val > MAX_BODY_BYTES) {
+            parser_set_error(parser, (http_status_t)413, "Payload Too Large");
+            return -1;
+        }
+        parser->content_length = (size_t)val;
+    } else if (strcasecmp(name_buf, "transfer-encoding") == 0) {
+        if (strstr(value_buf, "chunked") != NULL) {
+            parser->chunked = true;
+            parser->content_length = 0;
+        }
+    } else if (strcasecmp(name_buf, "connection") == 0) {
+        if (strcasestr(value_buf, "close")) {
+            parser->keep_alive = false;
+        } else if (strcasestr(value_buf, "keep-alive")) {
+            parser->keep_alive = true;
+        }
+    } else if (strcasecmp(name_buf, "host") == 0) {
+        parser->seen_host = true;
+    }
+
+    free(name_buf);
+    free(value_buf);
+    return 0;
+}
+
+static int append_body_data(http_parser_t *parser, const char *data, size_t len) {
+    if (parser->body_received + len > MAX_BODY_BYTES) {
+        parser_set_error(parser, (http_status_t)413, "Payload Too Large");
+        return -1;
+    }
+
+    size_t needed = parser->body_received + len + 1;
+    if (needed > parser->body_capacity) {
+        size_t new_cap = parser->body_capacity ? parser->body_capacity : READ_BUFFER_SIZE;
+        while (new_cap < needed) {
+            new_cap *= 2;
+            if (new_cap > MAX_BODY_BYTES + 1) {
+                new_cap = MAX_BODY_BYTES + 1;
+                break;
+            }
+        }
+        char *tmp = (char *)realloc(parser->req->body, new_cap);
+        if (!tmp) {
+            parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
+            return -1;
+        }
+        parser->req->body = tmp;
+        parser->body_capacity = new_cap;
+    }
+
+    memcpy(parser->req->body + parser->body_received, data, len);
+    parser->body_received += len;
+    parser->req->body[parser->body_received] = '\0';
+    parser->req->body_length = parser->body_received;
+    return 0;
+}
+
+static int parse_headers(http_parser_t *parser) {
+    while (1) {
+        ssize_t crlf_index = find_crlf(parser->buffer, parser->buffer_len);
+        if (crlf_index < 0) {
+            if (parser->buffer_len > MAX_HEADER_BYTES) {
+                parser_set_error(parser, (http_status_t)431, "Request Header Fields Too Large");
+                return -1;
+            }
+            return 0;
+        }
+
+        if (crlf_index == 0) {
+            parser_consume(parser, 2);
+            if (parser->keep_alive && !parser->seen_host) {
+                parser_set_error(parser, HTTP_BAD_REQUEST, "Missing Host header");
+                return -1;
+            }
+            if (parser->chunked) {
+                parser->state = PARSE_STATE_CHUNK_SIZE;
+            } else if (parser->content_length > 0) {
+                parser->state = PARSE_STATE_BODY;
+            } else {
+                parser->state = PARSE_STATE_COMPLETE;
+            }
+            return 1;
+        }
+
+        if ((size_t)crlf_index > MAX_HEADER_LINE_LEN) {
+            parser_set_error(parser, (http_status_t)431, "Header line too long");
+            return -1;
+        }
+
+        if (parser->header_count >= MAX_HEADER_COUNT) {
+            parser_set_error(parser, (http_status_t)431, "Too many headers");
+            return -1;
+        }
+
+        int result = parse_header_line(parser, parser->buffer, (size_t)crlf_index);
+        if (result < 0) {
+            return -1;
+        }
+        parser->header_count++;
+        parser_consume(parser, (size_t)crlf_index + 2);
+    }
+}
+
+static int parse_chunk_size(http_parser_t *parser) {
+    ssize_t crlf_index = find_crlf(parser->buffer, parser->buffer_len);
+    if (crlf_index < 0) {
+        return 0;
+    }
+
+    char *line = (char *)malloc((size_t)crlf_index + 1);
+    if (!line) {
+        parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
+        return -1;
+    }
+    memcpy(line, parser->buffer, (size_t)crlf_index);
+    line[crlf_index] = '\0';
+
+    char *endptr = NULL;
+    unsigned long chunk_size = strtoul(line, &endptr, 16);
+    if (endptr == line) {
+        free(line);
+        parser_set_error(parser, HTTP_BAD_REQUEST, "Invalid chunk size");
+        return -1;
+    }
+
+    parser_consume(parser, (size_t)crlf_index + 2);
+    free(line);
+
+    parser->current_chunk_size = chunk_size;
+    parser->current_chunk_received = 0;
+
+    if (chunk_size == 0) {
+        parser->state = PARSE_STATE_CHUNK_TRAILERS;
+    } else {
+        parser->state = PARSE_STATE_CHUNK_DATA;
+    }
+    return 1;
+}
+
+static int parse_chunk_data(http_parser_t *parser) {
+    size_t remaining = parser->current_chunk_size - parser->current_chunk_received;
+    if (remaining == 0) {
+        parser->state = PARSE_STATE_CHUNK_CRLF;
+        return 1;
+    }
+
+    size_t to_copy = parser->buffer_len < remaining ? parser->buffer_len : remaining;
+    if (to_copy == 0) {
+        return 0;
+    }
+
+    if (append_body_data(parser, parser->buffer, to_copy) < 0) {
+        return -1;
+    }
+    parser_consume(parser, to_copy);
+    parser->current_chunk_received += to_copy;
+
+    if (parser->current_chunk_received == parser->current_chunk_size) {
+        parser->state = PARSE_STATE_CHUNK_CRLF;
+    }
+    return 1;
+}
+
+static int parse_chunk_crlf(http_parser_t *parser) {
+    if (parser->buffer_len < 2) {
+        return 0;
+    }
+    if (parser->buffer[0] != '\r' || parser->buffer[1] != '\n') {
+        parser_set_error(parser, HTTP_BAD_REQUEST, "Malformed chunk data");
+        return -1;
+    }
+    parser_consume(parser, 2);
+    parser->state = PARSE_STATE_CHUNK_SIZE;
+    return 1;
+}
+
+static int parse_chunk_trailers(http_parser_t *parser) {
+    ssize_t crlf_index = find_crlf(parser->buffer, parser->buffer_len);
+    if (crlf_index < 0) {
+        return 0;
+    }
+    if (crlf_index == 0) {
+        parser_consume(parser, 2);
+        parser->state = PARSE_STATE_COMPLETE;
+        parser->req->body_length = parser->body_received;
+        return 1;
+    }
+    /* Ignore trailer headers for now */
+    parser_consume(parser, (size_t)crlf_index + 2);
+    return 1;
+}
+
+static void http_parser_init(http_parser_t *parser, http_request_t *req) {
+    memset(parser, 0, sizeof(*parser));
+    parser->state = PARSE_STATE_REQUEST_LINE;
+    parser->req = req;
+    parser->buffer_cap = READ_BUFFER_SIZE;
+    parser->buffer = (char *)malloc(parser->buffer_cap);
+    if (!parser->buffer) {
+        parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
+    }
+}
+
+static void http_parser_reset(http_parser_t *parser, http_request_t *req, bool preserve_buffer) {
+    parser->state = PARSE_STATE_REQUEST_LINE;
+    parser->req = req;
+    if (!preserve_buffer) {
+        parser->buffer_len = 0;
+        parser->total_bytes = 0;
+    } else {
+        if (parser->buffer_len > MAX_REQUEST_BUFFER) {
+            /* Safety clamp if leftover somehow exceeds limits */
+            parser->buffer_len = MAX_REQUEST_BUFFER;
+        }
+        parser->total_bytes = parser->buffer_len;
+    }
+    parser->header_count = 0;
+    parser->content_length = 0;
+    parser->body_received = 0;
+    parser->body_capacity = 0;
+    parser->chunked = false;
+    parser->current_chunk_size = 0;
+    parser->current_chunk_received = 0;
+    parser->keep_alive = false;
+    parser->seen_host = false;
+    parser->error_status = HTTP_BAD_REQUEST;
+    parser->error_message = NULL;
+    if (parser->req) {
+        parser->req->body_length = 0;
+    }
+}
+
+static void http_parser_destroy(http_parser_t *parser) {
+    free(parser->buffer);
+    parser->buffer = NULL;
+    parser->buffer_cap = 0;
+}
+
+static parser_result_t http_parser_execute(http_parser_t *parser, const char *data, size_t len) {
+    if (!parser || parser->state == PARSE_STATE_ERROR) {
+        return PARSER_ERROR;
+    }
+
+    if (len > 0) {
+        if (ensure_buffer_capacity(parser, len) < 0) {
+            return PARSER_ERROR;
+        }
+        memcpy(parser->buffer + parser->buffer_len, data, len);
+        parser->buffer_len += len;
+        parser->total_bytes += len;
+    }
+
+    while (parser->state != PARSE_STATE_ERROR && parser->state != PARSE_STATE_COMPLETE) {
+        switch (parser->state) {
+            case PARSE_STATE_REQUEST_LINE:
+                if (parse_request_line(parser) <= 0) {
+                    return parser->state == PARSE_STATE_ERROR ? PARSER_ERROR : PARSER_INCOMPLETE;
+                }
+                break;
+            case PARSE_STATE_HEADERS: {
+                int result = parse_headers(parser);
+                if (result < 0) {
+                    return PARSER_ERROR;
+                }
+                if (result == 0) {
+                    return PARSER_INCOMPLETE;
+                }
+                break;
+            }
+            case PARSE_STATE_BODY: {
+                size_t remaining = parser->content_length - parser->body_received;
+                size_t to_copy = parser->buffer_len < remaining ? parser->buffer_len : remaining;
+                if (to_copy == 0) {
+                    return PARSER_INCOMPLETE;
+                }
+                if (append_body_data(parser, parser->buffer, to_copy) < 0) {
+                    return PARSER_ERROR;
+                }
+                parser_consume(parser, to_copy);
+                if (parser->body_received == parser->content_length) {
+                    parser->state = PARSE_STATE_COMPLETE;
+                    parser->req->body_length = parser->body_received;
+                    return PARSER_COMPLETE;
+                }
+                break;
+            }
+            case PARSE_STATE_CHUNK_SIZE: {
+                int result = parse_chunk_size(parser);
+                if (result <= 0) {
+                    return result < 0 ? PARSER_ERROR : PARSER_INCOMPLETE;
+                }
+                break;
+            }
+            case PARSE_STATE_CHUNK_DATA: {
+                int result = parse_chunk_data(parser);
+                if (result <= 0) {
+                    return result < 0 ? PARSER_ERROR : PARSER_INCOMPLETE;
+                }
+                break;
+            }
+            case PARSE_STATE_CHUNK_CRLF: {
+                int result = parse_chunk_crlf(parser);
+                if (result <= 0) {
+                    return result < 0 ? PARSER_ERROR : PARSER_INCOMPLETE;
+                }
+                break;
+            }
+            case PARSE_STATE_CHUNK_TRAILERS: {
+                int result = parse_chunk_trailers(parser);
+                if (result <= 0) {
+                    return result < 0 ? PARSER_ERROR : PARSER_INCOMPLETE;
+                }
+                break;
+            }
+            default:
+                return PARSER_ERROR;
+        }
+    }
+
+    if (parser->state == PARSE_STATE_COMPLETE) {
+        return PARSER_COMPLETE;
+    }
+    return PARSER_ERROR;
 }
 
 /* Enable/disable async I/O mode */
@@ -538,100 +1468,154 @@ static void async_accept_handler(int fd, int events, void *user_data) {
         close(client_fd);
         return;
     }
-    
+
     conn->client_fd = client_fd;
     conn->server = server;
-    conn->buffer_pos = 0;
-    conn->request = NULL;
-    conn->response = NULL;
-    conn->request_complete = false;
-    
-    /* Add client socket to event loop for reading */
-    if (event_loop_add_fd(server->event_loop, client_fd, EVENT_READ, 
-                         async_read_handler, conn) < 0) {
-        fprintf(stderr, "Failed to add client socket to event loop\n");
-        free(conn);
-        close(client_fd);
+    conn->request = http_request_create();
+    conn->response = http_response_create();
+    conn->header_buf = NULL;
+    conn->header_len = 0;
+    conn->header_sent = 0;
+    conn->body_sent = 0;
+    conn->parser_initialized = false;
+    conn->response_ready = false;
+    conn->keep_alive = false;
+    conn->closing = false;
+    if (!conn->request || !conn->response) {
+        send_error_response(client_fd, HTTP_INTERNAL_ERROR, "Internal Server Error");
+        free_async_connection(conn);
         return;
     }
+
+    http_parser_init(&conn->parser, conn->request);
+    conn->parser_initialized = true;
+    if (conn->parser.state == PARSE_STATE_ERROR) {
+        http_status_t status = conn->parser.error_status ? conn->parser.error_status : HTTP_INTERNAL_ERROR;
+        send_error_response(client_fd, status, conn->parser.error_message);
+        free_async_connection(conn);
+        return;
+    }
+
+    if (event_loop_add_fd(server->event_loop, client_fd, EVENT_READ,
+                         async_read_handler, conn) < 0) {
+        fprintf(stderr, "Failed to add client socket to event loop\n");
+        free_async_connection(conn);
+        return;
+    }
+}
+
+static bool async_on_parser_result(async_connection_t *conn, int fd, parser_result_t result) {
+    if (!conn || !conn->server) {
+        return false;
+    }
+
+    http_server_t *server = conn->server;
+    bool keep_alive = false;
+
+    if (result == PARSER_ERROR) {
+        http_status_t status = conn->parser.error_status ? conn->parser.error_status : HTTP_BAD_REQUEST;
+        const char *message = conn->parser.error_message ? conn->parser.error_message : "Bad Request";
+        http_response_send_text(conn->response, status, message);
+        keep_alive = false;
+    } else if (result == PARSER_COMPLETE) {
+        if (server->router) {
+            if (router_route(server->router, conn->request, conn->response) < 0) {
+                http_response_send_text(conn->response, HTTP_NOT_FOUND, "Not Found");
+            }
+        } else {
+            http_response_send_text(conn->response, HTTP_NOT_FOUND, "Not Found");
+        }
+        keep_alive = conn->parser.keep_alive && !response_forces_close(conn->response);
+    } else {
+        return true;
+    }
+
+    if (conn->header_buf) {
+        free(conn->header_buf);
+        conn->header_buf = NULL;
+    }
+    conn->header_len = 0;
+    conn->header_sent = 0;
+    conn->body_sent = 0;
+
+    if (serialize_response(conn->response, keep_alive, &conn->header_buf, &conn->header_len) < 0) {
+        event_loop_remove_fd(server->event_loop, fd);
+        free_async_connection(conn);
+        return false;
+    }
+
+    conn->keep_alive = keep_alive;
+    conn->closing = !keep_alive;
+    conn->response_ready = true;
+
+    if (event_loop_modify_fd(server->event_loop, fd, EVENT_WRITE) < 0) {
+        event_loop_remove_fd(server->event_loop, fd);
+        free_async_connection(conn);
+        return false;
+    }
+
+    return true;
 }
 
 /* Async read handler */
 static void async_read_handler(int fd, int events, void *user_data) {
     async_connection_t *conn = (async_connection_t *)user_data;
-    
+
     if (events & EVENT_ERROR) {
         fprintf(stderr, "Error on client socket\n");
         event_loop_remove_fd(conn->server->event_loop, fd);
         free_async_connection(conn);
         return;
     }
-    
+
     if (!(events & EVENT_READ)) {
         return;
     }
-    
-    /* Read data from client */
-    ssize_t bytes_read = recv(fd, conn->buffer + conn->buffer_pos, 
-                              BUFFER_SIZE - conn->buffer_pos - 1, 0);
-    
-    if (bytes_read <= 0) {
-        if (bytes_read == 0 || (errno != EAGAIN && errno != EWOULDBLOCK)) {
-            /* Connection closed or error */
-            event_loop_remove_fd(conn->server->event_loop, fd);
-            free_async_connection(conn);
-        }
+
+    if (!conn->parser_initialized || conn->response_ready) {
         return;
     }
-    
-    conn->buffer_pos += bytes_read;
-    conn->buffer[conn->buffer_pos] = '\0';
-    
-    /* Check if we have a complete HTTP request (ends with \r\n\r\n) */
-    if (strstr(conn->buffer, "\r\n\r\n") != NULL) {
-        conn->request_complete = true;
-        
-        /* Parse request */
-        conn->request = parse_request(conn->buffer);
-        if (!conn->request) {
-            fprintf(stderr, "Failed to parse request\n");
+
+    parser_result_t result = PARSER_INCOMPLETE;
+    if (conn->parser.buffer_len > 0) {
+        result = http_parser_execute(&conn->parser, NULL, 0);
+    }
+
+    char read_buf[READ_BUFFER_SIZE];
+    while (result == PARSER_INCOMPLETE) {
+        ssize_t bytes_read = recv(fd, read_buf, sizeof(read_buf), 0);
+        if (bytes_read < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                break;
+            }
+            perror("recv failed");
             event_loop_remove_fd(conn->server->event_loop, fd);
             free_async_connection(conn);
             return;
         }
-        
-        /* Create response */
-        conn->response = (http_response_t *)calloc(1, sizeof(http_response_t));
-        if (!conn->response) {
-            fprintf(stderr, "Failed to allocate response\n");
+
+        if (bytes_read == 0) {
             event_loop_remove_fd(conn->server->event_loop, fd);
             free_async_connection(conn);
             return;
         }
-        conn->response->status = HTTP_OK;
-        
-        /* Route request */
-        if (conn->server->router) {
-            router_route(conn->server->router, conn->request, conn->response);
-        } else {
-            http_response_send_text(conn->response, HTTP_NOT_FOUND, "Not Found");
-        }
-        
-        /* Switch to write mode */
-        if (event_loop_modify_fd(conn->server->event_loop, fd, EVENT_WRITE) < 0) {
-            fprintf(stderr, "Failed to modify event for writing\n");
-            event_loop_remove_fd(conn->server->event_loop, fd);
-            free_async_connection(conn);
-            return;
-        }
-        
-        /* Immediately send response since we're switching to write */
+
+        result = http_parser_execute(&conn->parser, read_buf, (size_t)bytes_read);
+    }
+
+    if (result == PARSER_INCOMPLETE) {
+        return;
+    }
+
+    if (!async_on_parser_result(conn, fd, result)) {
+        return;
+    }
+
+    if (conn->response_ready) {
         async_write_handler(fd, EVENT_WRITE, conn);
-    } else if (conn->buffer_pos >= BUFFER_SIZE - 1) {
-        /* Request too large */
-        fprintf(stderr, "Request too large\n");
-        event_loop_remove_fd(conn->server->event_loop, fd);
-        free_async_connection(conn);
     }
 }
 
@@ -649,15 +1633,121 @@ static void async_write_handler(int fd, int events, void *user_data) {
     if (!(events & EVENT_WRITE)) {
         return;
     }
-    
-    /* Send response */
-    if (conn->response) {
-        send_response(fd, conn->response);
+    if (!conn->response || !conn->response_ready || !conn->header_buf) {
+        return;
     }
-    
-    /* Close connection */
-    event_loop_remove_fd(conn->server->event_loop, fd);
-    free_async_connection(conn);
+
+    for (;;) {
+        while (conn->header_sent < conn->header_len) {
+            ssize_t sent = send(fd, conn->header_buf + conn->header_sent,
+                                conn->header_len - conn->header_sent, 0);
+            if (sent < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    return;
+                }
+                perror("send failed");
+                event_loop_remove_fd(conn->server->event_loop, fd);
+                free_async_connection(conn);
+                return;
+            }
+            if (sent == 0) {
+                event_loop_remove_fd(conn->server->event_loop, fd);
+                free_async_connection(conn);
+                return;
+            }
+            conn->header_sent += (size_t)sent;
+        }
+
+        while (conn->body_sent < conn->response->body_length) {
+            if (!conn->response->body || conn->response->body_length == 0) {
+                conn->body_sent = conn->response->body_length;
+                break;
+            }
+            size_t remaining = conn->response->body_length - conn->body_sent;
+            ssize_t sent = send(fd, conn->response->body + conn->body_sent, remaining, 0);
+            if (sent < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    return;
+                }
+                perror("send failed");
+                event_loop_remove_fd(conn->server->event_loop, fd);
+                free_async_connection(conn);
+                return;
+            }
+            if (sent == 0) {
+                event_loop_remove_fd(conn->server->event_loop, fd);
+                free_async_connection(conn);
+                return;
+            }
+            conn->body_sent += (size_t)sent;
+            if ((size_t)sent < remaining) {
+                return;
+            }
+        }
+
+        if (conn->header_sent < conn->header_len || conn->body_sent < conn->response->body_length) {
+            return;
+        }
+
+        conn->response->sent = true;
+        free(conn->header_buf);
+        conn->header_buf = NULL;
+        conn->header_len = 0;
+        conn->response_ready = false;
+
+        bool reuse = conn->keep_alive && !conn->closing;
+
+        if (!reuse) {
+            event_loop_remove_fd(conn->server->event_loop, fd);
+            free_async_connection(conn);
+            return;
+        }
+
+        http_request_destroy(conn->request);
+        http_response_destroy(conn->response);
+        conn->request = http_request_create();
+        conn->response = http_response_create();
+        if (!conn->request || !conn->response) {
+            event_loop_remove_fd(conn->server->event_loop, fd);
+            free_async_connection(conn);
+            return;
+        }
+
+        http_parser_reset(&conn->parser, conn->request, true);
+        conn->keep_alive = false;
+        conn->closing = false;
+        conn->header_sent = 0;
+        conn->body_sent = 0;
+
+        parser_result_t result = PARSER_INCOMPLETE;
+        if (conn->parser.buffer_len > 0) {
+            result = http_parser_execute(&conn->parser, NULL, 0);
+        }
+
+        if (result == PARSER_INCOMPLETE) {
+            if (event_loop_modify_fd(conn->server->event_loop, fd, EVENT_READ) < 0) {
+                event_loop_remove_fd(conn->server->event_loop, fd);
+                free_async_connection(conn);
+            }
+            return;
+        }
+
+        if (!async_on_parser_result(conn, fd, result)) {
+            return;
+        }
+
+        if (!conn->response_ready || !conn->header_buf) {
+            return;
+        }
+
+        /* Loop to send pipelined response immediately */
+    }
 }
 
 /* Free async connection */
@@ -668,16 +1758,15 @@ static void free_async_connection(async_connection_t *conn) {
     
     if (conn->client_fd >= 0) {
         close(conn->client_fd);
+        conn->client_fd = -1;
     }
-    
-    if (conn->request) {
-        free_request(conn->request);
-    }
-    
-    if (conn->response) {
-        free_response(conn->response);
-    }
-    
+
+    free(conn->header_buf);
+    conn->header_buf = NULL;
+
+    http_parser_destroy(&conn->parser);
+    http_request_destroy(conn->request);
+    http_response_destroy(conn->response);
     free(conn);
 }
 


### PR DESCRIPTION
## Summary
- replace the legacy HTTP parsing logic with a state-machine parser that validates methods, headers, and request bodies for both threaded and async flows
- add keep-alive aware async send/receive loops with parser reuse so pipelined HTTP/1.1 requests are handled safely
- document and scaffold Docker-based workflows (builder/runtime images, helper scripts, repo guidance) and update roadmap/tasks to reflect the new parser work

## Testing
- cmake is not available in the local environment, so the build and test suite still need to be run (use the new docker-run scripts or set up CMake locally)
