### PR TITLE
Template engine: auto-escape by default ({{ }}) + raw opt-out ({{{ }}}) — fix XSS

### DIFF
--- a/include/kamran.k
+++ b/include/kamran.k
@@ -1203,8 +1203,15 @@ const char *template_context_get(template_context_t *ctx, const char *key);
 void template_context_destroy(template_context_t *ctx);
 
 /**
- * Render a template string with variable substitution
- * Variables use {{ variable_name }} syntax
+ * Render a template string with variable substitution.
+ *
+ * Substitution is HTML-escaped by default to prevent XSS:
+ *   {{ name }}   -> value is HTML-escaped ( & < > " ' )   [safe default]
+ *   {{{ name }}} -> value is emitted raw/unescaped         [trusted HTML only]
+ *
+ * Only use the triple-brace raw form for values you fully control; binding
+ * untrusted input with {{{ }}} reintroduces XSS. Unknown variables render empty.
+ *
  * @param template_str Template string
  * @param ctx Template context with variables
  * @return Rendered string (caller must free) or NULL on error

--- a/include/kamran.k
+++ b/include/kamran.k
@@ -1212,6 +1212,11 @@ void template_context_destroy(template_context_t *ctx);
  * Only use the triple-brace raw form for values you fully control; binding
  * untrusted input with {{{ }}} reintroduces XSS. Unknown variables render empty.
  *
+ * Escaping is sufficient for HTML text and quoted attribute values only. It is
+ * NOT sufficient for unquoted attributes, javascript:/data: URLs, or the bodies
+ * of <script>/<style> elements -- do not place template output in those
+ * contexts without additional, context-appropriate encoding.
+ *
  * @param template_str Template string
  * @param ctx Template context with variables
  * @return Rendered string (caller must free) or NULL on error

--- a/src/template.c
+++ b/src/template.c
@@ -207,35 +207,33 @@ static char *buffer_to_string(string_buffer_t *buf) {
     return result;
 }
 
-/* Extract variable name from template syntax {{ var }} */
-static char *extract_var_name(const char *start, const char *end) {
-    /* Skip opening {{ */
-    start += 2;
-    
-    /* Skip whitespace */
+/* Extract a trimmed variable name from the content between the delimiters,
+ * i.e. the half-open range [content_start, content_end).  Returns a malloc'd
+ * copy, or NULL if empty / on allocation failure. */
+static char *extract_var_name(const char *content_start, const char *content_end) {
+    const char *start = content_start;
+    const char *end = content_end;
+
     while (start < end && isspace((unsigned char)*start)) {
         start++;
     }
-    
-    /* Find end (before }}) */
-    const char *var_end = end - 2;
-    while (var_end > start && isspace((unsigned char)*(var_end - 1))) {
-        var_end--;
+    while (end > start && isspace((unsigned char)*(end - 1))) {
+        end--;
     }
-    
-    if (var_end <= start) {
+
+    if (end <= start) {
         return NULL;
     }
-    
-    size_t len = var_end - start;
+
+    size_t len = (size_t)(end - start);
     char *name = (char *)malloc(len + 1);
     if (!name) {
         return NULL;
     }
-    
+
     memcpy(name, start, len);
     name[len] = '\0';
-    
+
     return name;
 }
 
@@ -254,19 +252,52 @@ char *template_render(const char *template_str, template_context_t *ctx) {
     const char *last = p;
     
     while (*p) {
-        /* Look for {{ */
-        if (p[0] == '{' && p[1] == '{') {
-            /* Append text before variable */
+        if (p[0] == '{' && p[1] == '{' && p[2] == '{') {
+            /* Raw substitution {{{ var }}}: the caller explicitly opts into
+             * trusting the value, so it is emitted without HTML escaping. */
             if (p > last) {
-                buffer_append(output, last, p - last);
+                buffer_append(output, last, (size_t)(p - last));
             }
-            
+
+            /* Find closing }}} */
+            const char *end = p + 3;
+            while (*end && !(end[0] == '}' && end[1] == '}' && end[2] == '}')) {
+                end++;
+            }
+
+            if (*end == '\0') {
+                /* No closing }}}, treat as literal text */
+                buffer_append_str(output, "{{{");
+                p += 3;
+                last = p;
+                continue;
+            }
+
+            char *var_name = extract_var_name(p + 3, end);
+            if (var_name) {
+                const char *value = template_context_get(ctx, var_name);
+                if (value) {
+                    buffer_append_str(output, value);  /* raw, unescaped */
+                }
+                /* Variable not found: leave empty (no output) */
+                free(var_name);
+            }
+
+            p = end + 3;
+            last = p;
+        } else if (p[0] == '{' && p[1] == '{') {
+            /* Escaped substitution {{ var }}: HTML-escaped by default so that
+             * binding untrusted data cannot inject markup (XSS). */
+            if (p > last) {
+                buffer_append(output, last, (size_t)(p - last));
+            }
+
             /* Find closing }} */
             const char *end = p + 2;
             while (*end && !(end[0] == '}' && end[1] == '}')) {
                 end++;
             }
-            
+
             if (*end == '\0') {
                 /* No closing }}, treat as literal text */
                 buffer_append_str(output, "{{");
@@ -274,20 +305,23 @@ char *template_render(const char *template_str, template_context_t *ctx) {
                 last = p;
                 continue;
             }
-            
-            /* Extract variable name */
-            char *var_name = extract_var_name(p, end + 2);
+
+            char *var_name = extract_var_name(p + 2, end);
             if (var_name) {
-                /* Get variable value from context */
                 const char *value = template_context_get(ctx, var_name);
                 if (value) {
-                    buffer_append_str(output, value);
+                    char *escaped = input_sanitize_html(value);
+                    if (escaped) {
+                        buffer_append_str(output, escaped);
+                        free(escaped);
+                    }
+                    /* On escaper allocation failure, omit the value rather than
+                     * emit it raw -- fail safe (never output unescaped data). */
                 }
                 /* Variable not found: leave empty (no output) */
                 free(var_name);
             }
-            
-            /* Move past }} */
+
             p = end + 2;
             last = p;
         } else {

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1449,6 +1449,10 @@ void test_template_autoescape(void) {
     ASSERT(strstr(esc, "<script>") == NULL);          /* no raw injection */
     ASSERT(strstr(esc, "&lt;script&gt;") != NULL);    /* escaped */
     ASSERT(strstr(esc, "&amp;") != NULL);             /* & escaped */
+    ASSERT(strstr(esc, "&quot;") != NULL);            /* " escaped */
+    ASSERT(strstr(esc, "&#39;") != NULL);             /* ' escaped */
+    ASSERT(strchr(esc, '"') == NULL);                 /* no raw quote survives */
+    ASSERT(strchr(esc, '\'') == NULL);                /* no raw apostrophe survives */
     free(esc);
 
     /* {{{ x }}} is an explicit opt-in to raw, unescaped output. */

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1435,6 +1435,40 @@ void test_template_load_file(void) {
     PASS();
 }
 
+/* Security regression: {{ }} must HTML-escape (XSS prevention); {{{ }}} is raw. */
+void test_template_autoescape(void) {
+    TEST("template (auto-escape / raw)");
+
+    template_context_t *ctx = template_context_create();
+    ASSERT(ctx != NULL);
+    template_context_set(ctx, "x", "<script>alert(1)</script> & \"'");
+
+    /* {{ x }} must escape: no raw markup, entities present. */
+    char *esc = template_render("<p>{{ x }}</p>", ctx);
+    ASSERT(esc != NULL);
+    ASSERT(strstr(esc, "<script>") == NULL);          /* no raw injection */
+    ASSERT(strstr(esc, "&lt;script&gt;") != NULL);    /* escaped */
+    ASSERT(strstr(esc, "&amp;") != NULL);             /* & escaped */
+    free(esc);
+
+    /* {{{ x }}} is an explicit opt-in to raw, unescaped output. */
+    template_context_set(ctx, "y", "<b>ok</b>");
+    char *raw = template_render("{{{ y }}}", ctx);
+    ASSERT(raw != NULL);
+    ASSERT(strcmp(raw, "<b>ok</b>") == 0);
+    free(raw);
+
+    /* Plain values are unchanged (back-compat). */
+    template_context_set(ctx, "name", "Alice");
+    char *plain = template_render("Hi {{ name }}", ctx);
+    ASSERT(plain != NULL);
+    ASSERT(strcmp(plain, "Hi Alice") == 0);
+    free(plain);
+
+    template_context_destroy(ctx);
+    PASS();
+}
+
 /* Test auth middleware - basic auth create/destroy */
 void test_basic_auth_create_destroy(void) {
     TEST("basic_auth (create/destroy)");
@@ -4327,6 +4361,7 @@ int main(void) {
     test_template_variables();
     test_template_render();
     test_template_load_file();
+    test_template_autoescape();
 
     /* Phase 6: Authentication middleware tests */
     test_basic_auth_create_destroy();


### PR DESCRIPTION
## What
Fixes the audit's HIGH XSS finding. The template engine appended `{{ var }}` values **verbatim** (`template.c`), so an app binding untrusted input (`template_context_set(ctx, "name", user_input)`) and serving the result as HTML got stored/reflected XSS on the framework's primary rendering path.

## Fix — secure by default
- **`{{ var }}`** now HTML-escapes the value (`& < > " '`), reusing the existing, tested `input_sanitize_html()` (no new escaper).
- **`{{{ var }}}`** is a new, explicit opt-in for raw/trusted HTML (Mustache convention). The class of XSS can only occur if a developer *deliberately* marks output raw.
- On escaper allocation failure the value is **omitted, not emitted raw** (fail safe).
- Unknown variables still render empty; the raw branch is parsed before the escaped branch.

## Backward compatibility
Escaping only changes output for values containing `& < > " '`. All existing template tests and examples use plain values ("Alice", "Test Page", "WebAssembly"), so they render identically and stay green.

## Testing
- New `test_template_autoescape`: `{{ x }}` with `<script>alert(1)</script> & \"'` yields no raw `<script>`, has `&lt;script&gt;`/`&amp;`; `{{{ y }}}` emits `<b>ok</b>` raw; plain values unchanged.
- Full suite 152/152, **zero warnings**, clean under ASan/UBSan.
- `template_render()` doc in the public header now specifies the escaping contract.