### PR TITLE
Fix listen()-failure path leaving server unjoinably half-started (audit #4 HIGH)

### DIFF
--- a/src/http_server.c
+++ b/src/http_server.c
@@ -187,6 +187,7 @@ struct http_server {
     volatile sig_atomic_t running;
     volatile sig_atomic_t state;
     pthread_t accept_thread;
+    bool accept_thread_started;   /* true only once pthread_create() succeeded — gates every pthread_join() so an uninitialised handle is never joined */
     
     /* Socket timeouts */
     int read_timeout_sec;
@@ -300,6 +301,31 @@ http_server_t *http_server_create(void) {
     return server;
 }
 
+/* Reset the server to a clean STOPPED state after an http_server_listen() error
+ * that occurs once server->running has already been set true.
+ *
+ * Security-by-design (audit #4): the previous error paths closed the socket but
+ * left running=true with an uninitialised accept_thread and (in the threaded
+ * path) an already-created thread pool. A subsequent http_server_stop()/
+ * http_server_destroy() would then see running==true and pthread_join() a
+ * thread that was never started — undefined behaviour on a garbage handle — and
+ * leak the pool. Rather than patch each caller, we make failed startup leave the
+ * server indistinguishable from "never listened": stop()/destroy() early-return
+ * on running==false, so the join is unreachable, and the pool is freed here. */
+static void _listen_fail_cleanup(http_server_t *server) {
+    if (server->socket_fd >= 0) {
+        close(server->socket_fd);
+        server->socket_fd = -1;
+    }
+    if (server->pool) {
+        thread_pool_destroy(server->pool);
+        server->pool = NULL;
+    }
+    server->accept_thread_started = false;
+    server->running = false;
+    server->state = SERVER_STOPPED;
+}
+
 /* Start listening on port */
 int http_server_listen(http_server_t *server, uint16_t port) {
     if (!server) {
@@ -351,15 +377,15 @@ int http_server_listen(http_server_t *server, uint16_t port) {
         /* Set server socket to non-blocking */
         if (set_nonblocking(server->socket_fd) < 0) {
             perror("Failed to set server socket to non-blocking");
-            close(server->socket_fd);
+            _listen_fail_cleanup(server);
             return -1;
         }
-        
+
         /* Add server socket to event loop */
-        if (event_loop_add_fd(server->event_loop, server->socket_fd, EVENT_READ, 
+        if (event_loop_add_fd(server->event_loop, server->socket_fd, EVENT_READ,
                              async_accept_handler, server) < 0) {
             fprintf(stderr, "Failed to add server socket to event loop\n");
-            close(server->socket_fd);
+            _listen_fail_cleanup(server);
             return -1;
         }
         
@@ -370,19 +396,21 @@ int http_server_listen(http_server_t *server, uint16_t port) {
         server->pool = thread_pool_create(server->thread_count, 0);
         if (!server->pool) {
             fprintf(stderr, "Failed to create thread pool\n");
-            close(server->socket_fd);
+            _listen_fail_cleanup(server);
             return -1;
         }
-        
+
         printf("HTTP server listening on port %d (threaded mode, pool=%d)\n", port, server->thread_count);
-        
+
         /* Start accept thread */
         if (pthread_create(&server->accept_thread, NULL, accept_connections, server) != 0) {
             perror("pthread_create failed");
-            server->running = false;
-            close(server->socket_fd);
+            /* Frees the pool created just above and resets running/state. */
+            _listen_fail_cleanup(server);
             return -1;
         }
+        /* Handle is valid from here on — authorise the matching pthread_join(). */
+        server->accept_thread_started = true;
     }
     
     return 0;
@@ -409,8 +437,11 @@ void http_server_stop(http_server_t *server) {
             close(server->socket_fd);
             server->socket_fd = -1;
         }
-        pthread_join(server->accept_thread, NULL);
-        
+        if (server->accept_thread_started) {
+            pthread_join(server->accept_thread, NULL);
+            server->accept_thread_started = false;
+        }
+
         /* Drain and destroy thread pool */
         if (server->pool) {
             thread_pool_destroy(server->pool);
@@ -464,13 +495,16 @@ int http_server_shutdown(http_server_t *server, int timeout_sec) {
             event_loop_stop(server->event_loop);
         }
     } else {
-        pthread_join(server->accept_thread, NULL);
+        if (server->accept_thread_started) {
+            pthread_join(server->accept_thread, NULL);
+            server->accept_thread_started = false;
+        }
         if (server->pool) {
             thread_pool_destroy(server->pool);
             server->pool = NULL;
         }
     }
-    
+
     server->state = SERVER_STOPPED;
     printf("HTTP server shut down gracefully\n");
     return 0;

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -187,7 +187,7 @@ struct http_server {
     volatile sig_atomic_t running;
     volatile sig_atomic_t state;
     pthread_t accept_thread;
-    bool accept_thread_started;   /* true only once pthread_create() succeeded — gates every pthread_join() so an uninitialised handle is never joined */
+    volatile sig_atomic_t accept_thread_started;   /* set only once pthread_create() succeeded — gates every pthread_join() so an uninitialised handle is never joined; sig_atomic_t (like running/state) keeps it safe when stop() is driven from a signal handler */
     
     /* Socket timeouts */
     int read_timeout_sec;

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -1252,7 +1252,14 @@ void test_stress_listen_failure_cleanup(void) {
         }
         http_server_set_thread_count(server, 1);
 
-        int rc = http_server_listen(server, 19044);
+        /* Port 0 => the OS assigns a free ephemeral port, so bind()/listen()
+         * succeed regardless of what else is bound. This is essential: if we
+         * hard-coded a port and it happened to be busy, listen() would fail
+         * EARLY (before server->running is set true) and the buggy code path
+         * would never be reached — the test would pass as a false negative.
+         * With port 0 the only remaining failure point is the post-startup
+         * thread-pool creation we are deliberately forcing. */
+        int rc = http_server_listen(server, 0);
         if (rc == 0) {
             /* Could not force the failure — tear the running server down cleanly
              * and report SKIP (this path must itself be crash-free). */

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -17,6 +17,8 @@
 #include <netinet/in.h>
 #include <errno.h>
 #include <time.h>
+#include <sys/wait.h>       /* fork/waitpid isolation for the listen-failure test */
+#include <sys/resource.h>   /* setrlimit(RLIMIT_NPROC) to force thread-creation failure */
 
 /* Test counter */
 static int tests_run = 0;
@@ -1199,6 +1201,92 @@ void test_stress_event_loop_create_destroy_cycle(void) {
     PASS();
 }
 
+/*
+ * Regression test for audit #4 (HIGH): an http_server_listen() that fails AFTER
+ * server->running has been set true — e.g. thread-pool creation fails — must
+ * leave the server in a clean STOPPED state, so that a subsequent
+ * http_server_destroy() does NOT pthread_join() an accept thread that was never
+ * created (joining a garbage pthread_t is undefined behaviour and typically
+ * crashes) and does not leak the thread pool.
+ *
+ * We force the post-startup failure deterministically by lowering RLIMIT_NPROC
+ * inside a forked child so that thread_pool_create()'s eager pthread_create()
+ * fails with EAGAIN. The child then calls http_server_destroy(); with the bug
+ * present this dereferences an uninitialised thread handle and the child is
+ * killed by a signal. We assert the child instead exits normally.
+ *
+ * Isolation & portability:
+ *   - Everything runs in a forked child so the aggressive rlimit never touches
+ *     the rest of the suite.
+ *   - RLIMIT_NPROC is per real-UID and root is exempt on Linux; if we cannot
+ *     force the failure (listen() unexpectedly succeeds, as under root in some
+ *     CI containers, or the platform lacks RLIMIT_NPROC) the child tears the
+ *     running server down cleanly and reports SKIP. That still proves teardown
+ *     is crash-free; on non-root hosts it additionally exercises the exact
+ *     error path (and is a valid negative control there).
+ */
+#define LISTEN_FAIL_CHILD_OK    0   /* failure was forced and destroy() was clean */
+#define LISTEN_FAIL_CHILD_BUG   1   /* running/state not reset after failed listen() */
+#define LISTEN_FAIL_CHILD_SKIP  42  /* could not force the failure (e.g. running as root) */
+
+void test_stress_listen_failure_cleanup(void) {
+    TEST("listen() post-startup failure leaves server safely destroyable");
+
+    pid_t pid = fork();
+    ASSERT(pid >= 0);
+
+    if (pid == 0) {
+        /* ---------- child ---------- */
+#if defined(RLIMIT_NPROC)
+        /* Drive the real-UID process/thread limit below the current usage so any
+         * further pthread_create() (the thread pool's workers) fails EAGAIN. */
+        struct rlimit rl;
+        if (getrlimit(RLIMIT_NPROC, &rl) == 0) {
+            rl.rlim_cur = 1;
+            (void)setrlimit(RLIMIT_NPROC, &rl);
+        }
+#endif
+        http_server_t *server = http_server_create();
+        if (!server) {
+            _exit(LISTEN_FAIL_CHILD_SKIP);
+        }
+        http_server_set_thread_count(server, 1);
+
+        int rc = http_server_listen(server, 19044);
+        if (rc == 0) {
+            /* Could not force the failure — tear the running server down cleanly
+             * and report SKIP (this path must itself be crash-free). */
+            http_server_stop(server);
+            http_server_destroy(server);
+            _exit(LISTEN_FAIL_CHILD_SKIP);
+        }
+
+        /* listen() failed post-startup: the server must be back in STOPPED and
+         * destroy() must not join a never-created accept thread. */
+        if (http_server_get_state(server) != HTTP_SERVER_STOPPED) {
+            _exit(LISTEN_FAIL_CHILD_BUG);
+        }
+        http_server_destroy(server);   /* crashes here if the bug is present */
+        _exit(LISTEN_FAIL_CHILD_OK);
+    }
+
+    /* ---------- parent ---------- */
+    int status = 0;
+    ASSERT(waitpid(pid, &status, 0) == pid);
+
+    /* Never killed by a signal (that would be the join-on-garbage crash). */
+    ASSERT(WIFEXITED(status));
+    int code = WEXITSTATUS(status);
+    ASSERT(code != LISTEN_FAIL_CHILD_BUG);
+    ASSERT(code == LISTEN_FAIL_CHILD_OK || code == LISTEN_FAIL_CHILD_SKIP);
+    if (code == LISTEN_FAIL_CHILD_SKIP) {
+        printf("    (note: thread-creation failure not forced on this host; "
+               "verified teardown is crash-free)\n");
+    }
+
+    PASS();
+}
+
 /* ===== Main Test Runner ===== */
 
 int main(void) {
@@ -1249,6 +1337,7 @@ int main(void) {
         test_stress_slow_client();
         test_stress_slowloris_deadline();
         test_stress_request_deadline_silent();
+        test_stress_listen_failure_cleanup();
     }
 
     /* Input Validation Stress Tests */


### PR DESCRIPTION
## Summary

Closes audit finding **#4 (HIGH)**: `http_server_listen()` error paths that run *after* `server->running` is set true leave the server half-started, so a later `http_server_stop()`/`http_server_destroy()` calls `pthread_join()` on an accept thread that was never created — undefined behaviour on a garbage `pthread_t`, typically a crash. The `pthread_create()`-failure path additionally leaked the thread pool it had just created.

### Root cause
`http_server_listen()` sets `running = true; state = SERVER_RUNNING` and *then* performs mode-specific setup that can fail:
- **async**: `set_nonblocking()`, `event_loop_add_fd()`
- **threaded**: `thread_pool_create()`, `pthread_create()`

Those failure paths did `close(socket_fd); return -1;` but left `running == true` and an uninitialised `accept_thread`. `stop()`/`shutdown()` gate their teardown on `running`, then join `accept_thread` unconditionally.

### Fix — engineer the class out, not patch the symptom
- **`_listen_fail_cleanup()`** makes a failed startup indistinguishable from *never listened*: socket closed and reset to `-1`, thread pool freed, `running = false`, `state = SERVER_STOPPED`. Because `stop()`/`destroy()` early-return on `running == false`, the bad join becomes unreachable and the pool is never leaked. Every post-`running=true` error path now calls it.
- **`accept_thread_started` flag** is set **only** once `pthread_create()` succeeds and now gates *every* `pthread_join()` in `stop()`/`shutdown()`. So even if some future path left `running == true`, an uninitialised thread handle can never be joined (defence in depth).

## Test
`tests/test_stress.c::test_stress_listen_failure_cleanup` forks a child, lowers `RLIMIT_NPROC` so `thread_pool_create()` fails post-startup, and asserts the child's `http_server_destroy()` **exits normally** (never signal-killed) with state reset to `STOPPED`.

- Root / macOS can't force the rlimit failure against `pthread_create`, so the child **skips gracefully** while still proving teardown is crash-free.
- Non-root Linux (the **Clang Build & Test** CI leg runs directly on `ubuntu-latest` as `runner`) exercises the exact error path.

## Verification (local)
- `-Wall -Wextra -pedantic` (gnu11): **zero warnings**
- `ctest`: **6/6 pass**
- ASan + UBSan build: **6/6 pass**, no memory/UB errors
- **Negative control**: source-injected `thread_pool_create()` failure → with the fix the test passes taking the real error path; neutering `_listen_fail_cleanup()` makes the test **fail** (child reports non-STOPPED state) — confirming the test genuinely catches the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)