### PR TITLE
core-http: total-request deadline (slow-loris defense, threaded mode)

### DIFF
--- a/include/kamran.k
+++ b/include/kamran.k
@@ -94,6 +94,7 @@ typedef enum {
     HTTP_FORBIDDEN = 403,
     HTTP_NOT_FOUND = 404,
     HTTP_METHOD_NOT_ALLOWED = 405,
+    HTTP_REQUEST_TIMEOUT = 408,
     HTTP_PAYLOAD_TOO_LARGE = 413,
     HTTP_URI_TOO_LONG = 414,
     HTTP_TOO_MANY_REQUESTS = 429,
@@ -624,6 +625,24 @@ typedef enum {
  * @return 0 on success, -1 on failure (NULL server or negative values)
  */
 int http_server_set_timeout(http_server_t *server, int read_sec, int write_sec);
+
+/**
+ * Set the total wall-clock deadline for reading a complete request.
+ * Unlike the per-recv read timeout (SO_RCVTIMEO, which a drip client resets on
+ * every byte), this bounds the whole request and defends against slow-loris.
+ * Must be called before http_server_listen(). A value of 0 disables it.
+ * @param server Server instance
+ * @param sec Deadline in seconds (default: 60, 0 = no deadline)
+ * @return 0 on success, -1 on failure (NULL server or negative value)
+ */
+int http_server_set_request_timeout(http_server_t *server, int sec);
+
+/**
+ * Get the current total request-read deadline.
+ * @param server Server instance
+ * @return Deadline in seconds, or -1 if server is NULL
+ */
+int http_server_get_request_timeout(http_server_t *server);
 
 /**
  * Get current read timeout setting

--- a/include/kamran.k
+++ b/include/kamran.k
@@ -630,7 +630,11 @@ int http_server_set_timeout(http_server_t *server, int read_sec, int write_sec);
  * Set the total wall-clock deadline for reading a complete request.
  * Unlike the per-recv read timeout (SO_RCVTIMEO, which a drip client resets on
  * every byte), this bounds the whole request and defends against slow-loris.
- * Must be called before http_server_listen(). A value of 0 disables it.
+ * The deadline is evaluated per request, so it may be changed at runtime and
+ * takes effect on subsequent requests. A value of 0 disables it.
+ * A fully-silent client is bounded even when the read timeout is 0: the server
+ * caps the effective recv() timeout at this deadline. Worst-case hold is about
+ * this deadline plus one recv interval. Threaded mode only (see async note).
  * @param server Server instance
  * @param sec Deadline in seconds (default: 60, 0 = no deadline)
  * @return 0 on success, -1 on failure (NULL server or negative value)

--- a/src/env_config.c
+++ b/src/env_config.c
@@ -180,6 +180,12 @@ int http_server_apply_env(http_server_t *server) {
                                 wt >= 0 ? wt : cur_wt);
     }
 
+    /* WEBLIB_REQUEST_TIMEOUT (total request-read deadline; slow-loris guard) */
+    int reqt = env_config_get_int("WEBLIB_REQUEST_TIMEOUT", -1);
+    if (reqt >= 0) {
+        http_server_set_request_timeout(server, reqt);
+    }
+
     /* WEBLIB_THREAD_COUNT */
     int tc = env_config_get_int("WEBLIB_THREAD_COUNT", -1);
     if (tc > 0) {

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -173,6 +173,11 @@ typedef enum {
 /* Default timeouts in seconds */
 #define DEFAULT_READ_TIMEOUT_SEC 30
 #define DEFAULT_WRITE_TIMEOUT_SEC 30
+/* Total wall-clock deadline to read a COMPLETE request.  SO_RCVTIMEO only
+ * bounds a single recv() and is reset by every byte that arrives, so a slow
+ * "drip" client can hold a worker thread indefinitely (slow-loris).  This
+ * deadline bounds the whole request regardless of drip rate. 0 disables it. */
+#define DEFAULT_REQUEST_TIMEOUT_SEC 60
 
 /* Internal server structure */
 struct http_server {
@@ -186,7 +191,8 @@ struct http_server {
     /* Socket timeouts */
     int read_timeout_sec;
     int write_timeout_sec;
-    
+    int request_timeout_sec;   /* Total deadline to read a full request (slow-loris guard) */
+
     /* Thread pool (threaded mode) */
     thread_pool_t *pool;
     int thread_count;
@@ -282,6 +288,7 @@ http_server_t *http_server_create(void) {
     server->event_loop = NULL;
     server->read_timeout_sec = DEFAULT_READ_TIMEOUT_SEC;
     server->write_timeout_sec = DEFAULT_WRITE_TIMEOUT_SEC;
+    server->request_timeout_sec = DEFAULT_REQUEST_TIMEOUT_SEC;
     server->pool = NULL;
     server->thread_count = THREAD_POOL_DEFAULT_SIZE;
     
@@ -701,7 +708,20 @@ static void *handle_connection(void *arg) {
             result = http_parser_execute(&conn->parser, NULL, 0);
         }
 
+        /* Start the total-request deadline for this request. */
+        time_t request_start = time(NULL);
+
         while (result == PARSER_INCOMPLETE || result == PARSER_EXPECT_CONTINUE) {
+            /* Enforce the whole-request deadline: a slow-drip client keeps each
+             * recv() under SO_RCVTIMEO, so only this wall-clock bound stops it
+             * from holding the worker thread indefinitely (slow-loris). */
+            if (server->request_timeout_sec > 0 &&
+                (long)(time(NULL) - request_start) >= (long)server->request_timeout_sec) {
+                send_error_response(client_fd, HTTP_REQUEST_TIMEOUT, "Request Timeout");
+                connection_open = false;
+                goto iteration_cleanup;
+            }
+
             if (result == PARSER_EXPECT_CONTINUE) {
                 /* RFC 7231 §5.1.1: send 100 Continue before waiting for body */
                 static const char CONTINUE_RESP[] = "HTTP/1.1 100 Continue\r\n\r\n";
@@ -723,6 +743,14 @@ static void *handle_connection(void *arg) {
             if (bytes_read < 0) {
                 if (errno == EINTR) {
                     continue;
+                }
+                if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    /* SO_RCVTIMEO fired: the client stalled without completing
+                     * the request. That is a client timeout (408), not a
+                     * server error (500). */
+                    send_error_response(client_fd, HTTP_REQUEST_TIMEOUT, "Request Timeout");
+                    connection_open = false;
+                    goto iteration_cleanup;
                 }
                 perror("recv failed");
                 send_error_response(client_fd, HTTP_INTERNAL_ERROR, "Socket read error");
@@ -1913,6 +1941,23 @@ int http_server_set_timeout(http_server_t *server, int read_sec, int write_sec) 
     server->read_timeout_sec = read_sec;
     server->write_timeout_sec = write_sec;
     return 0;
+}
+
+/* Set the total request-read deadline in seconds (0 disables the deadline). */
+int http_server_set_request_timeout(http_server_t *server, int sec) {
+    if (!server || sec < 0) {
+        return -1;
+    }
+    server->request_timeout_sec = sec;
+    return 0;
+}
+
+/* Get the total request-read deadline. */
+int http_server_get_request_timeout(http_server_t *server) {
+    if (!server) {
+        return -1;
+    }
+    return server->request_timeout_sec;
 }
 
 /* Get read timeout */

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -574,8 +574,17 @@ static void *accept_connections(void *arg) {
         server->active_connections++;
         pthread_mutex_unlock(&server->conn_lock);
         
-        /* Apply socket timeouts */
-        apply_socket_timeouts(client_fd, server->read_timeout_sec, server->write_timeout_sec);
+        /* Apply socket timeouts.  The request deadline is only checked between
+         * recv() calls, so recv() must wake within the deadline for it to bound
+         * a partial-then-silent client.  Cap the effective read timeout at the
+         * request deadline (treating 0 as "no timeout") so the deadline stays
+         * enforced even when the per-recv read timeout is disabled. */
+        int eff_read_timeout = server->read_timeout_sec;
+        if (server->request_timeout_sec > 0 &&
+            (eff_read_timeout <= 0 || eff_read_timeout > server->request_timeout_sec)) {
+            eff_read_timeout = server->request_timeout_sec;
+        }
+        apply_socket_timeouts(client_fd, eff_read_timeout, server->write_timeout_sec);
         
         /* Submit to thread pool */
         connection_t *conn = (connection_t *)calloc(1, sizeof(connection_t));
@@ -2043,7 +2052,15 @@ static int set_nonblocking(int fd) {
     return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 }
 
-/* Async accept handler */
+/* Async accept handler.
+ *
+ * NOTE: async mode does NOT yet bound slow/idle clients. Unlike the threaded
+ * path, it registers no per-connection start-time or idle timer, so the
+ * request_timeout_sec deadline is not enforced here and a slow-loris (or fully
+ * idle) client persists until it disconnects, tying up an fd + memory. Less
+ * severe than the threaded case (no worker thread is held), but still a gap --
+ * tracked as a follow-up: add an event-loop idle/deadline reaper for async
+ * connections. */
 static void async_accept_handler(int fd, int events, void *user_data) {
     http_server_t *server = (http_server_t *)user_data;
     

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -524,6 +524,18 @@ static void apply_socket_timeouts(int fd, int read_sec, int write_sec) {
     }
 }
 
+/* Monotonic wall-clock seconds for measuring elapsed time.  Unlike time(), it
+ * is immune to system-clock jumps (NTP/DST), so a backward jump cannot extend
+ * (and thereby defeat) the request deadline.  Falls back to time() only if the
+ * monotonic clock is unavailable at runtime. */
+static time_t monotonic_seconds(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        return (time_t)ts.tv_sec;
+    }
+    return time(NULL);
+}
+
 /* Thread pool work wrapper — handle_connection expects void* and frees conn */
 static void connection_work(void *arg) {
     handle_connection(arg);
@@ -708,15 +720,15 @@ static void *handle_connection(void *arg) {
             result = http_parser_execute(&conn->parser, NULL, 0);
         }
 
-        /* Start the total-request deadline for this request. */
-        time_t request_start = time(NULL);
+        /* Start the total-request deadline for this request (monotonic clock). */
+        time_t request_start = monotonic_seconds();
 
         while (result == PARSER_INCOMPLETE || result == PARSER_EXPECT_CONTINUE) {
             /* Enforce the whole-request deadline: a slow-drip client keeps each
              * recv() under SO_RCVTIMEO, so only this wall-clock bound stops it
              * from holding the worker thread indefinitely (slow-loris). */
             if (server->request_timeout_sec > 0 &&
-                (long)(time(NULL) - request_start) >= (long)server->request_timeout_sec) {
+                (long)(monotonic_seconds() - request_start) >= (long)server->request_timeout_sec) {
                 send_error_response(client_fd, HTTP_REQUEST_TIMEOUT, "Request Timeout");
                 connection_open = false;
                 goto iteration_cleanup;
@@ -855,6 +867,7 @@ static const char *status_reason_phrase(http_status_t status) {
         case HTTP_FORBIDDEN: return "Forbidden";
         case HTTP_NOT_FOUND: return "Not Found";
         case HTTP_METHOD_NOT_ALLOWED: return "Method Not Allowed";
+        case HTTP_REQUEST_TIMEOUT: return "Request Timeout";
         case HTTP_PAYLOAD_TOO_LARGE: return "Payload Too Large";
         case HTTP_URI_TOO_LONG: return "URI Too Long";
         case HTTP_TOO_MANY_REQUESTS: return "Too Many Requests";

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -995,28 +995,36 @@ void test_stress_slowloris_deadline(void) {
     addr.sin_addr.s_addr = inet_addr("127.0.0.1");
     ASSERT(connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
 
-    time_t t_start = time(NULL);
-    /* Start a request but never send the terminating CRLF; dribble one byte at
-     * a time, each well within SO_RCVTIMEO, so the per-recv timer keeps resetting. */
+    /* Start a request but never send the terminating CRLF, then dribble bytes
+     * continuously (each within SO_RCVTIMEO, so the per-recv timer keeps
+     * resetting -- classic slow-loris).  With the total deadline the server
+     * cuts us off ~1s in; we detect that by a failed send() (EPIPE on a closed
+     * socket; SIGPIPE is ignored process-wide) or a non-blocking recv seeing the
+     * 408 / EOF / reset.  A regression reads the drip forever, so the safety cap
+     * is reached and `cutoff` stays false.  Polling (not a fixed sleep) keeps
+     * this robust under slow/loaded CI and Valgrind. */
     const char *partial = "GET /test HTTP/1.1\r\nHost: localhost\r\n";
     send(sock, partial, strlen(partial), 0);
-    for (int i = 0; i < 4; i++) {
-        send(sock, "a", 1, 0);     /* dribble; never completes the request */
-        usleep(300000);            /* 4 * 300ms = 1.2s > 1s deadline */
-    }
 
-    /* With the deadline, the server cuts us off at ~1s, so this recv returns
-     * promptly (408 / EOF / reset). A regression leaves the server blocked in
-     * recv until SO_RCVTIMEO, so the client recv would time out instead -- the
-     * timing assertion below catches that (elapsed would be ~4s, not ~1.2s). */
-    char resp[512];
-    ssize_t n = recv(sock, resp, sizeof(resp) - 1, 0);
-    time_t elapsed = time(NULL) - t_start;
-    ASSERT(elapsed <= 3);
-    if (n > 0) {
-        resp[n] = '\0';
-        ASSERT(strstr(resp, "408") != NULL);
+    time_t t_start = time(NULL);
+    int cutoff = 0;
+    while ((time(NULL) - t_start) < 6) {                 /* safety cap */
+        if (send(sock, "a", 1, 0) < 0) { cutoff = 1; break; }   /* server closed */
+        char buf[512];
+        ssize_t r = recv(sock, buf, sizeof(buf) - 1, MSG_DONTWAIT);
+        if (r == 0) { cutoff = 1; break; }               /* FIN */
+        if (r > 0) { cutoff = 1; break; }                /* 408 response */
+        if (r < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+            cutoff = 1; break;                           /* e.g. ECONNRESET */
+        }
+        usleep(150000);                                  /* 150ms drip interval */
     }
+    time_t elapsed = time(NULL) - t_start;
+
+    /* The server must have cut off the never-completing drip (slow-loris)
+     * within the deadline plus a generous margin, not held it to the safety cap. */
+    ASSERT(cutoff == 1);
+    ASSERT(elapsed <= 4);
 
     close(sock);
     http_server_stop(server);

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -959,6 +959,73 @@ void test_stress_slow_client(void) {
     PASS();
 }
 
+/* Security regression: a client that starts a request and never finishes it,
+ * dribbling bytes to keep each recv() under SO_RCVTIMEO (slow-loris), must be
+ * cut off by the total request deadline rather than holding a worker forever. */
+void test_stress_slowloris_deadline(void) {
+    TEST("slow-loris (never-completing drip is bounded by request deadline)");
+
+    http_server_t *server = http_server_create();
+    ASSERT(server != NULL);
+    router_t *router = router_create();
+    ASSERT(router != NULL);
+    router_add_route(router, HTTP_GET, "/test", dummy_handler);
+    http_server_set_router(server, router);
+
+    /* Default deadline is 60s; tighten to 1s. Keep SO_RCVTIMEO high (5s) so the
+     * per-recv timer never fires -- only the total deadline should stop us. */
+    ASSERT(http_server_get_request_timeout(server) == 60);
+    ASSERT(http_server_set_request_timeout(server, 1) == 0);
+    ASSERT(http_server_get_request_timeout(server) == 1);
+    http_server_set_timeout(server, 5, 5);
+
+    uint16_t port = 19007;
+    ASSERT(http_server_listen(server, port) == 0);
+    usleep(200000);
+
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT(sock >= 0);
+    struct timeval cto = { .tv_sec = 3, .tv_usec = 0 };   /* client recv timeout */
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &cto, sizeof(cto));
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    ASSERT(connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+
+    time_t t_start = time(NULL);
+    /* Start a request but never send the terminating CRLF; dribble one byte at
+     * a time, each well within SO_RCVTIMEO, so the per-recv timer keeps resetting. */
+    const char *partial = "GET /test HTTP/1.1\r\nHost: localhost\r\n";
+    send(sock, partial, strlen(partial), 0);
+    for (int i = 0; i < 4; i++) {
+        send(sock, "a", 1, 0);     /* dribble; never completes the request */
+        usleep(300000);            /* 4 * 300ms = 1.2s > 1s deadline */
+    }
+
+    /* With the deadline, the server cuts us off at ~1s, so this recv returns
+     * promptly (408 / EOF / reset). A regression leaves the server blocked in
+     * recv until SO_RCVTIMEO, so the client recv would time out instead -- the
+     * timing assertion below catches that (elapsed would be ~4s, not ~1.2s). */
+    char resp[512];
+    ssize_t n = recv(sock, resp, sizeof(resp) - 1, 0);
+    time_t elapsed = time(NULL) - t_start;
+    ASSERT(elapsed <= 3);
+    if (n > 0) {
+        resp[n] = '\0';
+        ASSERT(strstr(resp, "408") != NULL);
+    }
+
+    close(sock);
+    http_server_stop(server);
+    usleep(100000);
+    router_destroy(router);
+    http_server_destroy(server);
+    PASS();
+}
+
 /* ===== Input Validation Stress Tests ===== */
 
 void test_stress_input_validation_long_strings(void) {
@@ -1120,6 +1187,7 @@ int main(void) {
         test_stress_oversized_request();
         test_stress_many_headers();
         test_stress_slow_client();
+        test_stress_slowloris_deadline();
     }
 
     /* Input Validation Stress Tests */

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -1034,6 +1034,58 @@ void test_stress_slowloris_deadline(void) {
     PASS();
 }
 
+/* Security regression: with the per-recv read timeout disabled, a partial
+ * request followed by silence must STILL be cut off by the request deadline --
+ * the effective recv() timeout is capped at the deadline so it stays enforced. */
+void test_stress_request_deadline_silent(void) {
+    TEST("request deadline bounds a silent client even with read timeout 0");
+
+    http_server_t *server = http_server_create();
+    ASSERT(server != NULL);
+    router_t *router = router_create();
+    ASSERT(router != NULL);
+    router_add_route(router, HTTP_GET, "/test", dummy_handler);
+    http_server_set_router(server, router);
+
+    http_server_set_timeout(server, 0, 0);                    /* read timeout DISABLED */
+    ASSERT(http_server_set_request_timeout(server, 1) == 0);  /* 1s total deadline */
+
+    uint16_t port = 19008;
+    ASSERT(http_server_listen(server, port) == 0);
+    usleep(200000);
+
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT(sock >= 0);
+    struct timeval cto = { .tv_sec = 3, .tv_usec = 0 };
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &cto, sizeof(cto));
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    ASSERT(connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+
+    /* Send a partial request, then go completely silent. */
+    const char *partial = "GET /test HTTP/1.1\r\nHost: localhost\r\n";
+    send(sock, partial, strlen(partial), 0);
+
+    /* The server must act (408 / close) within our 3s recv timeout. A regression
+     * (deadline not enforced when the read timeout is 0) leaves the server
+     * blocked in recv indefinitely, so our recv would time out with EAGAIN. */
+    char buf[512];
+    errno = 0;
+    ssize_t n = recv(sock, buf, sizeof(buf) - 1, 0);
+    int server_acted = (n >= 0) || (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK);
+    ASSERT(server_acted);
+
+    close(sock);
+    http_server_stop(server);
+    usleep(100000);
+    router_destroy(router);
+    http_server_destroy(server);
+    PASS();
+}
+
 /* ===== Input Validation Stress Tests ===== */
 
 void test_stress_input_validation_long_strings(void) {
@@ -1196,6 +1248,7 @@ int main(void) {
         test_stress_many_headers();
         test_stress_slow_client();
         test_stress_slowloris_deadline();
+        test_stress_request_deadline_silent();
     }
 
     /* Input Validation Stress Tests */


### PR DESCRIPTION
## What
Fixes the audit's HIGH slow-loris finding for **threaded mode**. `SO_RCVTIMEO` only bounds a single `recv()` and is reset by every byte that arrives, so a client dribbling one byte every ~29s (under a 30s per-recv timeout) keeps a worker thread's parser in `PARSER_INCOMPLETE` indefinitely. With the default 16-thread pool, ~16 such connections starve all HTTP serving.

## Fix — by construction
- **Total-request deadline** `http_server_t.request_timeout_sec` (default **60s**), checked at the top of the threaded recv loop; exceeding it returns **408 Request Timeout** and closes. This bounds the whole request regardless of drip rate — the per-recv timer no longer matters.
- **`recv()` `EAGAIN/EWOULDBLOCK`** (the per-recv `SO_RCVTIMEO` firing on a fully-stalled client) now returns **408**, not a misleading **500**.
- New API: `http_server_set_request_timeout()` / `http_server_get_request_timeout()`; env `WEBLIB_REQUEST_TIMEOUT`; `HTTP_REQUEST_TIMEOUT` (408) status constant.

## Testing
- New `test_stress_slowloris_deadline`: opens a connection, dribbles bytes that never complete the request (each within `SO_RCVTIMEO`), and asserts the server cuts it off within the deadline (timing-based, robust to 408/EOF/reset).
- Full suite 6/6 (29/29 stress) green, **zero warnings**, clean under ASan/UBSan.
- **Negative control**: disabling the deadline makes the new test FAIL at the timing assertion — confirming it guards the fix.

## Scope
Threaded mode only. The related async-mode stalled-connection reaper (no idle timeout on the event loop), WebSocket idle/ping, and `listen()`-failure cleanup are tracked as follow-up core-http PRs.