### PR TITLE
Key Host-header enforcement on HTTP version, not keep_alive (audit 20)

### DIFF
--- a/src/http_server.c
+++ b/src/http_server.c
@@ -158,6 +158,10 @@ typedef struct http_parser {
     size_t current_chunk_size;
     size_t current_chunk_received;
     bool keep_alive;
+    bool http_1_1;               /* protocol version is HTTP/1.1 — set once from the
+                                    request line and never mutated by Connection, so
+                                    Host enforcement keys on the version (RFC 7230
+                                    §5.4) rather than on the connection-reuse flag */
     bool seen_host;
     http_status_t error_status;
     const char *error_message;
@@ -1515,9 +1519,11 @@ static int parse_request_line(http_parser_t *parser) {
     }
 
     if (strcmp(version, "HTTP/1.1") == 0) {
-        parser->keep_alive = true;
+        parser->http_1_1 = true;
+        parser->keep_alive = true;       /* HTTP/1.1 default; a Connection header may override */
     } else if (strcmp(version, "HTTP/1.0") == 0) {
-        parser->keep_alive = false;
+        parser->http_1_1 = false;
+        parser->keep_alive = false;      /* HTTP/1.0 default; a Connection header may override */
     } else {
         free(line);
         parser_set_error(parser, HTTP_BAD_REQUEST, "Unsupported HTTP version");
@@ -1887,7 +1893,12 @@ static int parse_headers(http_parser_t *parser) {
 
         if (crlf_index == 0) {
             parser_consume(parser, 2);
-            if (parser->keep_alive && !parser->seen_host) {
+            /* RFC 7230 §5.4: an HTTP/1.1 request MUST include a Host header.
+             * Key this on the protocol VERSION (http_1_1), not keep_alive — the
+             * latter is toggled by the Connection header, which would otherwise
+             * let "HTTP/1.1 + Connection: close" skip the check and force it on
+             * "HTTP/1.0 + Connection: keep-alive". */
+            if (parser->http_1_1 && !parser->seen_host) {
                 parser_set_error(parser, HTTP_BAD_REQUEST, "Missing Host header");
                 return -1;
             }
@@ -2085,6 +2096,7 @@ static void http_parser_reset(http_parser_t *parser, http_request_t *req, bool p
     parser->current_chunk_size = 0;
     parser->current_chunk_received = 0;
     parser->keep_alive = false;
+    parser->http_1_1 = false;
     parser->seen_host = false;
     parser->error_status = 0;
     parser->error_message = NULL;

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -1078,6 +1078,63 @@ void test_stress_request_target_control_bytes(void) {
     PASS();
 }
 
+/* Regression (audit #20): Host-header enforcement (RFC 7230 §5.4) must key on the
+ * HTTP version, not the keep_alive flag (which the Connection header toggles).
+ * Before the fix, "HTTP/1.1 + Connection: close" skipped the mandatory Host
+ * check, and "HTTP/1.0 + Connection: keep-alive" wrongly required it. */
+void test_stress_host_header_enforcement(void) {
+    TEST("Host header enforced by HTTP version, not keep-alive");
+
+    http_server_t *server = http_server_create();
+    ASSERT(server != NULL);
+    router_t *router = router_create();
+    ASSERT(router != NULL);
+    router_add_route(router, HTTP_GET, "/test", dummy_handler);
+    http_server_set_router(server, router);
+
+    uint16_t port = 19012;
+    ASSERT(http_server_listen(server, port) == 0);
+    usleep(200000);
+
+    char response[4096];
+
+    /* HTTP/1.1 + Connection: close, NO Host -> 400. The key regression: the old
+     * code keyed on keep_alive, which Connection: close had toggled off, so this
+     * mandatory check was skipped. */
+    const char *close_no_host =
+        "GET /test HTTP/1.1\r\nConnection: close\r\n\r\n";
+    ASSERT(_stress_send_request(port, close_no_host, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "400") != NULL);
+
+    /* HTTP/1.1 with Host present -> served. */
+    const char *ok_1_1 =
+        "GET /test HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    ASSERT(_stress_send_request(port, ok_1_1, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "200 OK") != NULL);
+
+    /* HTTP/1.0 without Host -> served (1.0 does not require Host). */
+    const char *ok_1_0 =
+        "GET /test HTTP/1.0\r\n\r\n";
+    ASSERT(_stress_send_request(port, ok_1_0, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "200 OK") != NULL);
+    ASSERT(strstr(response, "400") == NULL);
+
+    /* HTTP/1.0 + Connection: keep-alive, NO Host -> still served, NOT 400 (the
+     * old code would have required Host because keep-alive set keep_alive=true).
+     * keep-alive means the server holds the socket open, so the client read just
+     * times out after receiving the 200. */
+    const char *ka_1_0 =
+        "GET /test HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
+    ASSERT(_stress_send_request(port, ka_1_0, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "200 OK") != NULL);
+
+    http_server_stop(server);
+    usleep(100000);
+    router_destroy(router);
+    http_server_destroy(server);
+    PASS();
+}
+
 void test_stress_many_headers(void) {
     TEST("request with many headers (90 headers)");
 
@@ -1586,6 +1643,7 @@ int main(void) {
         test_stress_listen_failure_cleanup();
         test_stress_transfer_encoding_smuggling();
         test_stress_request_target_control_bytes();
+        test_stress_host_header_enforcement();
     }
 
     /* Input Validation Stress Tests */

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -1121,12 +1121,14 @@ void test_stress_host_header_enforcement(void) {
 
     /* HTTP/1.0 + Connection: keep-alive, NO Host -> still served, NOT 400 (the
      * old code would have required Host because keep-alive set keep_alive=true).
-     * keep-alive means the server holds the socket open, so the client read just
-     * times out after receiving the 200. */
+     * The server holds this keep-alive socket open, so a full-size drain would
+     * block until the 2s recv timeout; use a small buffer so _stress_send_request
+     * returns as soon as it fills (the status line + headers exceed 128 bytes). */
     const char *ka_1_0 =
         "GET /test HTTP/1.0\r\nConnection: keep-alive\r\n\r\n";
-    ASSERT(_stress_send_request(port, ka_1_0, response, sizeof(response)) == 0);
-    ASSERT(strstr(response, "200 OK") != NULL);
+    char ka_response[128];
+    ASSERT(_stress_send_request(port, ka_1_0, ka_response, sizeof(ka_response)) == 0);
+    ASSERT(strstr(ka_response, "200 OK") != NULL);
 
     http_server_stop(server);
     usleep(100000);


### PR DESCRIPTION
## Summary

Closes internal audit finding 20 (MEDIUM). RFC 7230 §5.4 requires an HTTP/1.1 request to include a `Host` header. The parser keyed that check on `parser->keep_alive`, but `keep_alive` is toggled by the `Connection` header — so enforcement depended on connection-reuse intent instead of protocol version:

- **`HTTP/1.1` + `Connection: close`** → `keep_alive` false → the mandatory Host check was **skipped**.
- **`HTTP/1.0` + `Connection: keep-alive`** → `keep_alive` true → Host was **wrongly required**.

## Fix
Added a `parser->http_1_1` flag, set once during request-line parsing (true for `HTTP/1.1`, false for `HTTP/1.0`) and **never mutated by the `Connection` header**, and keyed the Host check on it. `keep_alive` keeps its sole responsibility (connection reuse). The flag is zeroed by both `http_parser_init` (memset) and `http_parser_reset`.

## Test
`test_stress_host_header_enforcement`:
- `HTTP/1.1` + `Connection: close`, no Host → **400** (the key regression)
- `HTTP/1.1` + Host → **200**
- `HTTP/1.0`, no Host → **200**
- `HTTP/1.0` + `Connection: keep-alive`, no Host → **200** (not 400)

Negative control (revert to keying on `keep_alive`) fails the first case.

## Verification
- `-Wall -Wextra -pedantic` (gnu11): zero warnings
- `ctest`: 6/6 (normal + ASan/UBSan)

_"audit 20" refers to the internal working audit (docs/audit/), not a GitHub issue._

🤖 Generated with [Claude Code](https://claude.com/claude-code)