### PR TITLE
Reclaim idle session-cookie (max_age==0) sessions to prevent slot exhaustion (audit 26)

### DIFF
--- a/include/kamran.k
+++ b/include/kamran.k
@@ -1212,6 +1212,22 @@ bool session_is_expired(session_t *session);
 int session_cleanup_expired(session_store_t *store);
 
 /**
+ * Set the idle timeout used to reclaim session-cookie (max_age == 0) sessions.
+ *
+ * A session created with max_age == 0 has no absolute expiry, so without an idle
+ * timeout such sessions accumulate and permanently consume the store's fixed slot
+ * pool. By default the store reclaims a session-cookie session that has been idle
+ * (not accessed via session_get / the keyed data API) for 1800 seconds. Pass a
+ * different value to tune it, or <= 0 to disable idle reclamation entirely
+ * (restoring the never-expire behavior). Does not affect max_age > 0 sessions,
+ * which keep their absolute deadline.
+ *
+ * @param store Session store instance
+ * @param seconds Idle timeout in seconds (<= 0 disables idle reclamation)
+ */
+void session_store_set_idle_timeout(session_store_t *store, int seconds);
+
+/**
  * Get session from request (via cookie)
  * @param store Session store instance
  * @param req Request object

--- a/src/session.c
+++ b/src/session.c
@@ -13,6 +13,7 @@
 #define MAX_SESSIONS 1024
 #define SESSION_ID_LENGTH 32
 #define SESSION_COOKIE_NAME "MCWL_SESSION"
+#define SESSION_DEFAULT_IDLE_TIMEOUT 1800  /* 30 min idle reclaim for session cookies */
 
 /* Session data entry */
 typedef struct session_data_entry {
@@ -26,6 +27,8 @@ struct session {
     char session_id[SESSION_ID_LENGTH + 1];
     time_t created_at;
     time_t expires_at;
+    time_t last_accessed;   /* refreshed on every access; drives the idle timeout
+                               for session-cookie (max_age == 0) sessions */
     int max_age;
     session_data_entry_t *data;
     bool in_use;
@@ -35,6 +38,9 @@ struct session {
 struct session_store {
     session_t sessions[MAX_SESSIONS];
     size_t session_count;
+    int idle_timeout;       /* seconds; reclaim a max_age==0 session idle this long
+                               so the fixed slot pool cannot be permanently
+                               exhausted. <=0 disables idle reclamation. */
     pthread_mutex_t lock;
 };
 
@@ -97,7 +103,8 @@ session_store_t *session_store_create(void) {
     }
     
     store->session_count = 0;
-    
+    store->idle_timeout = SESSION_DEFAULT_IDLE_TIMEOUT;
+
     /* Initialize all sessions as unused */
     for (size_t i = 0; i < MAX_SESSIONS; i++) {
         store->sessions[i].in_use = false;
@@ -203,6 +210,7 @@ char *session_create(session_store_t *store, int max_age) {
     }
     
     session->data = NULL;
+    session->last_accessed = session->created_at;
     session->in_use = true;
     store->session_count++;
     
@@ -214,20 +222,41 @@ char *session_create(session_store_t *store, int max_age) {
 }
 
 /* Get session by ID */
+/* Whether an in-use session should be reclaimed, as of `now`. MUST be called
+ * with store->lock held.
+ *
+ * Unlike the public session_is_expired() (which only knows absolute deadlines
+ * and therefore treats a session cookie as immortal), this is store-aware:
+ *   - max_age > 0  -> absolute deadline (created_at + max_age), as before;
+ *   - max_age == 0 -> session cookie: no absolute deadline, but reclaimed once it
+ *     has been idle for store->idle_timeout seconds. Without this a store used in
+ *     session-cookie mode fills its fixed 1024 slots and never self-heals until
+ *     the process restarts — a slot-exhaustion DoS (audit #26). An idle_timeout
+ *     of <= 0 disables idle reclamation (restores the old never-expire behavior).
+ */
+static bool _session_expired_locked(const session_store_t *store,
+                                    const session_t *s, time_t now) {
+    if (s->max_age > 0) {
+        return s->expires_at > 0 && now >= s->expires_at;
+    }
+    return store->idle_timeout > 0 && (now - s->last_accessed) >= store->idle_timeout;
+}
+
 session_t *session_get(session_store_t *store, const char *session_id) {
     if (!store || !session_id) {
         return NULL;
     }
-    
+
     pthread_mutex_lock(&store->lock);
-    
+    time_t now = time(NULL);
+
     /* Find session with matching ID */
     for (size_t i = 0; i < MAX_SESSIONS; i++) {
-        if (store->sessions[i].in_use && 
+        if (store->sessions[i].in_use &&
             strcmp(store->sessions[i].session_id, session_id) == 0) {
-            
+
             /* Check if expired - auto-cleanup to prevent slot exhaustion */
-            if (session_is_expired(&store->sessions[i])) {
+            if (_session_expired_locked(store, &store->sessions[i], now)) {
                 free_session_data(store->sessions[i].data);
                 store->sessions[i].data = NULL;
                 store->sessions[i].in_use = false;
@@ -237,12 +266,13 @@ session_t *session_get(session_store_t *store, const char *session_id) {
                 pthread_mutex_unlock(&store->lock);
                 return NULL;
             }
-            
+
+            store->sessions[i].last_accessed = now;   /* refresh the idle timer */
             pthread_mutex_unlock(&store->lock);
             return &store->sessions[i];
         }
     }
-    
+
     pthread_mutex_unlock(&store->lock);
     return NULL;
 }
@@ -285,10 +315,11 @@ void session_destroy(session_store_t *store, const char *session_id) {
  * differ. No internal pointer is ever returned to the caller. */
 static session_t *find_active_session_locked(session_store_t *store,
                                              const char *session_id) {
+    time_t now = time(NULL);
     for (size_t i = 0; i < MAX_SESSIONS; i++) {
         session_t *s = &store->sessions[i];
         if (s->in_use && strcmp(s->session_id, session_id) == 0) {
-            if (session_is_expired(s)) {
+            if (_session_expired_locked(store, s, now)) {
                 /* Reclaim the expired slot on access — the same lazy cleanup
                  * session_get() performs. Because the keyed data API is now the
                  * primary access path (callers no longer go through
@@ -303,6 +334,7 @@ static session_t *find_active_session_locked(session_store_t *store,
                 }
                 return NULL;
             }
+            s->last_accessed = now;   /* data access refreshes the idle timer */
             return s;
         }
     }
@@ -457,11 +489,12 @@ int session_cleanup_expired(session_store_t *store) {
     }
     
     pthread_mutex_lock(&store->lock);
-    
+    time_t now = time(NULL);
+
     int cleaned = 0;
-    
+
     for (size_t i = 0; i < MAX_SESSIONS; i++) {
-        if (store->sessions[i].in_use && session_is_expired(&store->sessions[i])) {
+        if (store->sessions[i].in_use && _session_expired_locked(store, &store->sessions[i], now)) {
             free_session_data(store->sessions[i].data);
             store->sessions[i].data = NULL;
             store->sessions[i].in_use = false;
@@ -473,8 +506,19 @@ int session_cleanup_expired(session_store_t *store) {
     }
     
     pthread_mutex_unlock(&store->lock);
-    
+
     return cleaned;
+}
+
+/* Configure the idle timeout (seconds) used to reclaim session-cookie
+ * (max_age == 0) sessions. <= 0 disables idle reclamation. */
+void session_store_set_idle_timeout(session_store_t *store, int seconds) {
+    if (!store) {
+        return;
+    }
+    pthread_mutex_lock(&store->lock);
+    store->idle_timeout = seconds;
+    pthread_mutex_unlock(&store->lock);
 }
 
 /* Parse cookie header to extract session ID */

--- a/src/session.c
+++ b/src/session.c
@@ -239,7 +239,13 @@ static bool _session_expired_locked(const session_store_t *store,
     if (s->max_age > 0) {
         return s->expires_at > 0 && now >= s->expires_at;
     }
-    return store->idle_timeout > 0 && (now - s->last_accessed) >= store->idle_timeout;
+    /* Guard `now > last_accessed` before subtracting: if the wall clock moved
+     * backwards (or time_t is unsigned) the difference could otherwise underflow
+     * and reclaim a fresh session. When now <= last_accessed the session is by
+     * definition not idle, so it is kept. */
+    return store->idle_timeout > 0 &&
+           now > s->last_accessed &&
+           (now - s->last_accessed) >= (time_t)store->idle_timeout;
 }
 
 session_t *session_get(session_store_t *store, const char *session_id) {

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1450,6 +1450,41 @@ void test_session_keyed_access_reclaims_expired(void) {
     PASS();
 }
 
+/* Regression (audit #26): a session-cookie (max_age == 0) has no absolute expiry,
+ * so without an idle timeout it permanently consumes a fixed slot (slot-exhaustion
+ * DoS). It must now be reclaimed after the configurable idle timeout, while a
+ * timeout of <= 0 preserves the old never-expire behavior. */
+void test_session_cookie_idle_timeout(void) {
+    TEST("session-cookie (max_age=0) idle-timeout reclamation");
+
+    session_store_t *store = session_store_create();
+    ASSERT(store != NULL);
+
+    /* Idle reclamation: an untouched session cookie is reclaimed after the idle
+     * window (before the fix, max_age==0 never expired -> cleanup returned 0). */
+    char *sid = session_create(store, 0);
+    ASSERT(sid != NULL);
+    session_store_set_idle_timeout(store, 1);
+    ASSERT(session_get(store, sid) != NULL);        /* alive now */
+    sleep(2);                                        /* idle past the 1s window */
+    ASSERT(session_cleanup_expired(store) == 1);     /* reclaimed */
+    ASSERT(session_get(store, sid) == NULL);
+    free(sid);
+
+    /* idle_timeout <= 0 disables idle reclamation (never-expire preserved). */
+    session_store_set_idle_timeout(store, 0);
+    char *sid2 = session_create(store, 0);
+    ASSERT(sid2 != NULL);
+    sleep(2);
+    ASSERT(session_cleanup_expired(store) == 0);     /* not reclaimed */
+    ASSERT(session_get(store, sid2) != NULL);
+    free(sid2);
+
+    session_store_destroy(store);
+
+    PASS();
+}
+
 /* Test session destroy */
 void test_session_destroy_session(void) {
     TEST("session (destroy session)");
@@ -4670,6 +4705,7 @@ int main(void) {
     test_session_get_data_owned_copy();
     test_session_data_ops_on_dead_session();
     test_session_keyed_access_reclaims_expired();
+    test_session_cookie_idle_timeout();
     test_session_destroy_session();
     test_session_expiration();
     test_session_cleanup();

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1460,12 +1460,13 @@ void test_session_cookie_idle_timeout(void) {
     session_store_t *store = session_store_create();
     ASSERT(store != NULL);
 
-    /* Idle reclamation: an untouched session cookie is reclaimed after the idle
-     * window (before the fix, max_age==0 never expired -> cleanup returned 0). */
+    /* Idle reclamation: a session cookie left idle past the timeout (measured
+     * from its last access, the session_get below) is reclaimed. Before the fix,
+     * max_age==0 never expired -> cleanup returned 0. */
     char *sid = session_create(store, 0);
     ASSERT(sid != NULL);
     session_store_set_idle_timeout(store, 1);
-    ASSERT(session_get(store, sid) != NULL);        /* alive now */
+    ASSERT(session_get(store, sid) != NULL);        /* alive now; refreshes last_accessed */
     sleep(2);                                        /* idle past the 1s window */
     ASSERT(session_cleanup_expired(store) == 1);     /* reclaimed */
     ASSERT(session_get(store, sid) == NULL);


### PR DESCRIPTION
## Summary

Closes internal audit finding 26 (MEDIUM). A session created with `max_age == 0` (a "session cookie") has no absolute expiry, and `session_is_expired()` returns `false` for it unconditionally — so it is **never reclaimed**. A store used in session-cookie mode fills its fixed 1024 slots and, unlike `max_age > 0` sessions, **never self-heals** until the process restarts: a slot-exhaustion DoS (an attacker auto-creating cookieless sessions fills the store in ~1024 requests).

## Fix — server-side idle timeout (standard practice)
- **`struct session`** gains `last_accessed`, refreshed on every access (`session_get` and the keyed data API via `find_active_session_locked`).
- **`struct session_store`** gains `idle_timeout` (default **1800s**), settable via the new **`session_store_set_idle_timeout()`**; `<= 0` disables idle reclamation (restores the old never-expire behavior).
- A store-aware **`_session_expired_locked()`** computes reclaimability — absolute deadline for `max_age > 0` (unchanged), idle-based for `max_age == 0` — and replaces the `session_is_expired()` calls in `session_get`, `find_active_session_locked`, and `session_cleanup_expired`. Idle session cookies are thus reclaimed both lazily on access and by the periodic sweep.
- The public `session_is_expired()` (a handle metadata query with no store reference) is unchanged.

### Behavior change
`max_age == 0` sessions now expire after 30 min idle by default instead of never. This is standard web-session behavior and is fully configurable (set the idle timeout, or `<= 0` to opt out). `max_age > 0` sessions are unaffected.

## Test
`test_session_cookie_idle_timeout` sets a 1s idle timeout, confirms an idle session cookie is reclaimed (cleanup returns 1, lookup returns NULL), and confirms `idle_timeout <= 0` preserves never-expire. Existing session tests are unaffected (they check immediately after creation). Negative control (revert the `max_age==0` branch to never-expire) fails the reclamation assertion.

## Verification
- `-Wall -Wextra -pedantic` (gnu11): zero warnings
- `ctest`: 6/6 (normal + ASan/UBSan)

_"audit 26" refers to the internal working audit (docs/audit/), not a GitHub issue._

🤖 Generated with [Claude Code](https://claude.com/claude-code)