### PR TITLE
Fix Valgrind leaks in D1 worker tests (restore green CI)

### DIFF
--- a/tests/test_worker.c
+++ b/tests/test_worker.c
@@ -458,7 +458,7 @@ static void test_d1_create_table_and_insert(void) {
 static void test_d1_select(void) {
     TEST("d1_select");
     worker_d1_t *db = worker_d1_create("testdb");
-    worker_d1_exec(db, "CREATE TABLE items (id, title)");
+    worker_d1_result_destroy(worker_d1_exec(db, "CREATE TABLE items (id, title)"));
 
     /* Insert two rows */
     worker_d1_stmt_t *ins = worker_d1_prepare(db,
@@ -507,7 +507,7 @@ static void test_d1_select(void) {
 static void test_d1_delete_rows(void) {
     TEST("d1_delete_rows");
     worker_d1_t *db = worker_d1_create("testdb");
-    worker_d1_exec(db, "CREATE TABLE logs (id, msg)");
+    worker_d1_result_destroy(worker_d1_exec(db, "CREATE TABLE logs (id, msg)"));
 
     worker_d1_stmt_t *ins = worker_d1_prepare(db,
         "INSERT INTO logs (id, msg) VALUES (?, ?)");
@@ -550,7 +550,7 @@ static void test_d1_delete_rows(void) {
 static void test_d1_batch(void) {
     TEST("d1_batch");
     worker_d1_t *db = worker_d1_create("testdb");
-    worker_d1_exec(db, "CREATE TABLE batch_test (id, val)");
+    worker_d1_result_destroy(worker_d1_exec(db, "CREATE TABLE batch_test (id, val)"));
 
     worker_d1_stmt_t *s1 = worker_d1_prepare(db,
         "INSERT INTO batch_test (id, val) VALUES (?, ?)");


### PR DESCRIPTION
## What
`main`'s "Build, Test & Memcheck (Docker)" job fails on Valgrind: `test_worker` leaks 72 bytes in 3 blocks. Cause: `test_d1_select`, `test_d1_delete_rows`, and `test_d1_batch` call `worker_d1_exec(db, "CREATE TABLE ...")` for setup and discard the returned **owned** `worker_d1_result_t *` (the API transfers ownership; other call sites already `worker_d1_result_destroy` it).

## Fix
Wrap each of the three discarded CREATE TABLE results in `worker_d1_result_destroy()` (NULL-safe). Test-only change.

## Verify
- `test_worker`: 31/31 pass.
- `test_worker` is the last suite in the Valgrind loop and the only one leaking (all others already clean), so this restores the green gate.

Unblocks #74, which inherits main's red CI. worker_d1 *library* fixes (DELETE-all, positional INSERT) will follow in a dedicated workers PR.