### PR TITLE
websocket: cap frame + message size (memory-exhaustion DoS)

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -31,8 +31,11 @@ static const char *_strcasestr(const char *haystack, const char *needle) {
  * message.  A frame's length field is 64-bit, so without this cap a client can
  * claim a multi-terabyte payload and drive the receive/fragment buffers to
  * exhaust memory.  Oversized messages are rejected with RFC 6455 close 1009
- * (Message Too Big). Compile-time bound (default 16 MiB). */
+ * (Message Too Big). Compile-time bound (default 16 MiB); override with
+ * -DWS_MAX_MESSAGE_SIZE=... at build time. */
+#ifndef WS_MAX_MESSAGE_SIZE
 #define WS_MAX_MESSAGE_SIZE (16u * 1024u * 1024u)
+#endif
 
 /* WebSocket opcodes */
 typedef enum {
@@ -638,15 +641,14 @@ int websocket_process_data(websocket_connection_t *conn, const uint8_t *data, si
             return -1;
         }
         
-        /* Check for overflow: header_size + payload_length */
-        if (frame.payload_length > SIZE_MAX - (size_t)header_size) {
-            return -1;
-        }
-
-        /* Enforce a maximum single-frame payload BEFORE accumulating it: the
-         * 64-bit length field otherwise lets a client claim a multi-terabyte
-         * frame and exhaust memory. RFC 6455 §7.4.1 close 1009 = Message Too Big. */
-        if (frame.payload_length > WS_MAX_MESSAGE_SIZE) {
+        /* Reject an oversized frame on the header alone, BEFORE accumulating the
+         * payload: the 64-bit length field otherwise lets a client claim a
+         * multi-terabyte frame and exhaust memory. The second clause also keeps
+         * header_size + payload_length from overflowing size_t (relevant on a
+         * 32-bit build if WS_MAX_MESSAGE_SIZE is overridden very large). Either
+         * way, close 1009 (Message Too Big) -- never a silent -1. */
+        if (frame.payload_length > WS_MAX_MESSAGE_SIZE ||
+            frame.payload_length > SIZE_MAX - (size_t)header_size) {
             websocket_close(conn, 1009, "Message too big");
             return -1;
         }

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -649,6 +649,14 @@ int websocket_process_data(websocket_connection_t *conn, const uint8_t *data, si
          * way, close 1009 (Message Too Big) -- never a silent -1. */
         if (frame.payload_length > WS_MAX_MESSAGE_SIZE ||
             frame.payload_length > SIZE_MAX - (size_t)header_size) {
+            /* Drop any in-progress reassembly, consistent with the other error
+             * paths (defensive; the caller also destroys the connection on -1). */
+            if (conn->fragment_buffer) {
+                free(conn->fragment_buffer);
+                conn->fragment_buffer = NULL;
+                conn->fragment_len = 0;
+                conn->fragment_capacity = 0;
+            }
             websocket_close(conn, 1009, "Message too big");
             return -1;
         }

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -27,6 +27,12 @@ static const char *_strcasestr(const char *haystack, const char *needle) {
 #define WS_GUID "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 #define WS_FRAME_MAX_SIZE 65536
 #define WS_HEADER_MAX_SIZE 14
+/* Maximum accepted payload for a single frame AND for a reassembled fragmented
+ * message.  A frame's length field is 64-bit, so without this cap a client can
+ * claim a multi-terabyte payload and drive the receive/fragment buffers to
+ * exhaust memory.  Oversized messages are rejected with RFC 6455 close 1009
+ * (Message Too Big). Compile-time bound (default 16 MiB). */
+#define WS_MAX_MESSAGE_SIZE (16u * 1024u * 1024u)
 
 /* WebSocket opcodes */
 typedef enum {
@@ -636,7 +642,15 @@ int websocket_process_data(websocket_connection_t *conn, const uint8_t *data, si
         if (frame.payload_length > SIZE_MAX - (size_t)header_size) {
             return -1;
         }
-        
+
+        /* Enforce a maximum single-frame payload BEFORE accumulating it: the
+         * 64-bit length field otherwise lets a client claim a multi-terabyte
+         * frame and exhaust memory. RFC 6455 §7.4.1 close 1009 = Message Too Big. */
+        if (frame.payload_length > WS_MAX_MESSAGE_SIZE) {
+            websocket_close(conn, 1009, "Message too big");
+            return -1;
+        }
+
         size_t frame_size = (size_t)header_size + (size_t)frame.payload_length;
         if (conn->buffer_len < frame_size) {
             /* Need more data */
@@ -702,6 +716,17 @@ int websocket_process_data(websocket_connection_t *conn, const uint8_t *data, si
                 if (!conn->fragment_buffer) {
                     /* Protocol error: continuation without start frame */
                     websocket_close(conn, 1002, "Protocol error: unexpected continuation");
+                    return -1;
+                }
+                /* Cap the total reassembled message size (DoS): a client could
+                 * otherwise send unlimited continuation frames. Written to avoid
+                 * overflow (fragment_len is always <= WS_MAX_MESSAGE_SIZE). */
+                if (frame.payload_length > WS_MAX_MESSAGE_SIZE - conn->fragment_len) {
+                    free(conn->fragment_buffer);
+                    conn->fragment_buffer = NULL;
+                    conn->fragment_len = 0;
+                    conn->fragment_capacity = 0;
+                    websocket_close(conn, 1009, "Message too big");
                     return -1;
                 }
                 /* Append to fragmented message */

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -4379,9 +4379,9 @@ void test_websocket_oversized_frame(void) {
     g_ws_oversize_msg = 0;
     websocket_set_message_callback(conn, ws_oversize_cb);
 
-    /* Masked binary frame claiming a 64 GiB payload (>> the 16 MiB cap). Only
-     * the 14-byte header is supplied; it must be rejected without waiting for or
-     * allocating the payload. */
+    /* Masked binary frame claiming a 64 GiB payload (far above any reasonable
+     * WS_MAX_MESSAGE_SIZE). Only the 14-byte header is supplied; it must be
+     * rejected without waiting for or allocating the payload. */
     uint8_t frame[14] = {
         0x82,                                        /* FIN + binary opcode   */
         0xFF,                                        /* MASK + 64-bit length   */

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -4361,6 +4361,42 @@ void test_websocket_fragment_oom(void) {
     PASS();
 }
 
+/* Security regression: a frame claiming an enormous payload (the 64-bit length
+ * field allows terabytes) must be rejected on the header alone, before the
+ * receive buffer is grown -- preventing a memory-exhaustion DoS. */
+static int g_ws_oversize_msg = 0;
+static void ws_oversize_cb(websocket_connection_t *c, ws_message_type_t t,
+                           const void *d, size_t n) {
+    (void)c; (void)t; (void)d; (void)n; g_ws_oversize_msg = 1;
+}
+
+void test_websocket_oversized_frame(void) {
+    TEST("websocket oversized frame rejected (DoS guard)");
+
+    websocket_connection_t *conn = websocket_connection_create(999);
+    ASSERT(conn != NULL);
+    ASSERT(websocket_is_open(conn));
+    g_ws_oversize_msg = 0;
+    websocket_set_message_callback(conn, ws_oversize_cb);
+
+    /* Masked binary frame claiming a 64 GiB payload (>> the 16 MiB cap). Only
+     * the 14-byte header is supplied; it must be rejected without waiting for or
+     * allocating the payload. */
+    uint8_t frame[14] = {
+        0x82,                                        /* FIN + binary opcode   */
+        0xFF,                                        /* MASK + 64-bit length   */
+        0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, /* 0x1000000000 = 64 GiB */
+        0x11, 0x22, 0x33, 0x44                       /* masking key            */
+    };
+    int r = websocket_process_data(conn, frame, sizeof(frame));
+    ASSERT(r == -1);                    /* rejected, not accumulated */
+    ASSERT(!websocket_is_open(conn));   /* closed (RFC 6455 1009 Message Too Big) */
+    ASSERT(g_ws_oversize_msg == 0);     /* on_message never invoked */
+
+    websocket_connection_destroy(conn);
+    PASS();
+}
+
 /* Run all tests */
 int main(void) {
     printf("Running Modern C Web Library Tests\n");
@@ -4598,6 +4634,7 @@ int main(void) {
     test_parser_cl_before_te_smuggling();
     test_header_injection_rejected();
     test_websocket_fragment_oom();
+    test_websocket_oversized_frame();
 
     printf("\n===================================\n");
     printf("Tests run: %d\n", tests_run);


### PR DESCRIPTION
## What
Fixes the audit's HIGH WebSocket finding: **no maximum frame/message size**. A frame's payload length is a 64-bit field and the parser only rejected values with the top bit set (>= 2^63), so a client could claim a multi-terabyte frame — or stream unlimited continuation frames — and drive the receive buffer / fragment buffer to exhaust server memory.

## Fix
Enforce a compile-time `WS_MAX_MESSAGE_SIZE` (default **16 MiB**) on:
- **any single frame's `payload_length`**, checked *on the header alone* — before the receive buffer is grown to hold the payload; and
- the **running total** of a reassembled fragmented message (continuation frames), checked before each append.

Oversized messages are closed with **RFC 6455 §7.4.1 status 1009 (Message Too Big)**. Both checks are written to avoid integer overflow.

## Testing
- `test_websocket_oversized_frame`: feeds only the 14-byte header of a frame claiming a **64 GiB** payload; asserts `websocket_process_data` returns -1, the connection is closed, and no message callback fires (nothing was allocated).
- Full suite 154/154, **zero warnings**, clean under ASan/UBSan.
- **Negative control**: removing the per-frame check makes the test fail (`r == -1`), confirming it guards the fix.