### PR TITLE
worker_d1: fix DELETE/SELECT-all on unknown WHERE + positional INSERT

### DIFF
--- a/src/worker_d1.c
+++ b/src/worker_d1.c
@@ -261,13 +261,56 @@ static worker_d1_result_t *_d1_exec_insert(worker_d1_t *db, const char *sql,
     if (!t) return NULL;
     if (t->row_count >= D1_MAX_ROWS) return NULL;
 
+    /* Determine the column mapping. If the statement names columns --
+     * INSERT INTO t (b, a) VALUES (?, ?) -- bind each parameter to the NAMED
+     * column, not to physical order. Without a column list, bind positionally
+     * (SQL default: all columns in declared order). */
+    int col_map[D1_MAX_COLUMNS];
+    int named_count = -1;   /* -1 => no explicit column list */
+
+    const char *vals = _ci_strstr(p, "VALUES");
+    const char *open = strchr(p, '(');
+    if (open && (!vals || open < vals)) {
+        named_count = 0;
+        const char *q = open + 1;
+        while (*q && *q != ')' && named_count < D1_MAX_COLUMNS) {
+            char col[D1_MAX_COL_NAME];
+            q = _parse_word(q, col, sizeof(col));
+            if (col[0]) {
+                int idx = -1;
+                for (int c = 0; c < t->column_count; c++) {
+                    if (strcasecmp(t->columns[c].name, col) == 0) { idx = c; break; }
+                }
+                if (idx < 0) {
+                    /* Unknown column named in the INSERT: fail rather than
+                     * writing the value to the wrong cell. */
+                    worker_d1_result_t *r = calloc(1, sizeof(worker_d1_result_t));
+                    if (r) { r->success = false; }
+                    return r;
+                }
+                col_map[named_count++] = idx;
+            }
+            while (*q && *q != ',' && *q != ')') q++;
+            if (*q == ',') q++;
+        }
+    }
+
     d1_row_data_t *row = &t->rows[t->row_count];
     memset(row, 0, sizeof(d1_row_data_t));
 
-    /* Bind params to columns in order */
-    for (int i = 0; i < param_count && i < t->column_count; i++) {
-        if (params[i]) {
-            strncpy(row->cells[i], params[i], D1_MAX_CELL_LEN - 1);
+    if (named_count >= 0) {
+        /* Bind each parameter to its named column. */
+        for (int i = 0; i < param_count && i < named_count; i++) {
+            if (params[i]) {
+                strncpy(row->cells[col_map[i]], params[i], D1_MAX_CELL_LEN - 1);
+            }
+        }
+    } else {
+        /* No column list: positional binding to physical columns. */
+        for (int i = 0; i < param_count && i < t->column_count; i++) {
+            if (params[i]) {
+                strncpy(row->cells[i], params[i], D1_MAX_CELL_LEN - 1);
+            }
         }
     }
     t->row_count++;
@@ -298,7 +341,7 @@ static worker_d1_result_t *_d1_exec_select(worker_d1_t *db, const char *sql,
     /* Check for WHERE clause */
     const char *where = _ci_strstr(sql, "WHERE");
     int where_col = -1;
-    if (where && param_count > 0) {
+    if (where) {
         where += 5;
         char wcol[D1_MAX_COL_NAME];
         _parse_word(where, wcol, sizeof(wcol));
@@ -307,6 +350,13 @@ static worker_d1_result_t *_d1_exec_select(worker_d1_t *db, const char *sql,
                 where_col = c;
                 break;
             }
+        }
+        /* A WHERE clause that cannot be evaluated (unknown column or no bound
+         * parameter) must fail, not silently return every row. */
+        if (where_col < 0 || param_count <= 0 || !params[0]) {
+            worker_d1_result_t *err = calloc(1, sizeof(worker_d1_result_t));
+            if (err) { err->success = false; }
+            return err;
         }
     }
 
@@ -322,8 +372,8 @@ static worker_d1_result_t *_d1_exec_select(worker_d1_t *db, const char *sql,
     }
 
     for (int i = 0; i < t->row_count; i++) {
-        /* Apply WHERE filter */
-        if (where_col >= 0 && param_count > 0 && params[0]) {
+        /* Apply WHERE filter (where_col >= 0 implies a valid bound param). */
+        if (where_col >= 0) {
             if (strcmp(t->rows[i].cells[where_col], params[0]) != 0)
                 continue;
         }
@@ -355,7 +405,7 @@ static worker_d1_result_t *_d1_exec_delete(worker_d1_t *db, const char *sql,
 
     const char *where = _ci_strstr(sql, "WHERE");
     int where_col = -1;
-    if (where && param_count > 0) {
+    if (where) {
         where += 5;
         char wcol[D1_MAX_COL_NAME];
         _parse_word(where, wcol, sizeof(wcol));
@@ -365,14 +415,23 @@ static worker_d1_result_t *_d1_exec_delete(worker_d1_t *db, const char *sql,
                 break;
             }
         }
+        /* A WHERE clause was given but cannot be evaluated (unknown column or no
+         * bound parameter). Refuse the statement rather than silently deleting
+         * EVERY row -- a "WHERE bogus = ?" must never become DELETE-all. */
+        if (where_col < 0 || param_count <= 0 || !params[0]) {
+            worker_d1_result_t *r = calloc(1, sizeof(worker_d1_result_t));
+            if (r) { r->success = false; r->meta_changes = 0; }
+            return r;
+        }
     }
 
     int deleted = 0;
     for (int i = t->row_count - 1; i >= 0; i--) {
-        bool match = true;
-        if (where_col >= 0 && param_count > 0 && params[0]) {
-            match = (strcmp(t->rows[i].cells[where_col], params[0]) == 0);
-        }
+        /* No WHERE => delete all (intentional); otherwise filter by the
+         * resolved predicate. */
+        bool match = (where_col < 0)
+                     ? true
+                     : (strcmp(t->rows[i].cells[where_col], params[0]) == 0);
         if (match) {
             /* Shift rows */
             for (int j = i; j < t->row_count - 1; j++) {

--- a/src/worker_d1.c
+++ b/src/worker_d1.c
@@ -295,15 +295,32 @@ static worker_d1_result_t *_d1_exec_insert(worker_d1_t *db, const char *sql,
         }
     }
 
+    /* With an explicit column list, the number of bound parameters must match
+     * the number of named columns, and each must be bound: extra binds would be
+     * silently dropped and missing binds would leave empty cells -- both hide
+     * bugs. (Positional inserts keep the lenient behaviour.) */
+    if (named_count >= 0) {
+        if (param_count != named_count) {
+            worker_d1_result_t *r = calloc(1, sizeof(worker_d1_result_t));
+            if (r) { r->success = false; }
+            return r;
+        }
+        for (int i = 0; i < named_count; i++) {
+            if (!params[i]) {
+                worker_d1_result_t *r = calloc(1, sizeof(worker_d1_result_t));
+                if (r) { r->success = false; }
+                return r;
+            }
+        }
+    }
+
     d1_row_data_t *row = &t->rows[t->row_count];
     memset(row, 0, sizeof(d1_row_data_t));
 
     if (named_count >= 0) {
-        /* Bind each parameter to its named column. */
-        for (int i = 0; i < param_count && i < named_count; i++) {
-            if (params[i]) {
-                strncpy(row->cells[col_map[i]], params[i], D1_MAX_CELL_LEN - 1);
-            }
+        /* Bind each parameter to its named column (validated 1:1 above). */
+        for (int i = 0; i < named_count; i++) {
+            strncpy(row->cells[col_map[i]], params[i], D1_MAX_CELL_LEN - 1);
         }
     } else {
         /* No column list: positional binding to physical columns. */

--- a/src/worker_d1.c
+++ b/src/worker_d1.c
@@ -355,8 +355,10 @@ static worker_d1_result_t *_d1_exec_select(worker_d1_t *db, const char *sql,
     d1_table_t *t = _d1_find_table(db, tname);
     if (!t) return NULL;
 
-    /* Check for WHERE clause */
-    const char *where = _ci_strstr(sql, "WHERE");
+    /* Check for WHERE clause. Search only PAST the table name, so a table whose
+     * name contains "where" (e.g. "elsewhere", "nowhere") is not misdetected as
+     * having a WHERE clause -- which the fail-closed guard would then refuse. */
+    const char *where = _ci_strstr(from, "WHERE");
     int where_col = -1;
     if (where) {
         where += 5;
@@ -420,7 +422,9 @@ static worker_d1_result_t *_d1_exec_delete(worker_d1_t *db, const char *sql,
     d1_table_t *t = _d1_find_table(db, tname);
     if (!t) return NULL;
 
-    const char *where = _ci_strstr(sql, "WHERE");
+    /* Search for WHERE only past the table name (see the SELECT note): a table
+     * named "elsewhere"/"nowhere" must not be misread as having a WHERE clause. */
+    const char *where = _ci_strstr(p, "WHERE");
     int where_col = -1;
     if (where) {
         where += 5;

--- a/tests/test_worker.c
+++ b/tests/test_worker.c
@@ -613,7 +613,8 @@ static void test_d1_sql_safety(void) {
     worker_d1_stmt_bind(del, 1, "x");
     worker_d1_result_t *dr = worker_d1_stmt_run(del);
     ASSERT(dr != NULL);
-    ASSERT(dr->success == false || dr->meta_changes == 0);
+    ASSERT(dr->success == false);        /* refused */
+    ASSERT(dr->meta_changes == 0);       /* nothing deleted */
     worker_d1_result_destroy(dr);
     worker_d1_stmt_destroy(del);
 
@@ -627,17 +628,23 @@ static void test_d1_sql_safety(void) {
     json_value_free(rows);
     worker_d1_stmt_destroy(sel);
 
-    /* SELECT with an unknown WHERE column must fail, not return every row. */
+    /* SELECT with an unknown WHERE column must fail (no results), not return
+     * every row. The failed query yields no result array, so stmt_all == NULL. */
     worker_d1_stmt_t *bsel = worker_d1_prepare(db, "SELECT * FROM t WHERE nosuchcol = ?");
     worker_d1_stmt_bind(bsel, 1, "x");
     json_value_t *brows = worker_d1_stmt_all(bsel);
-    if (brows != NULL) {
-        char *bjs = json_stringify(brows);
-        ASSERT(bjs == NULL || strstr(bjs, "aye") == NULL);
-        free(bjs);
-        json_value_free(brows);
-    }
+    ASSERT(brows == NULL);
     worker_d1_stmt_destroy(bsel);
+
+    /* INSERT with a column list must reject a param-count mismatch (2 named
+     * columns, 1 bound param) rather than silently leaving a cell empty. */
+    worker_d1_stmt_t *mm = worker_d1_prepare(db, "INSERT INTO t (a, b) VALUES (?)");
+    worker_d1_stmt_bind(mm, 1, "only");
+    worker_d1_result_t *mr = worker_d1_stmt_run(mm);
+    ASSERT(mr != NULL);
+    ASSERT(mr->success == false);
+    worker_d1_result_destroy(mr);
+    worker_d1_stmt_destroy(mm);
 
     worker_d1_destroy(db);
     PASS();

--- a/tests/test_worker.c
+++ b/tests/test_worker.c
@@ -646,6 +646,47 @@ static void test_d1_sql_safety(void) {
     worker_d1_result_destroy(mr);
     worker_d1_stmt_destroy(mm);
 
+    /* Regression guard: a table whose NAME contains "where" (e.g. "elsewhere")
+     * must not be misread as having a WHERE clause and refused. */
+    worker_d1_result_destroy(worker_d1_exec(db, "CREATE TABLE elsewhere (x)"));
+    worker_d1_stmt_t *ew = worker_d1_prepare(db, "INSERT INTO elsewhere (x) VALUES (?)");
+    worker_d1_stmt_bind(ew, 1, "here");
+    worker_d1_result_destroy(worker_d1_stmt_run(ew));
+    worker_d1_stmt_destroy(ew);
+    worker_d1_stmt_t *ews = worker_d1_prepare(db, "SELECT * FROM elsewhere");
+    json_value_t *ewr = worker_d1_stmt_all(ews);
+    ASSERT(ewr != NULL);                          /* would be NULL if misdetected */
+    char *ewjs = json_stringify(ewr);
+    ASSERT(ewjs != NULL && strstr(ewjs, "here") != NULL);
+    free(ewjs); json_value_free(ewr); worker_d1_stmt_destroy(ews);
+
+    /* Positional INSERT (no column list) still binds by physical column order. */
+    worker_d1_result_destroy(worker_d1_exec(db, "CREATE TABLE pos (m, n)"));
+    worker_d1_stmt_t *pi = worker_d1_prepare(db, "INSERT INTO pos VALUES (?, ?)");
+    worker_d1_stmt_bind(pi, 1, "MM");
+    worker_d1_stmt_bind(pi, 2, "NN");
+    worker_d1_result_destroy(worker_d1_stmt_run(pi));
+    worker_d1_stmt_destroy(pi);
+    worker_d1_stmt_t *ps = worker_d1_prepare(db, "SELECT * FROM pos");
+    json_value_t *pr = worker_d1_stmt_all(ps);
+    char *pjs = json_stringify(pr);
+    ASSERT(pjs != NULL && strstr(pjs, "\"m\":\"MM\"") != NULL &&
+           strstr(pjs, "\"n\":\"NN\"") != NULL);
+    free(pjs); json_value_free(pr); worker_d1_stmt_destroy(ps);
+
+    /* DELETE with NO WHERE clause deletes all (intended). */
+    worker_d1_result_t *da = worker_d1_exec(db, "DELETE FROM elsewhere");
+    ASSERT(da != NULL && da->success && da->meta_changes == 1);
+    worker_d1_result_destroy(da);
+    worker_d1_stmt_t *es2 = worker_d1_prepare(db, "SELECT * FROM elsewhere");
+    json_value_t *er2 = worker_d1_stmt_all(es2);
+    if (er2) {
+        char *e2 = json_stringify(er2);
+        ASSERT(e2 == NULL || strstr(e2, "here") == NULL);   /* emptied */
+        free(e2); json_value_free(er2);
+    }
+    worker_d1_stmt_destroy(es2);
+
     worker_d1_destroy(db);
     PASS();
 }

--- a/tests/test_worker.c
+++ b/tests/test_worker.c
@@ -578,6 +578,71 @@ static void test_d1_batch(void) {
     PASS();
 }
 
+/* Security regression: INSERT must map values to NAMED columns (not physical
+ * order), and a WHERE clause with an unknown column must NOT become a
+ * DELETE-all / SELECT-all. */
+static void test_d1_sql_safety(void) {
+    TEST("d1_sql_safety (named-column INSERT, unknown-WHERE guard)");
+    worker_d1_t *db = worker_d1_create("safedb");
+    ASSERT(db != NULL);
+    worker_d1_result_destroy(worker_d1_exec(db, "CREATE TABLE t (a, b)"));
+
+    /* Column list is REORDERED (b, a): values must land in the named columns. */
+    worker_d1_stmt_t *ins = worker_d1_prepare(db, "INSERT INTO t (b, a) VALUES (?, ?)");
+    ASSERT(ins != NULL);
+    worker_d1_stmt_bind(ins, 1, "bee");   /* -> column b */
+    worker_d1_stmt_bind(ins, 2, "aye");   /* -> column a */
+    worker_d1_result_t *ir = worker_d1_stmt_run(ins);
+    ASSERT(ir != NULL && ir->success);
+    worker_d1_result_destroy(ir);
+    worker_d1_stmt_destroy(ins);
+
+    worker_d1_stmt_t *sel = worker_d1_prepare(db, "SELECT * FROM t");
+    json_value_t *rows = worker_d1_stmt_all(sel);
+    ASSERT(rows != NULL);
+    char *js = json_stringify(rows);
+    ASSERT(js != NULL);
+    ASSERT(strstr(js, "\"a\":\"aye\"") != NULL);   /* mapped to named col a */
+    ASSERT(strstr(js, "\"b\":\"bee\"") != NULL);   /* mapped to named col b */
+    free(js);
+    json_value_free(rows);
+    worker_d1_stmt_destroy(sel);
+
+    /* DELETE with an unknown WHERE column must be refused, not delete-all. */
+    worker_d1_stmt_t *del = worker_d1_prepare(db, "DELETE FROM t WHERE nosuchcol = ?");
+    worker_d1_stmt_bind(del, 1, "x");
+    worker_d1_result_t *dr = worker_d1_stmt_run(del);
+    ASSERT(dr != NULL);
+    ASSERT(dr->success == false || dr->meta_changes == 0);
+    worker_d1_result_destroy(dr);
+    worker_d1_stmt_destroy(del);
+
+    /* The row must still be present (was NOT wiped). */
+    sel = worker_d1_prepare(db, "SELECT * FROM t");
+    rows = worker_d1_stmt_all(sel);
+    ASSERT(rows != NULL);
+    js = json_stringify(rows);
+    ASSERT(js != NULL && strstr(js, "aye") != NULL);
+    free(js);
+    json_value_free(rows);
+    worker_d1_stmt_destroy(sel);
+
+    /* SELECT with an unknown WHERE column must fail, not return every row. */
+    worker_d1_stmt_t *bsel = worker_d1_prepare(db, "SELECT * FROM t WHERE nosuchcol = ?");
+    worker_d1_stmt_bind(bsel, 1, "x");
+    json_value_t *brows = worker_d1_stmt_all(bsel);
+    if (brows != NULL) {
+        char *bjs = json_stringify(brows);
+        ASSERT(bjs == NULL || strstr(bjs, "aye") == NULL);
+        free(bjs);
+        json_value_free(brows);
+    }
+    worker_d1_stmt_destroy(bsel);
+
+    worker_d1_destroy(db);
+    PASS();
+}
+
 /* ========================================================
  * Queues Tests
  * ======================================================== */
@@ -783,6 +848,7 @@ int main(void) {
     test_d1_select();
     test_d1_delete_rows();
     test_d1_batch();
+    test_d1_sql_safety();
 
     /* Queues */
     test_queue_create_destroy();


### PR DESCRIPTION
## What
Fixes the audit's two HIGH D1-worker bugs (plus the matching SELECT flaw):

1. **DELETE degrades to delete-all.** A `DELETE ... WHERE <unknown-col> = ?` (or a WHERE with no bound param) left the per-row match defaulting to `true`, so it **wiped the entire table** instead of matching nothing. → Now the statement is **refused** (success=false, 0 changes). A DELETE with *no* WHERE still deletes all (intentional).
2. **INSERT ignores the column list.** `INSERT INTO t (b, a) VALUES (?, ?)` bound parameters to **physical** column order, so values landed in the **wrong cells**. → Now each parameter maps to its **named** column; an unknown named column fails.
3. **SELECT-all on unknown WHERE** (same class): an unresolvable WHERE returned every row. → Now fails.

## Testing
- `test_d1_sql_safety`: a reordered-column INSERT (`(b, a)`) round-trips to the correct columns; a `DELETE ... WHERE nosuchcol = ?` leaves the row intact; a SELECT with an unknown WHERE column doesn't return it.
- All existing D1 tests unchanged (their column lists are already in declared order; their WHEREs use real columns). Full suite 6/6, worker 32/32, **zero warnings**, clean under ASan/UBSan.
- **Negative control**: the new test fails against the pre-fix code (positional INSERT put the value in the wrong column).