### PR TITLE
Fail closed on CORS wildcard origin + credentials (CWE-942)

### DIFF
--- a/src/middleware_cors.c
+++ b/src/middleware_cors.c
@@ -84,9 +84,10 @@ static void _set_cors_headers(http_response_t *res, const char *origin, bool is_
     }
 
     /* Access-Control-Allow-Credentials is only valid alongside a specific
-     * origin; it must never accompany the wildcard '*' (which is why the
-     * wildcard branch above carries no credentials). */
-    if (config->allow_credentials && config->allowed_origins != NULL) {
+     * origin that was actually echoed into Access-Control-Allow-Origin; it must
+     * never accompany the wildcard '*' (which is why the wildcard branch above
+     * carries no credentials) and never be emitted without an ACAO. */
+    if (config->allow_credentials && config->allowed_origins != NULL && origin != NULL) {
         http_response_set_header(res, "Access-Control-Allow-Credentials", "true");
     }
 

--- a/src/middleware_cors.c
+++ b/src/middleware_cors.c
@@ -70,23 +70,23 @@ static void _set_cors_headers(http_response_t *res, const char *origin, bool is_
 
     /* Set Access-Control-Allow-Origin */
     if (config->allowed_origins == NULL) {
-        /* Wildcard mode: when credentials are allowed, must echo specific origin
-         * (browsers reject Access-Control-Allow-Origin: * with credentials) */
-        if (config->allow_credentials && origin != NULL) {
-            http_response_set_header(res, "Access-Control-Allow-Origin", origin);
-            http_response_set_header(res, "Vary", "Origin");
-        } else {
-            http_response_set_header(res, "Access-Control-Allow-Origin", "*");
-        }
+        /* Wildcard mode. cors_middleware_create() refuses wildcard + credentials,
+         * so credentials are never in play here: always emit the literal '*' and
+         * never reflect the caller's Origin. Reflecting the Origin together with
+         * Access-Control-Allow-Credentials: true is exactly the CWE-942 hole this
+         * avoids by construction. */
+        http_response_set_header(res, "Access-Control-Allow-Origin", "*");
     } else if (origin != NULL) {
-        /* Specific origin is allowed */
+        /* Specific allowed origin. */
         http_response_set_header(res, "Access-Control-Allow-Origin", origin);
         /* Vary header to indicate origin-based response */
         http_response_set_header(res, "Vary", "Origin");
     }
 
-    /* Set Access-Control-Allow-Credentials if enabled */
-    if (config->allow_credentials) {
+    /* Access-Control-Allow-Credentials is only valid alongside a specific
+     * origin; it must never accompany the wildcard '*' (which is why the
+     * wildcard branch above carries no credentials). */
+    if (config->allow_credentials && config->allowed_origins != NULL) {
         http_response_set_header(res, "Access-Control-Allow-Credentials", "true");
     }
 
@@ -229,6 +229,22 @@ static char *_strdup_optional(const char *src) {
  */
 middleware_fn_t cors_middleware_create(const cors_options_t *options) {
     if (options == NULL) {
+        return NULL;
+    }
+
+    /* Security (CWE-942): reject a wildcard origin combined with credentials.
+     * There is no safe way to allow credentialed requests from *any* origin:
+     * doing so forces the server to reflect the caller's Origin back with
+     * Access-Control-Allow-Credentials: true, which lets any website read a
+     * victim's authenticated responses. Fail closed so the dangerous config
+     * cannot be constructed — credentialed CORS requires an explicit
+     * allowed_origins list. Checked before touching any existing config so a
+     * rejected call never tears down a previously-valid one. */
+    if (options->allow_credentials && options->allowed_origins == NULL) {
+        fprintf(stderr,
+                "cors_middleware_create: refusing allow_credentials with a "
+                "wildcard origin (CWE-942); provide an explicit allowed_origins "
+                "list to use credentials\n");
         return NULL;
     }
 

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -940,6 +940,48 @@ void test_cors_create_destroy(void) {
     PASS();
 }
 
+/* Regression (audit #22, CWE-942): the CORS middleware must refuse a wildcard
+ * origin (allowed_origins == NULL) combined with credentials, so it can never
+ * reflect an arbitrary Origin back with Access-Control-Allow-Credentials: true.
+ * Credentialed CORS must use an explicit origin allow-list. */
+void test_cors_rejects_wildcard_with_credentials(void) {
+    TEST("cors refuses wildcard origin + credentials (CWE-942)");
+
+    /* Dangerous combo: wildcard + credentials -> refused (returns NULL). */
+    cors_options_t bad = {
+        .allowed_origins = NULL,
+        .allowed_methods = "GET, POST",
+        .allow_credentials = true,
+        .max_age = 3600
+    };
+    ASSERT(cors_middleware_create(&bad) == NULL);
+
+    /* Wildcard WITHOUT credentials is still fine. */
+    cors_options_t wildcard_ok = {
+        .allowed_origins = NULL,
+        .allowed_methods = "GET, POST",
+        .allow_credentials = false,
+        .max_age = 3600
+    };
+    middleware_fn_t mw = cors_middleware_create(&wildcard_ok);
+    ASSERT(mw != NULL);
+    cors_middleware_destroy();
+
+    /* Explicit origins WITH credentials is the safe, supported combo. */
+    const char *origins[] = {"https://app.example.com", NULL};
+    cors_options_t creds_ok = {
+        .allowed_origins = origins,
+        .allowed_methods = "GET, POST",
+        .allow_credentials = true,
+        .max_age = 3600
+    };
+    mw = cors_middleware_create(&creds_ok);
+    ASSERT(mw != NULL);
+    cors_middleware_destroy();
+
+    PASS();
+}
+
 /* Test CORS middleware - handler behavior */
 void test_cors_handler(void) {
     TEST("cors (handler)");
@@ -4552,6 +4594,7 @@ int main(void) {
     
     /* Phase 5: CORS middleware tests */
     test_cors_create_destroy();
+    test_cors_rejects_wildcard_with_credentials();
     test_cors_handler();
     
     /* Phase 5: Rate limiting tests */

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -50,6 +50,22 @@ static const char *_test_find_header(void *headers, const char *name_lower) {
     return NULL;
 }
 
+/*
+ * Test-local helper: prepend a header node onto an http_header_node list, using
+ * the same layout header_list_add() builds. Name is stored lowercased because
+ * http_request_get_header() lowercases the lookup key. Lets a test synthesize a
+ * request header (e.g. Origin) without the internal parser.
+ */
+static void _test_add_header(void **headers, const char *name_lower, const char *value) {
+    _test_hdr_node_t *n = (_test_hdr_node_t *)calloc(1, sizeof(_test_hdr_node_t));
+    if (!n) return;
+    n->name = strdup(name_lower);
+    n->raw_name = strdup(name_lower);
+    n->value = strdup(value);
+    n->next = (_test_hdr_node_t *)*headers;
+    *headers = n;
+}
+
 /* Dummy handler for testing */
 static void dummy_handler(http_request_t *req, http_response_t *res) {
     (void)req;
@@ -977,6 +993,43 @@ void test_cors_rejects_wildcard_with_credentials(void) {
     };
     mw = cors_middleware_create(&creds_ok);
     ASSERT(mw != NULL);
+    cors_middleware_destroy();
+
+    PASS();
+}
+
+/* Regression (audit #22 defense-in-depth): in wildcard mode the handler must
+ * emit a literal Access-Control-Allow-Origin: * — never reflect the request
+ * Origin — and must not emit Access-Control-Allow-Credentials. This guards the
+ * runtime path even though create-time refusal already blocks wildcard+creds. */
+void test_cors_wildcard_does_not_reflect(void) {
+    TEST("cors wildcard emits '*' and never reflects Origin / credentials");
+
+    cors_options_t opts = {
+        .allowed_origins = NULL,          /* wildcard */
+        .allowed_methods = "GET, POST",
+        .allow_credentials = false,
+        .max_age = 3600
+    };
+    middleware_fn_t mw = cors_middleware_create(&opts);
+    ASSERT(mw != NULL);
+
+    http_request_t req = {0};
+    req.method = HTTP_GET;
+    _test_add_header(&req.headers, "origin", "http://evil.example");
+
+    http_response_t res = {0};
+    bool cont = mw(&req, &res, NULL);
+    ASSERT(cont == true);
+
+    const char *acao = _test_find_header(res.headers, "access-control-allow-origin");
+    const char *acac = _test_find_header(res.headers, "access-control-allow-credentials");
+    ASSERT(acao != NULL);
+    ASSERT(strcmp(acao, "*") == 0);            /* literal '*', NOT the reflected Origin */
+    ASSERT(acac == NULL);                       /* no credentials advertised in wildcard mode */
+
+    _test_free_header_list(res.headers);
+    _test_free_header_list(req.headers);
     cors_middleware_destroy();
 
     PASS();
@@ -4595,6 +4648,7 @@ int main(void) {
     /* Phase 5: CORS middleware tests */
     test_cors_create_destroy();
     test_cors_rejects_wildcard_with_credentials();
+    test_cors_wildcard_does_not_reflect();
     test_cors_handler();
     
     /* Phase 5: Rate limiting tests */


### PR DESCRIPTION
## Summary

Closes audit finding **#22 (MEDIUM, CWE-942 — CORS credential reflection)**.

With a wildcard origin (`allowed_origins == NULL`) and `allow_credentials` set, `_set_cors_headers()` reflected the raw request `Origin` into `Access-Control-Allow-Origin` and emitted `Access-Control-Allow-Credentials: true`. That is textbook credential reflection: a page at `https://evil.com` can make a credentialed `fetch` and the browser exposes the authenticated response because it sees `ACAO: https://evil.com` + `ACAC: true`.

## Fix — engineer the combination out (fail closed)
There is no safe way to allow credentials from *any* origin, so the dangerous combination is refused rather than reflected:

- **`cors_middleware_create()`** now returns `NULL` when `allow_credentials` is set together with a wildcard origin (checked *before* any existing config is torn down, so a rejected call can't nuke a valid one). Credentialed CORS requires an explicit `allowed_origins` list.
- **`_set_cors_headers()`** no longer reflects in wildcard mode — it always emits the literal `*` — and only emits `Access-Control-Allow-Credentials` alongside a specific origin, so `*` + credentials can never be produced. Defense in depth behind the create-time refusal.

## Test
`test_cors_rejects_wildcard_with_credentials` asserts:
- wildcard + credentials → refused (`NULL`)
- wildcard without credentials → still works
- explicit origins + credentials (the safe, supported combo) → still works

A negative control (disabling the guard) fails the test as expected. Existing CORS tests and the `rest_api_server` example (wildcard, credentials unset) are unaffected.

## Verification (local)
- `-Wall -Wextra -pedantic` (gnu11): **zero warnings**
- `ctest`: **6/6 pass** (normal + ASan/UBSan)
- Negative control confirms the regression test catches a missing guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)