### PR TITLE
Make session data access key-based to eliminate the session_get UAF class (audit #11 HIGH)

### DIFF
--- a/include/kamran.k
+++ b/include/kamran.k
@@ -1173,7 +1173,8 @@ int session_set_data(session_store_t *store, const char *session_id,
  * @param store Session store instance
  * @param session_id Session ID
  * @param key Data key
- * @return Newly allocated value (caller frees) or NULL if not found
+ * @return Newly allocated value (caller frees), or NULL if the session/key is
+ *         not found or the copy could not be allocated
  */
 char *session_get_data(session_store_t *store, const char *session_id,
                        const char *key);

--- a/include/kamran.k
+++ b/include/kamran.k
@@ -1120,7 +1120,17 @@ void session_store_destroy(session_store_t *store);
 char *session_create(session_store_t *store, int max_age);
 
 /**
- * Get session by ID
+ * Get session by ID.
+ *
+ * The returned handle is valid only as a short-lived, single-threaded existence/
+ * identity check (e.g. session_get(...) != NULL, session_get_id, session_is_expired
+ * immediately after). Do NOT retain it or use it for data access: another thread
+ * may destroy or expire the session and its fixed slot may be reused for a
+ * different session, so a stored handle can silently alias the wrong session.
+ * For reading/writing session data use the (store, session_id)-keyed
+ * session_get_data / session_set_data / session_remove_data, which re-resolve the
+ * session under the lock on every call.
+ *
  * @param store Session store instance
  * @param session_id Session ID
  * @return Session instance or NULL if not found/expired
@@ -1135,27 +1145,49 @@ session_t *session_get(session_store_t *store, const char *session_id);
 void session_destroy(session_store_t *store, const char *session_id);
 
 /**
- * Set session data
- * @param session Session instance
+ * Set session data.
+ *
+ * Keyed on (store, session_id) rather than a session_t* handle: the session is
+ * re-resolved under the store lock on every call, so a raw session pointer never
+ * escapes the lock and can never be used after the slot is freed or reused for a
+ * different session (see the note on session_get()).
+ *
+ * @param store Session store instance
+ * @param session_id Session ID
  * @param key Data key
  * @param value Data value (will be copied)
+ * @return 0 on success, -1 if the session does not exist / is expired, or on
+ *         allocation failure
  */
-void session_set_data(session_t *session, const char *key, const char *value);
+int session_set_data(session_store_t *store, const char *session_id,
+                     const char *key, const char *value);
 
 /**
- * Get session data
- * @param session Session instance
+ * Get session data.
+ *
+ * Returns a freshly allocated copy of the value (or NULL if the session/key is
+ * not found); the caller must free() it. Returning a copy — rather than a
+ * pointer into the store's internal, lock-protected data — closes the
+ * use-after-free window that existed when a borrowed pointer outlived the lock.
+ *
+ * @param store Session store instance
+ * @param session_id Session ID
  * @param key Data key
- * @return Data value or NULL if not found
+ * @return Newly allocated value (caller frees) or NULL if not found
  */
-const char *session_get_data(session_t *session, const char *key);
+char *session_get_data(session_store_t *store, const char *session_id,
+                       const char *key);
 
 /**
- * Remove session data
- * @param session Session instance
+ * Remove session data.
+ *
+ * @param store Session store instance
+ * @param session_id Session ID
  * @param key Data key
+ * @return 0 if the key was removed, -1 if the session/key was not found
  */
-void session_remove_data(session_t *session, const char *key);
+int session_remove_data(session_store_t *store, const char *session_id,
+                        const char *key);
 
 /**
  * Get session ID

--- a/src/session.c
+++ b/src/session.c
@@ -288,7 +288,22 @@ static session_t *find_active_session_locked(session_store_t *store,
     for (size_t i = 0; i < MAX_SESSIONS; i++) {
         session_t *s = &store->sessions[i];
         if (s->in_use && strcmp(s->session_id, session_id) == 0) {
-            return session_is_expired(s) ? NULL : s;
+            if (session_is_expired(s)) {
+                /* Reclaim the expired slot on access — the same lazy cleanup
+                 * session_get() performs. Because the keyed data API is now the
+                 * primary access path (callers no longer go through
+                 * session_get()), doing it here too prevents expired sessions
+                 * from lingering in their fixed slots until the next explicit
+                 * session_cleanup_expired(). */
+                free_session_data(s->data);
+                s->data = NULL;
+                s->in_use = false;
+                if (store->session_count > 0) {
+                    store->session_count--;
+                }
+                return NULL;
+            }
+            return s;
         }
     }
     return NULL;

--- a/src/session.c
+++ b/src/session.c
@@ -29,7 +29,6 @@ struct session {
     int max_age;
     session_data_entry_t *data;
     bool in_use;
-    struct session_store *store; /* Back-reference for locking data operations */
 };
 
 /* Session store structure */
@@ -205,7 +204,6 @@ char *session_create(session_store_t *store, int max_age) {
     
     session->data = NULL;
     session->in_use = true;
-    session->store = store;
     store->session_count++;
     
     char *result = strdup(session->session_id);
@@ -276,127 +274,142 @@ void session_destroy(session_store_t *store, const char *session_id) {
     pthread_mutex_unlock(&store->lock);
 }
 
-/* Set session data */
-void session_set_data(session_t *session, const char *key, const char *value) {
-    if (!session || !key || !value || !session->store) {
-        return;
+/* Find an in-use, non-expired session by ID. MUST be called with store->lock
+ * held. Returns the slot or NULL.
+ *
+ * Resolving the session by ID under the lock on every data operation is what
+ * makes the data API immune to the stale-handle / slot-reuse hazards of a raw
+ * session_t*: a session that was destroyed or has expired (in_use == false, or
+ * past its deadline) is reported as not-found, and a fixed slot that was reused
+ * for a different session cannot be mistaken for this one because the IDs
+ * differ. No internal pointer is ever returned to the caller. */
+static session_t *find_active_session_locked(session_store_t *store,
+                                             const char *session_id) {
+    for (size_t i = 0; i < MAX_SESSIONS; i++) {
+        session_t *s = &store->sessions[i];
+        if (s->in_use && strcmp(s->session_id, session_id) == 0) {
+            return session_is_expired(s) ? NULL : s;
+        }
     }
-    
-    pthread_mutex_lock(&session->store->lock);
-    
-    /* Check if key already exists - update value */
-    session_data_entry_t *current = session->data;
-    while (current) {
+    return NULL;
+}
+
+/* Set session data (keyed on store + session_id; see header). */
+int session_set_data(session_store_t *store, const char *session_id,
+                     const char *key, const char *value) {
+    if (!store || !session_id || !key || !value) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&store->lock);
+
+    session_t *session = find_active_session_locked(store, session_id);
+    if (!session) {
+        pthread_mutex_unlock(&store->lock);
+        return -1;
+    }
+
+    /* Update in place if the key already exists. */
+    for (session_data_entry_t *current = session->data; current; current = current->next) {
         if (strcmp(current->key, key) == 0) {
-            /* Update existing value */
             char *new_value = strdup(value);
             if (!new_value) {
-                pthread_mutex_unlock(&session->store->lock);
-                return; /* Keep old value if allocation fails */
+                pthread_mutex_unlock(&store->lock);
+                return -1; /* Keep old value if allocation fails */
             }
             free(current->value);
             current->value = new_value;
-            pthread_mutex_unlock(&session->store->lock);
-            return;
+            pthread_mutex_unlock(&store->lock);
+            return 0;
         }
-        current = current->next;
     }
-    
-    /* Create new entry */
+
+    /* Otherwise prepend a new entry. */
     session_data_entry_t *entry = (session_data_entry_t *)malloc(sizeof(session_data_entry_t));
     if (!entry) {
-        pthread_mutex_unlock(&session->store->lock);
-        return;
+        pthread_mutex_unlock(&store->lock);
+        return -1;
     }
-    
     entry->key = strdup(key);
-    if (!entry->key) {
-        free(entry);
-        pthread_mutex_unlock(&session->store->lock);
-        return;
-    }
-    
     entry->value = strdup(value);
-    if (!entry->value) {
+    if (!entry->key || !entry->value) {
         free(entry->key);
+        free(entry->value);
         free(entry);
-        pthread_mutex_unlock(&session->store->lock);
-        return;
+        pthread_mutex_unlock(&store->lock);
+        return -1;
     }
-    
     entry->next = session->data;
     session->data = entry;
-    
-    pthread_mutex_unlock(&session->store->lock);
+
+    pthread_mutex_unlock(&store->lock);
+    return 0;
 }
 
-/* Get session data */
-const char *session_get_data(session_t *session, const char *key) {
-    if (!session || !key) {
+/* Get session data.
+ * Returns a freshly allocated copy the caller must free() (NULL if not found).
+ * Copying under the lock removes the use-after-free window that a borrowed
+ * pointer into the store's data would leave open once the lock is released. */
+char *session_get_data(session_store_t *store, const char *session_id,
+                       const char *key) {
+    if (!store || !session_id || !key) {
         return NULL;
     }
-    
-    const char *result = NULL;
-    
-    if (session->store) {
-        pthread_mutex_lock(&session->store->lock);
-    }
-    
-    session_data_entry_t *current = session->data;
-    while (current) {
-        if (strcmp(current->key, key) == 0) {
-            result = current->value;
-            break;
+
+    pthread_mutex_lock(&store->lock);
+
+    char *result = NULL;
+    session_t *session = find_active_session_locked(store, session_id);
+    if (session) {
+        for (session_data_entry_t *current = session->data; current; current = current->next) {
+            if (strcmp(current->key, key) == 0) {
+                result = strdup(current->value);
+                break;
+            }
         }
-        current = current->next;
     }
-    
-    if (session->store) {
-        pthread_mutex_unlock(&session->store->lock);
-    }
-    
+
+    pthread_mutex_unlock(&store->lock);
     return result;
 }
 
-/* Remove session data */
-void session_remove_data(session_t *session, const char *key) {
-    if (!session || !key) {
-        return;
+/* Remove session data. Returns 0 if removed, -1 if the session/key was absent. */
+int session_remove_data(session_store_t *store, const char *session_id,
+                        const char *key) {
+    if (!store || !session_id || !key) {
+        return -1;
     }
-    
-    if (session->store) {
-        pthread_mutex_lock(&session->store->lock);
+
+    pthread_mutex_lock(&store->lock);
+
+    session_t *session = find_active_session_locked(store, session_id);
+    if (!session) {
+        pthread_mutex_unlock(&store->lock);
+        return -1;
     }
-    
+
     session_data_entry_t *current = session->data;
     session_data_entry_t *prev = NULL;
-    
+    int removed = -1;
     while (current) {
         if (strcmp(current->key, key) == 0) {
-            /* Remove entry */
             if (prev) {
                 prev->next = current->next;
             } else {
                 session->data = current->next;
             }
-            
             free(current->key);
             free(current->value);
             free(current);
-            
-            if (session->store) {
-                pthread_mutex_unlock(&session->store->lock);
-            }
-            return;
+            removed = 0;
+            break;
         }
-        
         prev = current;
         current = current->next;
     }
-    
-    if (session->store) {
-        pthread_mutex_unlock(&session->store->lock);
-    }
+
+    pthread_mutex_unlock(&store->lock);
+    return removed;
 }
 
 /* Get session ID */

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -526,8 +526,8 @@ void test_stress_session_data_operations(void) {
     char *session_id = session_create(store, 3600);
     ASSERT(session_id != NULL);
 
-    session_t *session = session_get(store, session_id);
-    ASSERT(session != NULL);
+    /* Existence check; the handle is not retained for data access. */
+    ASSERT(session_get(store, session_id) != NULL);
 
     char key[32], value[64];
 

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -535,16 +535,17 @@ void test_stress_session_data_operations(void) {
     for (int i = 0; i < 100; i++) {
         snprintf(key, sizeof(key), "key%d", i);
         snprintf(value, sizeof(value), "value%d", i);
-        session_set_data(session, key, value);
+        ASSERT(session_set_data(store, session_id, key, value) == 0);
     }
 
-    /* Retrieve and verify all */
+    /* Retrieve and verify all (each returns an owned copy to free) */
     for (int i = 0; i < 100; i++) {
         snprintf(key, sizeof(key), "key%d", i);
         snprintf(value, sizeof(value), "value%d", i);
-        const char *retrieved = session_get_data(session, key);
+        char *retrieved = session_get_data(store, session_id, key);
         ASSERT(retrieved != NULL);
         ASSERT(strcmp(retrieved, value) == 0);
+        free(retrieved);
     }
 
     session_destroy(store, session_id);

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1221,8 +1221,8 @@ void test_session_data_operations(void) {
     char *sid = session_create(store, 3600);
     ASSERT(sid != NULL);
 
-    session_t *sess = session_get(store, sid);
-    ASSERT(sess != NULL);
+    /* Existence check; the handle itself is not retained for data access. */
+    ASSERT(session_get(store, sid) != NULL);
 
     /* Set data (keyed on store + session id) */
     ASSERT(session_set_data(store, sid, "user_id", "42") == 0);
@@ -1320,6 +1320,34 @@ void test_session_data_ops_on_dead_session(void) {
     /* An unknown id resolves to nothing either. */
     ASSERT(session_get_data(store, "no-such-session-id", "k") == NULL);
     ASSERT(session_set_data(store, "no-such-session-id", "k", "v") == -1);
+
+    free(sid);
+    session_store_destroy(store);
+
+    PASS();
+}
+
+/* Regression (Copilot review of audit #11): keyed data access must reclaim an
+ * expired session's fixed slot the same way session_get() does, so that with the
+ * keyed API as the primary path expired sessions don't linger until an explicit
+ * session_cleanup_expired(). */
+void test_session_keyed_access_reclaims_expired(void) {
+    TEST("keyed data access reclaims an expired session slot");
+
+    session_store_t *store = session_store_create();
+    ASSERT(store != NULL);
+    char *sid = session_create(store, 1);   /* expires after ~1s */
+    ASSERT(sid != NULL);
+    ASSERT(session_set_data(store, sid, "k", "v") == 0);
+
+    sleep(2);   /* let the session expire */
+
+    /* Keyed access on the expired session returns NULL and reclaims the slot. */
+    ASSERT(session_get_data(store, sid, "k") == NULL);
+
+    /* The access above already reclaimed the slot, so an explicit cleanup finds
+     * nothing left to free. (Without the reclaim this would return 1.) */
+    ASSERT(session_cleanup_expired(store) == 0);
 
     free(sid);
     session_store_destroy(store);
@@ -4544,6 +4572,7 @@ int main(void) {
     test_session_data_operations();
     test_session_get_data_owned_copy();
     test_session_data_ops_on_dead_session();
+    test_session_keyed_access_reclaims_expired();
     test_session_destroy_session();
     test_session_expiration();
     test_session_cleanup();

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1224,34 +1224,102 @@ void test_session_data_operations(void) {
     session_t *sess = session_get(store, sid);
     ASSERT(sess != NULL);
 
-    /* Set data */
-    session_set_data(sess, "user_id", "42");
-    session_set_data(sess, "username", "testuser");
+    /* Set data (keyed on store + session id) */
+    ASSERT(session_set_data(store, sid, "user_id", "42") == 0);
+    ASSERT(session_set_data(store, sid, "username", "testuser") == 0);
 
-    /* Get data */
-    const char *user_id = session_get_data(sess, "user_id");
+    /* Get data — returns an owned copy the caller must free() */
+    char *user_id = session_get_data(store, sid, "user_id");
     ASSERT(user_id != NULL);
     ASSERT(strcmp(user_id, "42") == 0);
+    free(user_id);
 
-    const char *username = session_get_data(sess, "username");
+    char *username = session_get_data(store, sid, "username");
     ASSERT(username != NULL);
     ASSERT(strcmp(username, "testuser") == 0);
+    free(username);
 
     /* Update data */
-    session_set_data(sess, "user_id", "99");
-    user_id = session_get_data(sess, "user_id");
+    ASSERT(session_set_data(store, sid, "user_id", "99") == 0);
+    user_id = session_get_data(store, sid, "user_id");
     ASSERT(user_id != NULL);
     ASSERT(strcmp(user_id, "99") == 0);
+    free(user_id);
 
     /* Remove data */
-    session_remove_data(sess, "user_id");
-    ASSERT(session_get_data(sess, "user_id") == NULL);
+    ASSERT(session_remove_data(store, sid, "user_id") == 0);
+    ASSERT(session_get_data(store, sid, "user_id") == NULL);
 
     /* Other data should still be there */
-    ASSERT(session_get_data(sess, "username") != NULL);
+    username = session_get_data(store, sid, "username");
+    ASSERT(username != NULL);
+    free(username);
 
     /* Get non-existent key */
-    ASSERT(session_get_data(sess, "nonexistent") == NULL);
+    ASSERT(session_get_data(store, sid, "nonexistent") == NULL);
+
+    free(sid);
+    session_store_destroy(store);
+
+    PASS();
+}
+
+/* Regression (audit #11): session_get_data must return an INDEPENDENT owned copy,
+ * not a borrowed pointer into the store's internal data. If it were borrowed,
+ * overwriting the value (which frees the old internal string) or destroying the
+ * session (which frees the data list) would leave the caller holding a dangling
+ * pointer — a use-after-free ASan flags immediately. */
+void test_session_get_data_owned_copy(void) {
+    TEST("session_get_data returns an independent owned copy (UAF-safe)");
+
+    session_store_t *store = session_store_create();
+    ASSERT(store != NULL);
+    char *sid = session_create(store, 3600);
+    ASSERT(sid != NULL);
+
+    ASSERT(session_set_data(store, sid, "k", "original") == 0);
+
+    char *copy = session_get_data(store, sid, "k");
+    ASSERT(copy != NULL);
+    ASSERT(strcmp(copy, "original") == 0);
+
+    /* Overwrite: frees the old internal value. A borrowed copy would dangle. */
+    ASSERT(session_set_data(store, sid, "k", "replaced") == 0);
+    ASSERT(strcmp(copy, "original") == 0);   /* copy is unaffected */
+
+    /* Destroy: frees the whole data list. A borrowed copy would dangle. */
+    session_destroy(store, sid);
+    ASSERT(strcmp(copy, "original") == 0);   /* copy is still valid */
+
+    free(copy);
+    free(sid);
+    session_store_destroy(store);
+
+    PASS();
+}
+
+/* Regression (audit #11): data operations keyed on a destroyed/expired session
+ * (or an unknown id) must fail safely — reads return NULL, writes/removes return
+ * -1 — rather than resurrecting data on a dead slot or aliasing a reused slot. */
+void test_session_data_ops_on_dead_session(void) {
+    TEST("session data ops on destroyed/unknown session fail safely");
+
+    session_store_t *store = session_store_create();
+    ASSERT(store != NULL);
+    char *sid = session_create(store, 3600);
+    ASSERT(sid != NULL);
+    ASSERT(session_set_data(store, sid, "k", "v") == 0);
+
+    session_destroy(store, sid);
+
+    /* The id no longer resolves to an active session. */
+    ASSERT(session_get_data(store, sid, "k") == NULL);
+    ASSERT(session_set_data(store, sid, "k", "v2") == -1);   /* no resurrection */
+    ASSERT(session_remove_data(store, sid, "k") == -1);
+
+    /* An unknown id resolves to nothing either. */
+    ASSERT(session_get_data(store, "no-such-session-id", "k") == NULL);
+    ASSERT(session_set_data(store, "no-such-session-id", "k", "v") == -1);
 
     free(sid);
     session_store_destroy(store);
@@ -1355,11 +1423,11 @@ void test_session_null_handling(void) {
     /* All functions should handle NULL gracefully */
     ASSERT(session_create(NULL, 3600) == NULL);
     ASSERT(session_get(NULL, "test") == NULL);
-    ASSERT(session_get_data(NULL, "key") == NULL);
+    ASSERT(session_get_data(NULL, "test", "key") == NULL);
     ASSERT(session_get_id(NULL) == NULL);
     session_destroy(NULL, "test");
-    session_set_data(NULL, "key", "value");
-    session_remove_data(NULL, "key");
+    ASSERT(session_set_data(NULL, "test", "key", "value") == -1);
+    ASSERT(session_remove_data(NULL, "test", "key") == -1);
 
     PASS();
 }
@@ -4474,6 +4542,8 @@ int main(void) {
     test_session_store_create_destroy();
     test_session_create_get();
     test_session_data_operations();
+    test_session_get_data_owned_copy();
+    test_session_data_ops_on_dead_session();
     test_session_destroy_session();
     test_session_expiration();
     test_session_cleanup();


### PR DESCRIPTION
## Summary

Closes audit finding **#11 (HIGH, memory safety)**. The session API handed out internal, lock-protected pointers that outlived the lock:

- `session_get()` returns a raw `session_t*` into the store's fixed slot array.
- `session_get_data()` returned a pointer straight into that slot's internal value **after releasing** the store lock.

### The vulnerability class
1. **Use-after-free:** a concurrent `session_set_data()` (which `free()`s the old value on update) or `session_destroy()` (which frees the whole data list) turns the borrowed value pointer into a dangling one → UAF read.
2. **Cross-session aliasing:** the fixed slot can be destroyed then reused by `session_create()` for a *different* session, so a retained handle silently reads/writes the wrong session.

### Fix — engineer the class out
All data access is now keyed on `(store, session_id)` and resolves the session **under the store lock on every call**:

- `find_active_session_locked()` looks the session up by id while the lock is held; a destroyed/expired/unknown/reused id resolves to `NULL`, so no operation can touch a dead or repurposed slot.
- `session_get_data()` returns a **freshly allocated copy the caller frees** (mirroring `cache_get`) — the UAF window is gone because no internal pointer escapes the lock.
- `session_set_data()` / `session_remove_data()` now return `int` and fail (`-1`) on a missing session instead of resurrecting data on a dead slot.
- `session_get()` still returns a handle, but its doc now scopes it to a short-lived existence/identity check and forbids retaining it for data access.
- Removed the now-unused `session->store` back-pointer (its only purpose was the old in-accessor locking).

### API change
`session_set_data`/`session_get_data`/`session_remove_data` signatures change from `(session_t*, …)` to `(session_store_t*, const char *session_id, …)`; `session_get_data` returns owned memory. Only tests called these; all call sites are migrated.

## Tests
- `test_session_get_data_owned_copy` — proves the returned value stays valid after the stored value is overwritten **and** the session destroyed. A borrowed pointer makes ASan abort here (verified via a negative control that swaps `strdup` back to a borrow → ASan double-free/UAF).
- `test_session_data_ops_on_dead_session` — reads/writes on a destroyed or unknown id fail safely (NULL / -1).

## Verification (local)
- `-Wall -Wextra -pedantic` (gnu11): **zero warnings**
- `ctest`: **6/6 pass** (normal and ASan+UBSan builds)
- **Negative control**: reverting `session_get_data` to a borrowed pointer makes the ASan build abort in the regression test — confirming it genuinely catches the UAF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)