### PR TITLE
Harden CSPRNG + remove predictable-entropy fallbacks (fail closed)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ if(EMSCRIPTEN)
 elseif(WIN32)
     # Windows-specific settings
     add_definitions(-D_WIN32_WINNT=0x0600)
-    set(PLATFORM_LIBS ws2_32)
+    # bcrypt: BCryptGenRandom() used by secure_random_bytes()
+    set(PLATFORM_LIBS ws2_32 bcrypt)
 elseif(UNIX AND NOT APPLE)
     # Linux-specific settings
     set(PLATFORM_LIBS pthread)

--- a/src/security_utils.c
+++ b/src/security_utils.c
@@ -12,21 +12,44 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #if defined(_WIN32)
+#include <windows.h>
 #include <bcrypt.h>
+#else
+#include <errno.h>
+#include <unistd.h>   /* ssize_t */
+#endif
+
+/* Choose the best available system CSPRNG per platform.  arc4random_buf() on
+ * Apple/BSD and getrandom(2) on Linux both draw from the kernel CSPRNG without
+ * a file descriptor, so they keep working under chroot / fd exhaustion /
+ * minimal sandboxes where opening /dev/urandom would fail.  (macOS ships
+ * <sys/random.h> too, but it declares getentropy, not getrandom — so getrandom
+ * is gated on __linux__.) */
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
+    defined(__NetBSD__) || defined(__DragonFly__)
+/* arc4random_buf() is declared in <stdlib.h>. */
+#elif !defined(_WIN32)
+#  if defined(__linux__) && defined(__has_include)
+#    if __has_include(<sys/random.h>)
+#      include <sys/random.h>
+#      define WEBLIB_HAVE_GETRANDOM 1
+#    endif
+#  endif
 #endif
 
 /* ---- secure memory wipe ---------------------------------------------- */
 
 void secure_zero(void *ptr, size_t len) {
     if (!ptr || len == 0) return;
-#if defined(__STDC_LIB_EXT1__) || defined(_WIN32)
-    memset_s(ptr, len, 0, len);
-#else
-    volatile unsigned char *p = (volatile unsigned char *)ptr;
-    while (len--) *p++ = 0;
-#endif
+    /* A volatile function pointer to memset forces the wipe to execute: the
+     * compiler cannot prove the callee is memset, so it cannot elide the stores
+     * as dead.  Portable across glibc/musl/macOS/BSD/Windows with no Annex-K
+     * (__STDC_WANT_LIB_EXT1__ / memset_s) or platform-header dependency. */
+    static void *(*const volatile memset_fn)(void *, int, size_t) = &memset;
+    memset_fn(ptr, 0, len);
 }
 
 /* ---- constant-time comparison ---------------------------------------- */
@@ -47,20 +70,49 @@ bool secure_compare(const void *a, const void *b, size_t len) {
 
 /* ---- cryptographically secure random bytes --------------------------- */
 
+/*
+ * Fill buf with len cryptographically secure random bytes.
+ * Returns 0 on success, -1 on failure.  On failure the buffer contents are
+ * unspecified and MUST NOT be used -- callers must fail closed and never fall
+ * back to a predictable PRNG (rand/rand_r) for keys, tokens, or session IDs.
+ */
 int secure_random_bytes(void *buf, size_t len) {
     if (!buf || len == 0) return -1;
 
 #if defined(_WIN32)
-    /* Windows: BCryptGenRandom (Vista+) */
     NTSTATUS status = BCryptGenRandom(NULL, (PUCHAR)buf, (ULONG)len,
                                       BCRYPT_USE_SYSTEM_PREFERRED_RNG);
     return NT_SUCCESS(status) ? 0 : -1;
+
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
+      defined(__NetBSD__) || defined(__DragonFly__)
+    /* System CSPRNG; cannot fail and needs no file descriptor. */
+    arc4random_buf(buf, len);
+    return 0;
+
 #else
-    /* POSIX: /dev/urandom (Linux, macOS, BSD) */
-    FILE *fp = fopen("/dev/urandom", "rb");
-    if (!fp) return -1;
-    size_t got = fread(buf, 1, len, fp);
-    fclose(fp);
-    return (got == len) ? 0 : -1;
+    unsigned char *p = (unsigned char *)buf;
+    size_t off = 0;
+
+#if defined(WEBLIB_HAVE_GETRANDOM)
+    while (off < len) {
+        ssize_t r = getrandom(p + off, len - off, 0);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            break;  /* getrandom unavailable at runtime -> try /dev/urandom */
+        }
+        off += (size_t)r;
+    }
+    if (off == len) return 0;
+#endif
+
+    /* Fallback: /dev/urandom, filling anything getrandom did not. */
+    {
+        FILE *fp = fopen("/dev/urandom", "rb");
+        if (!fp) return -1;
+        size_t got = fread(p + off, 1, len - off, fp);
+        fclose(fp);
+        return (off + got == len) ? 0 : -1;
+    }
 #endif
 }

--- a/src/session.c
+++ b/src/session.c
@@ -39,13 +39,16 @@ struct session_store {
     pthread_mutex_t lock;
 };
 
-/* Generate random session ID */
-static void generate_session_id(char *buffer, size_t length) {
-    static const char charset[] = 
+/* Generate a random session ID.  Returns 0 on success, -1 on CSPRNG failure.
+ * Fails closed: it never falls back to a predictable PRNG (rand/rand_r) for a
+ * security token -- a caller that cannot obtain entropy must refuse the
+ * session rather than issue a guessable ID. */
+static int generate_session_id(char *buffer, size_t length) {
+    static const char charset[] =
         "0123456789"
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz";
-    
+
     size_t charset_len = sizeof(charset) - 1;
     unsigned char random_bytes[64]; /* Max SESSION_ID_LENGTH */
 
@@ -53,39 +56,30 @@ static void generate_session_id(char *buffer, size_t length) {
         length = sizeof(random_bytes);
     }
 
-    if (secure_random_bytes(random_bytes, length) == 0) {
-        /* Rejection sampling to avoid modular bias.
-         * 256 / 62 = 4 remainder 8; threshold = 256 - 8 = 248 */
-        unsigned char threshold = (unsigned char)(256 - (256 % charset_len));
-        for (size_t i = 0; i < length; ) {
-            if (random_bytes[i] < threshold) {
-                buffer[i] = charset[random_bytes[i] % charset_len];
-                i++;
-            } else {
-                /* Re-sample this byte */
-                unsigned char replacement;
-                if (secure_random_bytes(&replacement, 1) != 0) {
-                    /* RNG failure — abort session ID generation entirely */
-                    memset(buffer, 0, length + 1);
-                    return;
-                }
-                random_bytes[i] = replacement;
-                /* loop will retry */
+    if (secure_random_bytes(random_bytes, length) != 0) {
+        return -1;
+    }
+
+    /* Rejection sampling to avoid modular bias.
+     * 256 / 62 = 4 remainder 8; threshold = 256 - 8 = 248 */
+    unsigned char threshold = (unsigned char)(256 - (256 % charset_len));
+    for (size_t i = 0; i < length; ) {
+        if (random_bytes[i] < threshold) {
+            buffer[i] = charset[random_bytes[i] % charset_len];
+            i++;
+        } else {
+            /* Re-sample this byte. */
+            unsigned char replacement;
+            if (secure_random_bytes(&replacement, 1) != 0) {
+                secure_zero(random_bytes, sizeof(random_bytes));
+                return -1;
             }
-        }
-    } else {
-        /* Fallback: use rand_r() with thread-local seed for thread safety */
-        static __thread unsigned int seed_state = 0;
-        if (seed_state == 0) {
-            seed_state = (unsigned int)time(NULL);
-            seed_state ^= (unsigned int)clock();
-            seed_state ^= (unsigned int)(size_t)&seed_state;
-        }
-        for (size_t i = 0; i < length; i++) {
-            buffer[i] = charset[rand_r(&seed_state) % charset_len];
+            random_bytes[i] = replacement;
         }
     }
     buffer[length] = '\0';
+    secure_zero(random_bytes, sizeof(random_bytes));   /* wipe raw entropy */
+    return 0;
 }
 
 /* Create session store */
@@ -172,8 +166,13 @@ char *session_create(session_store_t *store, int max_age) {
     bool unique = false;
     
     for (int attempt = 0; attempt < max_attempts && !unique; attempt++) {
-        generate_session_id(session->session_id, SESSION_ID_LENGTH);
-        
+        if (generate_session_id(session->session_id, SESSION_ID_LENGTH) != 0) {
+            /* CSPRNG unavailable: fail closed rather than issue a guessable ID. */
+            fprintf(stderr, "session_create: secure RNG unavailable — refusing to issue session ID\n");
+            pthread_mutex_unlock(&store->lock);
+            return NULL;
+        }
+
         /* Check for uniqueness */
         unique = true;
         for (size_t i = 0; i < MAX_SESSIONS; i++) {

--- a/src/session.c
+++ b/src/session.c
@@ -57,6 +57,9 @@ static int generate_session_id(char *buffer, size_t length) {
     }
 
     if (secure_random_bytes(random_bytes, length) != 0) {
+        /* May hold partial CSPRNG output on failure: wipe it, leave no ID. */
+        secure_zero(random_bytes, sizeof(random_bytes));
+        buffer[0] = '\0';
         return -1;
     }
 

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -4087,6 +4087,17 @@ void test_secure_random_bytes(void) {
     }
     ASSERT(all_zero == 0);
 
+    /* A larger-than-256-byte fill exercises the multi-call getrandom/read loop
+     * (getrandom may return partial; getentropy caps at 256 per call). */
+    unsigned char big[300];
+    memset(big, 0, sizeof(big));
+    ASSERT(secure_random_bytes(big, sizeof(big)) == 0);
+    int big_all_zero = 1;
+    for (size_t i = 0; i < sizeof(big); i++) {
+        if (big[i] != 0) { big_all_zero = 0; break; }
+    }
+    ASSERT(big_all_zero == 0);
+
     /* NULL/zero-length returns error */
     ASSERT(secure_random_bytes(NULL, 16) == -1);
     ASSERT(secure_random_bytes(buf1, 0) == -1);

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -4087,8 +4087,9 @@ void test_secure_random_bytes(void) {
     }
     ASSERT(all_zero == 0);
 
-    /* A larger-than-256-byte fill exercises the multi-call getrandom/read loop
-     * (getrandom may return partial; getentropy caps at 256 per call). */
+    /* A larger-than-256-byte fill exercises the getrandom() partial-read loop:
+     * on Linux getrandom() only guarantees full delivery for requests up to
+     * 256 bytes, so larger requests may return partial and must be looped. */
     unsigned char big[300];
     memset(big, 0, sizeof(big));
     ASSERT(secure_random_bytes(big, sizeof(big)) == 0);
@@ -4099,7 +4100,7 @@ void test_secure_random_bytes(void) {
     ASSERT(big_all_zero == 0);
 
     /* The tail past the first 256 bytes must also be randomized -- catches a
-     * fill loop that stops after a single getrandom/getentropy chunk. */
+     * getrandom() loop that stops after the first (<=256-byte) partial read. */
     int big_tail_zero = 1;
     for (size_t i = 256; i < sizeof(big); i++) {
         if (big[i] != 0) { big_tail_zero = 0; break; }

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -4098,6 +4098,14 @@ void test_secure_random_bytes(void) {
     }
     ASSERT(big_all_zero == 0);
 
+    /* The tail past the first 256 bytes must also be randomized -- catches a
+     * fill loop that stops after a single getrandom/getentropy chunk. */
+    int big_tail_zero = 1;
+    for (size_t i = 256; i < sizeof(big); i++) {
+        if (big[i] != 0) { big_tail_zero = 0; break; }
+    }
+    ASSERT(big_tail_zero == 0);
+
     /* NULL/zero-length returns error */
     ASSERT(secure_random_bytes(NULL, 16) == -1);
     ASSERT(secure_random_bytes(buf1, 0) == -1);


### PR DESCRIPTION
## What
Engineers out the audit's HIGH finding — *CSPRNG is /dev/urandom-only and callers silently downgrade to a predictable PRNG* — and the related predictable session-ID fallback. Entropy underpins session IDs, CSRF tokens, and the upcoming TLS keys.

### `security_utils.c`
- **`secure_random_bytes()`**: prefer the kernel CSPRNG with no file descriptor — `getrandom(2)` on Linux, `arc4random_buf()` on macOS/BSD, `BCryptGenRandom` on Windows — falling back to `/dev/urandom`. **Returns -1 (fail closed)** if no source is available; it never downgrades to a predictable RNG. (macOS ships `<sys/random.h>` but only declares `getentropy`, so `getrandom` is gated on `__linux__`.)
- **`secure_zero()`**: the old `memset_s` branch was mis-guarded (undeclared without `__STDC_WANT_LIB_EXT1__`, absent on MSVC). Replaced with a `volatile` function-pointer call to `memset` that no compiler can elide — portable across glibc/musl/macOS/BSD/Windows.

### `session.c`
- **`generate_session_id()`** now returns success/failure and **fails closed**: the `rand_r()`-seeded-from-`time/clock/&addr` fallback is removed, so a CSPRNG failure can never produce a guessable session ID. The raw entropy buffer is `secure_zero`'d after use.
- **`session_create()`** refuses to issue a session when entropy is unavailable, instead of returning an empty/weak ID.

## Testing
- Full suite 151/151, **zero warnings** under `-Wall -Wextra -pedantic`; clean under ASan/UBSan.
- `secure_random_bytes` test extended with a >256-byte fill to exercise the multi-call getrandom/read loop.
- Existing session tests pass unchanged.
- CSRF token generation already failed closed (no change needed).

Part of the post-audit security-hardening pass; scoped to the entropy class. Email/input-validation and other security-utils items follow separately.