### PR TITLE
Harden HTTP request framing against smuggling (RFC 7230): TE token-parse, control bytes, duplicate CL, OWS

### DIFF
--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1513,6 +1513,116 @@ static int parse_request_line(http_parser_t *parser) {
     return 1;
 }
 
+/* RFC 7230 §3.2.6 token characters (tchar). */
+static bool _is_tchar(unsigned char c) {
+    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+        return true;
+    }
+    switch (c) {
+        case '!': case '#': case '$': case '%': case '&': case '\'':
+        case '*': case '+': case '-': case '.': case '^': case '_':
+        case '`': case '|': case '~':
+            return true;
+        default:
+            return false;
+    }
+}
+
+typedef enum {
+    TE_CHUNKED,      /* the sole coding is "chunked" -> read a chunked body */
+    TE_UNSUPPORTED,  /* a transfer-coding we cannot apply is present -> 501 */
+    TE_MALFORMED     /* chunked missing/repeated/not-final, or bad syntax -> 400 */
+} te_result_t;
+
+/*
+ * Classify a Transfer-Encoding field value per RFC 7230 §3.3.1 / §3.3.3.
+ *
+ * The field is a comma-separated list of transfer-codings (each a token with
+ * optional ";"-parameters). We deliberately TOKEN-parse rather than
+ * substring-match "chunked": the old strstr(value, "chunked") accepted
+ * "xchunked", "chunkedx", and "chunked, gzip" (chunked not last). A stricter
+ * upstream proxy frames those differently, which is the classic
+ * Transfer-Encoding request-smuggling (TE.TE) precondition.
+ *
+ * "chunked" is the only coding this server can apply, and per §3.3.1 it MUST be
+ * the final coding for a request. So the ONLY value that yields a chunked body
+ * is a list whose single coding is "chunked"; anything else is rejected:
+ *   - chunked repeated, not final, or absent  -> TE_MALFORMED (400): the message
+ *     framing cannot be determined reliably.
+ *   - a non-chunked coding present with chunked last (e.g. "gzip, chunked") ->
+ *     TE_UNSUPPORTED (501): we cannot decode that transfer-coding.
+ */
+static te_result_t classify_transfer_encoding(const char *value) {
+    int coding_count = 0;
+    int chunked_count = 0;
+    bool last_is_chunked = false;
+    bool has_unsupported = false;
+
+    const char *p = value;
+    while (*p) {
+        /* Skip optional whitespace and empty list elements (the #rule tolerates
+         * stray commas). */
+        while (*p == ' ' || *p == '\t' || *p == ',') {
+            p++;
+        }
+        if (*p == '\0') {
+            break;
+        }
+
+        /* Read the coding name (a token). */
+        const char *name = p;
+        while (_is_tchar((unsigned char)*p)) {
+            p++;
+        }
+        size_t name_len = (size_t)(p - name);
+        if (name_len == 0) {
+            return TE_MALFORMED; /* a non-token char where a coding name was due */
+        }
+
+        /* After the name, only OWS, an optional ";"-parameter section, then a
+         * comma (or end) are valid. Anything else (e.g. "chunked gzip" without a
+         * comma, or trailing junk) is malformed. */
+        while (*p == ' ' || *p == '\t') {
+            p++;
+        }
+        if (*p == ';') {
+            /* Skip the parameter section up to the next list separator. We do
+             * not interpret parameters; any comma (even one inside a quoted
+             * string) ends the element, which at worst rejects an exotic value
+             * as malformed — the safe direction for smuggling. */
+            while (*p != '\0' && *p != ',') {
+                p++;
+            }
+        }
+        if (*p != '\0' && *p != ',') {
+            return TE_MALFORMED;
+        }
+
+        coding_count++;
+        if (name_len == 7 && strncasecmp(name, "chunked", 7) == 0) {
+            chunked_count++;
+            last_is_chunked = true;
+        } else {
+            has_unsupported = true;
+            last_is_chunked = false;
+        }
+    }
+
+    if (coding_count == 0) {
+        return TE_MALFORMED;                 /* Transfer-Encoding present but empty */
+    }
+    if (chunked_count > 1) {
+        return TE_MALFORMED;                 /* chunked applied more than once */
+    }
+    if (chunked_count == 0 || !last_is_chunked) {
+        return TE_MALFORMED;                 /* chunked absent or not the final coding */
+    }
+    if (has_unsupported) {
+        return TE_UNSUPPORTED;               /* e.g. "gzip, chunked": can't decode gzip */
+    }
+    return TE_CHUNKED;                        /* exactly "chunked" */
+}
+
 static int parse_header_line(http_parser_t *parser, const char *line, size_t len) {
     const char *colon = memchr(line, ':', len);
     if (!colon) {
@@ -1603,8 +1713,24 @@ static int parse_header_line(http_parser_t *parser, const char *line, size_t len
             return -1;
         }
         parser->seen_transfer_encoding = true;
-        if (strstr(value_buf, "chunked") != NULL) {
+        /* RFC 7230 §3.3.1: token-parse the transfer-coding list instead of a
+         * substring match, so "xchunked"/"chunkedx"/"chunked, gzip" can never be
+         * mistaken for a chunked body (request-smuggling precondition). */
+        te_result_t te = classify_transfer_encoding(value_buf);
+        if (te == TE_CHUNKED) {
             parser->chunked = true;
+        } else if (te == TE_UNSUPPORTED) {
+            free(name_buf);
+            free(value_buf);
+            parser_set_error(parser, HTTP_NOT_IMPLEMENTED,
+                             "Unsupported Transfer-Encoding");
+            return -1;
+        } else { /* TE_MALFORMED */
+            free(name_buf);
+            free(value_buf);
+            parser_set_error(parser, HTTP_BAD_REQUEST,
+                             "Malformed Transfer-Encoding");
+            return -1;
         }
     } else if (strcasecmp(name_buf, "expect") == 0) {
         if (strcasecmp(value_buf, "100-continue") == 0) {

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1476,6 +1476,23 @@ static int parse_request_line(http_parser_t *parser) {
         return -1;
     }
 
+    /* RFC 7230 §3.2/§3.5: the request-target must contain no whitespace or
+     * control characters. find_crlf only splits on CR+LF pairs and the token
+     * split is SP-only, so without this a bare CR/LF/HTAB or other CTL byte
+     * survives verbatim into req->path / query_string — a CRLF-injection /
+     * response-splitting primitive, and a request-line smuggling / cache-key
+     * divergence when an upstream proxy interprets the byte differently. Reject
+     * SP, HTAB, CR, LF, any other C0 control, and DEL with 400. (High bytes
+     * 0x80-0xFF are left for the routing/application layer.) */
+    for (const char *t = target; *t != '\0'; t++) {
+        unsigned char c = (unsigned char)*t;
+        if (c <= 0x20 || c == 0x7f) {
+            free(line);
+            parser_set_error(parser, HTTP_BAD_REQUEST, "Invalid request target");
+            return -1;
+        }
+    }
+
     char *query = strchr(target, '?');
     if (query) {
         *query = '\0';

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1745,6 +1745,16 @@ static int parse_header_line(http_parser_t *parser, const char *line, size_t len
                              "Both Content-Length and Transfer-Encoding present");
             return -1;
         }
+        /* RFC 7230 §3.3.2: Content-Length = 1*DIGIT. strtoull() would also accept
+         * a leading '+'/'-' sign (e.g. "+5" -> 5, "-0" -> 0), which a strict
+         * proxy rejects — an accept/reject framing divergence. Require the first
+         * byte to be an ASCII digit so only unsigned decimal is accepted. */
+        if (value_buf[0] < '0' || value_buf[0] > '9') {
+            free(name_buf);
+            free(value_buf);
+            parser_set_error(parser, HTTP_BAD_REQUEST, "Invalid Content-Length header");
+            return -1;
+        }
         char *endptr = NULL;
         unsigned long long val = strtoull(value_buf, &endptr, 10);
         if (endptr == value_buf || *endptr != '\0') {
@@ -1921,12 +1931,36 @@ static int parse_chunk_size(http_parser_t *parser) {
     memcpy(line, parser->buffer, (size_t)crlf_index);
     line[crlf_index] = '\0';
 
-    char *endptr = NULL;
-    errno = 0;
-    unsigned long chunk_size = strtoul(line, &endptr, 16);
-    /* Reject trailing garbage after hex digits (allow optional chunk-ext starting with ';') */
-    if (endptr == line || errno == ERANGE || chunk_size > MAX_BODY_BYTES ||
-        (*endptr != '\0' && *endptr != ';')) {
+    /* RFC 7230 §4.1: chunk-size = 1*HEXDIG. Parse the hex digits by hand instead
+     * of strtoul(), which also accepts leading whitespace, a +/- sign, and a
+     * "0x" prefix — any of which a strict proxy rejects, producing a chunk-body
+     * framing desync (e.g. "0x0" would be read as a terminating chunk and the
+     * trailing bytes smuggled as a pipelined request). Only an optional ";"
+     * chunk-ext may follow the digits. */
+    size_t idx = 0;
+    unsigned long chunk_size = 0;
+    bool have_digit = false;
+    for (; line[idx] != '\0' && line[idx] != ';'; idx++) {
+        unsigned int digit;
+        char c = line[idx];
+        if (c >= '0' && c <= '9') {
+            digit = (unsigned int)(c - '0');
+        } else if (c >= 'a' && c <= 'f') {
+            digit = (unsigned int)(c - 'a' + 10);
+        } else if (c >= 'A' && c <= 'F') {
+            digit = (unsigned int)(c - 'A' + 10);
+        } else {
+            break; /* non-HEXDIG (and not ';') -> invalid, rejected below */
+        }
+        chunk_size = chunk_size * 16u + digit;
+        have_digit = true;
+        if (chunk_size > MAX_BODY_BYTES) {
+            free(line);
+            parser_set_error(parser, HTTP_PAYLOAD_TOO_LARGE, "Chunk too large");
+            return -1;
+        }
+    }
+    if (!have_digit || (line[idx] != '\0' && line[idx] != ';')) {
         free(line);
         parser_set_error(parser, HTTP_BAD_REQUEST, "Invalid chunk size");
         return -1;

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1559,29 +1559,32 @@ static te_result_t classify_transfer_encoding(const char *value) {
     bool has_unsupported = false;
 
     const char *p = value;
-    while (*p) {
-        /* Skip optional whitespace and empty list elements (the #rule tolerates
-         * stray commas). */
-        while (*p == ' ' || *p == '\t' || *p == ',') {
-            p++;
-        }
-        if (*p == '\0') {
-            break;
-        }
 
-        /* Read the coding name (a token). */
+    /* Skip leading OWS. A leading comma is an empty list element, which we
+     * reject below rather than tolerate (see the separator handling): being
+     * strict about empty elements removes a source of accept/reject divergence
+     * with upstream proxies — itself a smuggling precondition. */
+    while (*p == ' ' || *p == '\t') {
+        p++;
+    }
+    if (*p == '\0') {
+        return TE_MALFORMED;                 /* empty or whitespace-only value */
+    }
+
+    for (;;) {
+        /* A coding name (token) must appear here. An empty element (e.g. from a
+         * leading/doubled/trailing comma) lands on ',' or '\0' and is rejected. */
         const char *name = p;
         while (_is_tchar((unsigned char)*p)) {
             p++;
         }
         size_t name_len = (size_t)(p - name);
         if (name_len == 0) {
-            return TE_MALFORMED; /* a non-token char where a coding name was due */
+            return TE_MALFORMED;
         }
 
-        /* After the name, only OWS, an optional ";"-parameter section, then a
-         * comma (or end) are valid. Anything else (e.g. "chunked gzip" without a
-         * comma, or trailing junk) is malformed. */
+        /* After the name, only OWS then an optional ";"-parameter section may
+         * precede the separator. */
         while (*p == ' ' || *p == '\t') {
             p++;
         }
@@ -1594,9 +1597,6 @@ static te_result_t classify_transfer_encoding(const char *value) {
                 p++;
             }
         }
-        if (*p != '\0' && *p != ',') {
-            return TE_MALFORMED;
-        }
 
         coding_count++;
         if (name_len == 7 && strncasecmp(name, "chunked", 7) == 0) {
@@ -1606,10 +1606,26 @@ static te_result_t classify_transfer_encoding(const char *value) {
             has_unsupported = true;
             last_is_chunked = false;
         }
+
+        if (*p == '\0') {
+            break;                           /* end of the list */
+        }
+        if (*p != ',') {
+            return TE_MALFORMED;             /* junk after a coding (e.g. missing comma) */
+        }
+        p++;                                 /* consume exactly one comma separator */
+        while (*p == ' ' || *p == '\t') {    /* OWS after the comma */
+            p++;
+        }
+        if (*p == '\0') {
+            return TE_MALFORMED;             /* trailing comma -> empty final element */
+        }
+        /* A ',' here would be a doubled comma (empty element); the next
+         * iteration reads name_len == 0 and rejects it. */
     }
 
     if (coding_count == 0) {
-        return TE_MALFORMED;                 /* Transfer-Encoding present but empty */
+        return TE_MALFORMED;                 /* unreachable: guarded above, kept for clarity */
     }
     if (chunked_count > 1) {
         return TE_MALFORMED;                 /* chunked applied more than once */
@@ -1631,7 +1647,12 @@ static int parse_header_line(http_parser_t *parser, const char *line, size_t len
     }
 
     size_t name_len = (size_t)(colon - line);
-    while (name_len > 0 && isspace((unsigned char)line[name_len - 1])) {
+    /* Trim only RFC 7230 OWS (SP / HTAB) — NOT isspace(), which would also eat
+     * VT (0x0B) / FF (0x0C). Treating VT/FF as trimmable whitespace let
+     * "Transfer-Encoding: chunked\x0b" reduce to the token "chunked" here while
+     * a compliant proxy keeps the byte and frames the message differently — a
+     * request-smuggling desync. Keep leading and trailing trims symmetric. */
+    while (name_len > 0 && (line[name_len - 1] == ' ' || line[name_len - 1] == '\t')) {
         name_len--;
     }
     if (name_len == 0) {
@@ -1644,7 +1665,7 @@ static int parse_header_line(http_parser_t *parser, const char *line, size_t len
         value_start++;
     }
     const char *value_end = line + len;
-    while (value_end > value_start && isspace((unsigned char)value_end[-1])) {
+    while (value_end > value_start && (value_end[-1] == ' ' || value_end[-1] == '\t')) {
         value_end--;
     }
 
@@ -1663,6 +1684,32 @@ static int parse_header_line(http_parser_t *parser, const char *line, size_t len
     name_buf[name_len] = '\0';
     memcpy(value_buf, value_start, value_len);
     value_buf[value_len] = '\0';
+
+    /* RFC 7230 §3.2: the field-name is a token, and the field-value carries no
+     * control bytes. Validate the exact byte ranges (not the C-string length) so
+     * an embedded NUL cannot pass. This is a request-smuggling defense: without
+     * it, "Transfer-Encoding: chunked\0, gzip" is copied verbatim but every later
+     * C-string reader (strcasecmp, classify_transfer_encoding) stops at the NUL
+     * and sees only "chunked" -> the origin frames a chunked body while a proxy
+     * that reads the whole value frames it differently. Reject NUL / C0 controls
+     * (except HTAB) / DEL, and any non-token byte in the name, with 400. */
+    for (size_t i = 0; i < name_len; i++) {
+        if (!_is_tchar((unsigned char)name_buf[i])) {
+            free(name_buf);
+            free(value_buf);
+            parser_set_error(parser, HTTP_BAD_REQUEST, "Invalid header name");
+            return -1;
+        }
+    }
+    for (size_t i = 0; i < value_len; i++) {
+        unsigned char c = (unsigned char)value_buf[i];
+        if ((c < 0x20 && c != '\t') || c == 0x7f) {
+            free(name_buf);
+            free(value_buf);
+            parser_set_error(parser, HTTP_BAD_REQUEST, "Invalid header value");
+            return -1;
+        }
+    }
 
     bool replace = (strcasecmp(name_buf, "set-cookie") != 0);
     if (header_list_add((http_header_node_t **)&parser->req->headers, name_buf, name_buf, value_buf, replace) < 0) {

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1647,16 +1647,18 @@ static int parse_header_line(http_parser_t *parser, const char *line, size_t len
     }
 
     size_t name_len = (size_t)(colon - line);
-    /* Trim only RFC 7230 OWS (SP / HTAB) — NOT isspace(), which would also eat
-     * VT (0x0B) / FF (0x0C). Treating VT/FF as trimmable whitespace let
-     * "Transfer-Encoding: chunked\x0b" reduce to the token "chunked" here while
-     * a compliant proxy keeps the byte and frames the message differently — a
-     * request-smuggling desync. Keep leading and trailing trims symmetric. */
-    while (name_len > 0 && (line[name_len - 1] == ' ' || line[name_len - 1] == '\t')) {
-        name_len--;
-    }
     if (name_len == 0) {
         parser_set_error(parser, HTTP_BAD_REQUEST, "Empty header name");
+        return -1;
+    }
+    /* RFC 7230 §3.2.4: no whitespace is allowed between the field-name and the
+     * colon, and a server MUST reject it (400) — do NOT silently trim it. A
+     * lenient origin that strips "Transfer-Encoding : chunked" back to a real TE
+     * header while a strict proxy treats the space-bearing name as not-a-header
+     * is a request-smuggling desync. (Leading whitespace or any other non-token
+     * name byte is caught by the field-name token validation below.) */
+    if (line[name_len - 1] == ' ' || line[name_len - 1] == '\t') {
+        parser_set_error(parser, HTTP_BAD_REQUEST, "Whitespace before header colon");
         return -1;
     }
 
@@ -1664,6 +1666,11 @@ static int parse_header_line(http_parser_t *parser, const char *line, size_t len
     while ((size_t)(value_start - line) < len && (*value_start == ' ' || *value_start == '\t')) {
         value_start++;
     }
+    /* Trim trailing value OWS using only SP / HTAB — NOT isspace(), which would
+     * also eat VT (0x0B) / FF (0x0C). Treating VT/FF as trimmable whitespace let
+     * "Transfer-Encoding: chunked\x0b" reduce to the token "chunked" while a
+     * compliant proxy keeps the byte and frames the message differently — a
+     * request-smuggling desync. (Interior control bytes are rejected below.) */
     const char *value_end = line + len;
     while (value_end > value_start && (value_end[-1] == ' ' || value_end[-1] == '\t')) {
         value_end--;
@@ -1720,6 +1727,16 @@ static int parse_header_line(http_parser_t *parser, const char *line, size_t len
     }
 
     if (strcasecmp(name_buf, "content-length") == 0) {
+        /* RFC 7230 §3.3.3: a second Content-Length is a CL.CL smuggling
+         * precondition (a proxy keying off the first value and this origin off
+         * the last disagree on the body boundary). Reject any duplicate outright,
+         * mirroring the duplicate-Transfer-Encoding guard below. */
+        if (parser->seen_content_length) {
+            free(name_buf);
+            free(value_buf);
+            parser_set_error(parser, HTTP_BAD_REQUEST, "Duplicate Content-Length header");
+            return -1;
+        }
         /* RFC 7230 §3.3.3: reject if Transfer-Encoding already seen */
         if (parser->seen_transfer_encoding) {
             free(name_buf);

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -840,6 +840,80 @@ void test_stress_oversized_request(void) {
     PASS();
 }
 
+/* Regression (audit #21): Transfer-Encoding must be token-parsed per RFC 7230
+ * §3.3.1, not substring-matched. Verifies the smuggling vectors the old
+ * strstr(value,"chunked") accepted are now rejected, while a well-formed
+ * "chunked" request still works. */
+void test_stress_transfer_encoding_smuggling(void) {
+    TEST("Transfer-Encoding token parse rejects smuggling vectors");
+
+    http_server_t *server = http_server_create();
+    ASSERT(server != NULL);
+    router_t *router = router_create();
+    ASSERT(router != NULL);
+    router_add_route(router, HTTP_POST, "/upload", dummy_handler);
+    http_server_set_router(server, router);
+
+    uint16_t port = 19010;
+    ASSERT(http_server_listen(server, port) == 0);
+    usleep(200000);
+
+    char response[4096];
+
+    /* Valid: the sole coding is "chunked" + a proper chunked body -> accepted. */
+    const char *valid =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
+        "Transfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+    ASSERT(_stress_send_request(port, valid, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "200 OK") != NULL);
+
+    /* Token match is case-insensitive; empty chunked body is fine. */
+    const char *valid_case =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
+        "Transfer-Encoding: Chunked\r\n\r\n0\r\n\r\n";
+    ASSERT(_stress_send_request(port, valid_case, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "200 OK") != NULL);
+
+    /* "chunked" with an (ignored) parameter is still the chunked coding. */
+    const char *valid_param =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
+        "Transfer-Encoding: chunked;x=y\r\n\r\n0\r\n\r\n";
+    ASSERT(_stress_send_request(port, valid_param, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "200 OK") != NULL);
+
+    /* Vectors the old substring match accepted -> now 400 (Malformed). */
+    const char *bad_400[] = {
+        "Transfer-Encoding: xchunked",         /* substring, not a token */
+        "Transfer-Encoding: chunkedx",
+        "Transfer-Encoding: chunked, gzip",     /* chunked not the final coding */
+        "Transfer-Encoding: chunked, chunked",  /* chunked applied twice */
+        "Transfer-Encoding: gzip",              /* chunked absent -> undeterminable */
+        "Transfer-Encoding: chunked chunked",   /* two codings, missing comma */
+        NULL
+    };
+    for (int i = 0; bad_400[i] != NULL; i++) {
+        char req[256];
+        snprintf(req, sizeof(req),
+                 "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n%s\r\n\r\n",
+                 bad_400[i]);
+        ASSERT(_stress_send_request(port, req, response, sizeof(response)) == 0);
+        ASSERT(strstr(response, "400") != NULL);
+    }
+
+    /* A non-chunked coding we cannot apply, with chunked last -> 501. */
+    const char *req501 =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
+        "Transfer-Encoding: gzip, chunked\r\n\r\n";
+    ASSERT(_stress_send_request(port, req501, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "501") != NULL);
+
+    http_server_stop(server);
+    usleep(100000);
+    router_destroy(router);
+    http_server_destroy(server);
+    PASS();
+}
+
 void test_stress_many_headers(void) {
     TEST("request with many headers (90 headers)");
 
@@ -1346,6 +1420,7 @@ int main(void) {
         test_stress_slowloris_deadline();
         test_stress_request_deadline_silent();
         test_stress_listen_failure_cleanup();
+        test_stress_transfer_encoding_smuggling();
     }
 
     /* Input Validation Stress Tests */

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -931,6 +931,9 @@ void test_stress_transfer_encoding_smuggling(void) {
         "Transfer-Encoding : chunked",              /* whitespace before colon (RFC 7230 §3.2.4) */
         "Content-Length : 6",                       /* whitespace before colon (tab variant below) */
         "Content-Length\t: 6",                      /* tab before colon */
+        "Content-Length: +5",                       /* signed Content-Length (strtoull leniency) */
+        "Content-Length: -0",                       /* signed zero */
+        "Content-Length: 0x5",                      /* hex Content-Length */
         NULL
     };
     for (int i = 0; bad_400[i] != NULL; i++) {
@@ -1002,6 +1005,23 @@ void test_stress_transfer_encoding_smuggling(void) {
         "Content-Length: 6\r\nContent-Length: 5\r\n\r\n";
     ASSERT(_stress_send_request(port, dup_cl, response, sizeof(response)) == 0);
     ASSERT(strstr(response, "400") != NULL);
+
+    /* Malformed chunk-size lines (RFC 7230 §4.1: chunk-size = 1*HEXDIG) must be
+     * rejected. strtoul() would leniently accept a "0x" prefix, a +/- sign, or
+     * leading whitespace and desync chunk-body framing (e.g. "0x0" reads as a
+     * terminating chunk, smuggling the trailing bytes as a pipelined request). */
+    const char *bad_chunk[] = {
+        "0x0", "0x5", " 5", "\t3", "-0", "+5", "g", "",
+        NULL
+    };
+    for (int i = 0; bad_chunk[i] != NULL; i++) {
+        char req[256];
+        snprintf(req, sizeof(req),
+                 "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
+                 "Transfer-Encoding: chunked\r\n\r\n%s\r\nhello\r\n0\r\n\r\n", bad_chunk[i]);
+        ASSERT(_stress_send_request(port, req, response, sizeof(response)) == 0);
+        ASSERT(strstr(response, "400") != NULL);
+    }
 
     http_server_stop(server);
     usleep(100000);

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -111,12 +111,22 @@ static int _stress_send_request(uint16_t port, const char *request, char *respon
         total_sent += sent;
     }
 
-    /* Receive response */
+    /* Receive the full response. A single recv() can return only the header
+     * segment before the body arrives (more likely under ASan's slower timing),
+     * so drain until the peer closes (these callers use Connection: close) or
+     * the buffer fills. */
     memset(response, 0, resp_size);
-    ssize_t received = recv(sock, response, resp_size - 1, 0);
+    size_t total = 0;
+    while (total < resp_size - 1) {
+        ssize_t n = recv(sock, response + total, resp_size - 1 - total, 0);
+        if (n <= 0) {
+            break;
+        }
+        total += (size_t)n;
+    }
     close(sock);
 
-    return (received > 0) ? 0 : -1;
+    return (total > 0) ? 0 : -1;
 }
 
 static void *_concurrent_request_thread(void *arg) {
@@ -840,10 +850,22 @@ void test_stress_oversized_request(void) {
     PASS();
 }
 
-/* Regression (audit #21): Transfer-Encoding must be token-parsed per RFC 7230
- * §3.3.1, not substring-matched. Verifies the smuggling vectors the old
- * strstr(value,"chunked") accepted are now rejected, while a well-formed
- * "chunked" request still works. */
+/* Echoes the (already de-chunked) request body back so a test can verify the
+ * decoded bytes, not just the status line. */
+static void _te_echo_body_handler(http_request_t *req, http_response_t *res) {
+    char buf[256];
+    size_t n = (req->body_length < sizeof(buf) - 1) ? req->body_length : sizeof(buf) - 1;
+    if (req->body && n > 0) {
+        memcpy(buf, req->body, n);
+    }
+    buf[n] = '\0';
+    http_response_send_text(res, HTTP_OK, buf);
+}
+
+/* Regression (audit #21 + adversarial review): Transfer-Encoding must be
+ * token-parsed per RFC 7230 §3.3.1, not substring-matched. Covers the accept
+ * path (including that the body is de-chunked correctly), the 400 malformed/
+ * smuggling matrix, and the 501 unsupported-coding boundary. */
 void test_stress_transfer_encoding_smuggling(void) {
     TEST("Transfer-Encoding token parse rejects smuggling vectors");
 
@@ -851,7 +873,7 @@ void test_stress_transfer_encoding_smuggling(void) {
     ASSERT(server != NULL);
     router_t *router = router_create();
     ASSERT(router != NULL);
-    router_add_route(router, HTTP_POST, "/upload", dummy_handler);
+    router_add_route(router, HTTP_POST, "/upload", _te_echo_body_handler);
     http_server_set_router(server, router);
 
     uint16_t port = 19010;
@@ -860,35 +882,52 @@ void test_stress_transfer_encoding_smuggling(void) {
 
     char response[4096];
 
-    /* Valid: the sole coding is "chunked" + a proper chunked body -> accepted. */
-    const char *valid =
-        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
-        "Transfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
-    ASSERT(_stress_send_request(port, valid, response, sizeof(response)) == 0);
-    ASSERT(strstr(response, "200 OK") != NULL);
+    /* --- Accept path: sole "chunked" coding, body must be de-chunked exactly. */
+    struct { const char *te; const char *body; const char *expect_decoded; } ok[] = {
+        { "chunked",     "5\r\nhello\r\n0\r\n\r\n",              "hello"  }, /* single chunk */
+        { "chunked",     "3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n",    "foobar" }, /* multi-chunk reassembly */
+        { "chunked",     "5;ext=1\r\nhello\r\n0\r\n\r\n",        "hello"  }, /* chunk-extension ignored */
+        { "Chunked",     "0\r\n\r\n",                            ""       }, /* case-insensitive token */
+        { "chunked;x=y", "0\r\n\r\n",                            ""       }, /* ignored parameter */
+        { "chunked;",    "0\r\n\r\n",                            ""       }, /* bare (empty) parameter */
+        { NULL, NULL, NULL }
+    };
+    for (int i = 0; ok[i].te != NULL; i++) {
+        char req[256];
+        snprintf(req, sizeof(req),
+                 "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
+                 "Transfer-Encoding: %s\r\n\r\n%s", ok[i].te, ok[i].body);
+        ASSERT(_stress_send_request(port, req, response, sizeof(response)) == 0);
+        ASSERT(strstr(response, "200 OK") != NULL);
+        if (ok[i].expect_decoded[0] != '\0') {
+            /* The echoed body proves the decoder produced the right bytes. */
+            ASSERT(strstr(response, ok[i].expect_decoded) != NULL);
+        }
+    }
 
-    /* Token match is case-insensitive; empty chunked body is fine. */
-    const char *valid_case =
-        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
-        "Transfer-Encoding: Chunked\r\n\r\n0\r\n\r\n";
-    ASSERT(_stress_send_request(port, valid_case, response, sizeof(response)) == 0);
-    ASSERT(strstr(response, "200 OK") != NULL);
-
-    /* "chunked" with an (ignored) parameter is still the chunked coding. */
-    const char *valid_param =
-        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
-        "Transfer-Encoding: chunked;x=y\r\n\r\n0\r\n\r\n";
-    ASSERT(_stress_send_request(port, valid_param, response, sizeof(response)) == 0);
-    ASSERT(strstr(response, "200 OK") != NULL);
-
-    /* Vectors the old substring match accepted -> now 400 (Malformed). */
+    /* --- 400 Malformed: framing cannot be determined reliably. */
     const char *bad_400[] = {
-        "Transfer-Encoding: xchunked",         /* substring, not a token */
+        "Transfer-Encoding: xchunked",             /* substring, not a token */
         "Transfer-Encoding: chunkedx",
-        "Transfer-Encoding: chunked, gzip",     /* chunked not the final coding */
-        "Transfer-Encoding: chunked, chunked",  /* chunked applied twice */
-        "Transfer-Encoding: gzip",              /* chunked absent -> undeterminable */
-        "Transfer-Encoding: chunked chunked",   /* two codings, missing comma */
+        "Transfer-Encoding: chunked, gzip",         /* chunked not the final coding */
+        "Transfer-Encoding: chunked, chunked",      /* chunked applied twice */
+        "Transfer-Encoding: chunked , chunked",     /* ...with OWS before the comma */
+        "Transfer-Encoding: chunked, gzip, chunked",/* chunked repeated + not last */
+        "Transfer-Encoding: gzip",                  /* chunked absent -> undeterminable */
+        "Transfer-Encoding: identity",              /* legacy non-chunked coding */
+        "Transfer-Encoding: chunked chunked",       /* two codings, missing comma */
+        "Transfer-Encoding: chunked/gzip",          /* non-OWS junk after token */
+        "Transfer-Encoding: chunked@",              /* trailing non-token byte */
+        "Transfer-Encoding: chunked,",              /* trailing empty list element */
+        "Transfer-Encoding: ,chunked",              /* leading empty list element */
+        "Transfer-Encoding: chunked,,chunked",      /* doubled comma / empty element */
+        "Transfer-Encoding: ,",                     /* nothing but a separator */
+        "Transfer-Encoding: ;chunked",              /* leading ';' -> zero-length name */
+        "Transfer-Encoding: @chunked",              /* leading non-token char */
+        "Transfer-Encoding: chunked;x=\"a,b\"",     /* quoted comma splits -> malformed (intentional) */
+        "Transfer-Encoding: chunked\x0b",           /* trailing VT: not OWS, must not be trimmed */
+        "Transfer-Encoding: chunked\x0c",           /* trailing FF: control byte in value */
+        "Transfer-Encoding: chu\x0bnked",           /* interior control byte */
         NULL
     };
     for (int i = 0; bad_400[i] != NULL; i++) {
@@ -900,12 +939,58 @@ void test_stress_transfer_encoding_smuggling(void) {
         ASSERT(strstr(response, "400") != NULL);
     }
 
-    /* A non-chunked coding we cannot apply, with chunked last -> 501. */
-    const char *req501 =
-        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
-        "Transfer-Encoding: gzip, chunked\r\n\r\n";
-    ASSERT(_stress_send_request(port, req501, response, sizeof(response)) == 0);
-    ASSERT(strstr(response, "501") != NULL);
+    /* --- 501 Not Implemented: a non-chunked coding we cannot apply, chunked last. */
+    const char *bad_501[] = {
+        "Transfer-Encoding: gzip, chunked",
+        "Transfer-Encoding: gzip , chunked",        /* OWS before the comma */
+        "Transfer-Encoding: gzip,\tchunked",        /* tab as inter-element OWS */
+        "Transfer-Encoding: gzip, deflate, chunked",/* multiple unsupported, chunked last */
+        "Transfer-Encoding: gzip;q=1, chunked",     /* parameter on the unsupported coding */
+        NULL
+    };
+    for (int i = 0; bad_501[i] != NULL; i++) {
+        char req[256];
+        snprintf(req, sizeof(req),
+                 "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n%s\r\n\r\n",
+                 bad_501[i]);
+        ASSERT(_stress_send_request(port, req, response, sizeof(response)) == 0);
+        ASSERT(strstr(response, "501") != NULL);
+    }
+
+    /* Embedded NUL in the Transfer-Encoding value must be rejected (400), not
+     * silently truncated to the token before it (which would let the origin read
+     * a chunked body while a proxy frames the full "chunked\0, gzip" differently
+     * -- a smuggling desync). A NUL cannot pass through the C-string helper, so
+     * send raw with an explicit length. */
+    {
+        static const char nul_req[] =
+            "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
+            "Transfer-Encoding: chunked\x00, gzip\r\n\r\n";
+        size_t nul_len = sizeof(nul_req) - 1;  /* keep the embedded NUL, drop the C terminator */
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        ASSERT(sock >= 0);
+        struct timeval tv = { 2, 0 };
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+        struct sockaddr_in addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(port);
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+        ASSERT(connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+        size_t off = 0;
+        while (off < nul_len) {
+            ssize_t s = send(sock, nul_req + off, nul_len - off, 0);
+            if (s <= 0) break;
+            off += (size_t)s;
+        }
+        ASSERT(off == nul_len);
+        char resp[1024];
+        memset(resp, 0, sizeof(resp));
+        ssize_t r = recv(sock, resp, sizeof(resp) - 1, 0);
+        close(sock);
+        ASSERT(r > 0);
+        ASSERT(strstr(resp, "400") != NULL);
+    }
 
     http_server_stop(server);
     usleep(100000);

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -928,6 +928,9 @@ void test_stress_transfer_encoding_smuggling(void) {
         "Transfer-Encoding: chunked\x0b",           /* trailing VT: not OWS, must not be trimmed */
         "Transfer-Encoding: chunked\x0c",           /* trailing FF: control byte in value */
         "Transfer-Encoding: chu\x0bnked",           /* interior control byte */
+        "Transfer-Encoding : chunked",              /* whitespace before colon (RFC 7230 §3.2.4) */
+        "Content-Length : 6",                       /* whitespace before colon (tab variant below) */
+        "Content-Length\t: 6",                      /* tab before colon */
         NULL
     };
     for (int i = 0; bad_400[i] != NULL; i++) {
@@ -991,6 +994,14 @@ void test_stress_transfer_encoding_smuggling(void) {
         ASSERT(r > 0);
         ASSERT(strstr(resp, "400") != NULL);
     }
+
+    /* Duplicate Content-Length (CL.CL smuggling): a second Content-Length must be
+     * rejected (400), not silently last-wins. */
+    const char *dup_cl =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
+        "Content-Length: 6\r\nContent-Length: 5\r\n\r\n";
+    ASSERT(_stress_send_request(port, dup_cl, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "400") != NULL);
 
     http_server_stop(server);
     usleep(100000);

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -1030,6 +1030,54 @@ void test_stress_transfer_encoding_smuggling(void) {
     PASS();
 }
 
+/* Regression (round-5 review): the request-target must not carry whitespace or
+ * control bytes into req->path. A bare CR/LF/HTAB/CTL survives find_crlf (which
+ * splits only on CR+LF) and the SP-only token split, and is a CRLF-injection /
+ * request-line smuggling / cache-poisoning primitive — it must be 400. */
+void test_stress_request_target_control_bytes(void) {
+    TEST("request-target with control bytes is rejected");
+
+    http_server_t *server = http_server_create();
+    ASSERT(server != NULL);
+    router_t *router = router_create();
+    ASSERT(router != NULL);
+    router_add_route(router, HTTP_GET, "/ab", dummy_handler);
+    http_server_set_router(server, router);
+
+    uint16_t port = 19011;
+    ASSERT(http_server_listen(server, port) == 0);
+    usleep(200000);
+
+    char response[4096];
+
+    /* A clean target still works. */
+    const char *good = "GET /ab HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    ASSERT(_stress_send_request(port, good, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "200 OK") != NULL);
+
+    const char *bad_target[] = {
+        "GET /a\rb HTTP/1.1",       /* bare CR */
+        "GET /a\nb HTTP/1.1",       /* bare LF */
+        "GET /a\tb HTTP/1.1",       /* HTAB */
+        "GET /a\x01""b HTTP/1.1",   /* C0 control */
+        "GET /a\x7f""b HTTP/1.1",   /* DEL */
+        NULL
+    };
+    for (int i = 0; bad_target[i] != NULL; i++) {
+        char req[256];
+        snprintf(req, sizeof(req),
+                 "%s\r\nHost: localhost\r\nConnection: close\r\n\r\n", bad_target[i]);
+        ASSERT(_stress_send_request(port, req, response, sizeof(response)) == 0);
+        ASSERT(strstr(response, "400") != NULL);
+    }
+
+    http_server_stop(server);
+    usleep(100000);
+    router_destroy(router);
+    http_server_destroy(server);
+    PASS();
+}
+
 void test_stress_many_headers(void) {
     TEST("request with many headers (90 headers)");
 
@@ -1537,6 +1585,7 @@ int main(void) {
         test_stress_request_deadline_silent();
         test_stress_listen_failure_cleanup();
         test_stress_transfer_encoding_smuggling();
+        test_stress_request_target_control_bytes();
     }
 
     /* Input Validation Stress Tests */


### PR DESCRIPTION
## Summary

Closes internal audit finding 21 (request smuggling) and, through three rounds of adversarial review, hardens `parse_header_line` / `classify_transfer_encoding` into a comprehensive defense against the standard HTTP/1.1 request-framing smuggling set.

Started as: replace `strstr(value,"chunked")` with an RFC 7230 §3.3.1 **token parse** (only a lone `chunked` coding yields a chunked body; chunked-not-final/repeated/absent → 400; unknown coding with chunked last → 501; empty comma list-elements → 400).

A 5-lens adversarial workflow (+ two re-verify rounds) then found and fixed several further bypasses of the first cut:

| Vector | Fix |
|--------|-----|
| **TE substring** (`xchunked`, `chunkedx`, `chunked, gzip`) | token parse, chunked must be sole final coding |
| **Embedded NUL** (`chunked\0, gzip`) truncating the C-string view | reject NUL / C0-controls (except HT) / DEL in field-values; validate field-name is a token — for **all** headers |
| **VT/FF over-trim** (`chunked\x0b`) via `isspace()` | trim only RFC 7230 OWS (SP/HTAB) |
| **Duplicate `Content-Length`** (CL.CL, last-wins) | reject any duplicate (400), mirroring duplicate-TE |
| **Whitespace before colon** (`Transfer-Encoding : chunked`) | reject (400) per §3.2.4 instead of trimming |
| Empty comma list-elements (`chunked,`, `,chunked`) | reject (400) |

Together with the pre-existing CL+TE-both-orders and duplicate-TE guards, the parser now covers CL.TE / TE.CL / TE.TE / CL.CL / TE-obfuscation / chunked-not-final / control-bytes / OWS-tricks.

## Tests (`test_stress_transfer_encoding_smuggling`)
End-to-end against a live server: the accept path now **verifies de-chunking correctness** (an echo handler asserts decoded `hello` / multi-chunk `foobar` / chunk-extension bytes), plus a large 400 matrix (substring, not-last, repeated, absent, missing/empty commas, leading non-token, non-OWS junk, quoted-comma, control bytes incl. a raw-NUL send, VT/FF, whitespace-before-colon, duplicate CL) and a 501 matrix. `_stress_send_request` now drains the full response.

## Adversarial review
Reviewed by a multi-lens workflow (RFC-conformance, smuggler-desync, C-safety, interop, test-coverage) with per-finding verification across three rounds. C-safety confirmed **zero** memory/UB defects (ASan/UBSan). Each fix has a negative control that fails the corresponding test when reverted.

## Verification
- `-Wall -Wextra -pedantic` (gnu11): zero warnings
- `ctest`: 6/6 (normal + ASan/UBSan)

_"audit 21" refers to the internal working audit (docs/audit/), not a GitHub issue._

🤖 Generated with [Claude Code](https://claude.com/claude-code)