### PR TITLE
Canonicalize request path at ingest to stop empty-segment route aliasing (audit 19)

### DIFF
--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1419,6 +1419,38 @@ static bool assign_http_method(http_request_t *req, const char *method) {
     return false;
 }
 
+/* Canonicalize a request path in place: collapse runs of '/' into a single '/'
+ * and strip a single trailing '/' (except for the root "/"). This is done once
+ * at ingest so the router — and every handler that reads req->path — sees one
+ * canonical form. Without it, "/a//b", "/a/b/", and "//a//b//" reach the router
+ * as distinct strings, and because :param matching tokenizes on '/' (dropping
+ * empty segments) while literal matching uses strcmp, those variants alias onto
+ * a :param route yet not onto a literal route — an inconsistency and a
+ * path-confusion / ACL-or-cache-key divergence class (audit #19). The result is
+ * never longer than the input, so the in-place rewrite is safe. */
+static void normalize_path(char *path) {
+    if (!path) {
+        return;
+    }
+    const char *r = path;
+    char *w = path;
+    while (*r) {
+        if (*r == '/') {
+            *w++ = '/';
+            while (*r == '/') {
+                r++;               /* skip the rest of the slash run */
+            }
+        } else {
+            *w++ = *r++;
+        }
+    }
+    *w = '\0';
+    size_t len = (size_t)(w - path);
+    if (len > 1 && path[len - 1] == '/') {
+        path[len - 1] = '\0';      /* strip a single trailing slash, keep root "/" */
+    }
+}
+
 static int parse_request_line(http_parser_t *parser) {
     ssize_t crlf_index = find_crlf(parser->buffer, parser->buffer_len);
     if (crlf_index < 0) {
@@ -1517,6 +1549,9 @@ static int parse_request_line(http_parser_t *parser) {
         parser_set_error(parser, HTTP_INTERNAL_ERROR, "Out of memory");
         return -1;
     }
+    /* Canonicalize before routing so //, trailing slashes, etc. cannot alias
+     * distinct wire paths onto one route (audit #19). */
+    normalize_path(parser->req->path);
 
     if (strcmp(version, "HTTP/1.1") == 0) {
         parser->http_1_1 = true;

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -1184,10 +1184,15 @@ void test_stress_path_normalization(void) {
                  cases[i].req_path);
         ASSERT(_stress_send_request(port, req, response, sizeof(response)) == 0);
         ASSERT(strstr(response, "200 OK") != NULL);
-        ASSERT(strstr(response, cases[i].canonical) != NULL);  /* echoed canonical path */
+        /* The response body is the echoed req->path; assert it equals the
+         * canonical form exactly (Connection: close, so nothing trails it). */
+        char *body = strstr(response, "\r\n\r\n");
+        ASSERT(body != NULL);
+        ASSERT(strcmp(body + 4, cases[i].canonical) == 0);
     }
 
-    /* Root "/" and its all-slash forms collapse to "/" and hit the root handler. */
+    /* Root "/" and its all-slash forms collapse to "/" and hit the root handler,
+     * and the handler must see exactly "/". */
     const char *roots[] = { "/", "//", "///", NULL };
     for (int i = 0; roots[i] != NULL; i++) {
         char req[256];
@@ -1195,6 +1200,9 @@ void test_stress_path_normalization(void) {
                  "GET %s HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n", roots[i]);
         ASSERT(_stress_send_request(port, req, response, sizeof(response)) == 0);
         ASSERT(strstr(response, "200 OK") != NULL);
+        char *body = strstr(response, "\r\n\r\n");
+        ASSERT(body != NULL);
+        ASSERT(strcmp(body + 4, "/") == 0);
     }
 
     /* Normalization must not over-match: an unregistered path still 404s. */

--- a/tests/test_stress.c
+++ b/tests/test_stress.c
@@ -1137,6 +1137,79 @@ void test_stress_host_header_enforcement(void) {
     PASS();
 }
 
+/* Echoes req->path so a test can verify the path the router/handler actually saw. */
+static void _echo_path_handler(http_request_t *req, http_response_t *res) {
+    http_response_send_text(res, HTTP_OK, req->path ? req->path : "");
+}
+
+/* Regression (audit #19): the request path must be canonicalized (collapse '//',
+ * strip trailing '/') before routing, so distinct wire forms cannot alias — and
+ * so literal (strcmp) and :param (segment) routes behave consistently. */
+void test_stress_path_normalization(void) {
+    TEST("request path is canonicalized before routing");
+
+    http_server_t *server = http_server_create();
+    ASSERT(server != NULL);
+    router_t *router = router_create();
+    ASSERT(router != NULL);
+    router_add_route(router, HTTP_GET, "/a/b", _echo_path_handler);    /* literal */
+    router_add_route(router, HTTP_GET, "/p/:id", _echo_path_handler);  /* :param  */
+    router_add_route(router, HTTP_GET, "/", _echo_path_handler);       /* root    */
+    http_server_set_router(server, router);
+
+    uint16_t port = 19013;
+    ASSERT(http_server_listen(server, port) == 0);
+    usleep(200000);
+
+    char response[4096];
+
+    /* Each weird form canonicalizes, routes to the same handler, and the handler
+     * sees the canonical path (echoed in the body). Without normalization the
+     * literal route's strcmp would 404 the '//' and trailing-slash forms. */
+    struct { const char *req_path; const char *canonical; } cases[] = {
+        { "/a/b",     "/a/b" },
+        { "/a//b",    "/a/b" },
+        { "//a//b",   "/a/b" },
+        { "/a/b/",    "/a/b" },
+        { "//a//b//", "/a/b" },
+        { "/a///b/",  "/a/b" },
+        { "/p/9",     "/p/9" },   /* :param route */
+        { "/p//9/",   "/p/9" },   /* :param, weird -> canonical */
+        { NULL, NULL }
+    };
+    for (int i = 0; cases[i].req_path != NULL; i++) {
+        char req[256];
+        snprintf(req, sizeof(req),
+                 "GET %s HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+                 cases[i].req_path);
+        ASSERT(_stress_send_request(port, req, response, sizeof(response)) == 0);
+        ASSERT(strstr(response, "200 OK") != NULL);
+        ASSERT(strstr(response, cases[i].canonical) != NULL);  /* echoed canonical path */
+    }
+
+    /* Root "/" and its all-slash forms collapse to "/" and hit the root handler. */
+    const char *roots[] = { "/", "//", "///", NULL };
+    for (int i = 0; roots[i] != NULL; i++) {
+        char req[256];
+        snprintf(req, sizeof(req),
+                 "GET %s HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n", roots[i]);
+        ASSERT(_stress_send_request(port, req, response, sizeof(response)) == 0);
+        ASSERT(strstr(response, "200 OK") != NULL);
+    }
+
+    /* Normalization must not over-match: an unregistered path still 404s. */
+    const char *miss =
+        "GET /a/b/extra HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    ASSERT(_stress_send_request(port, miss, response, sizeof(response)) == 0);
+    ASSERT(strstr(response, "404") != NULL);
+
+    http_server_stop(server);
+    usleep(100000);
+    router_destroy(router);
+    http_server_destroy(server);
+    PASS();
+}
+
 void test_stress_many_headers(void) {
     TEST("request with many headers (90 headers)");
 
@@ -1646,6 +1719,7 @@ int main(void) {
         test_stress_transfer_encoding_smuggling();
         test_stress_request_target_control_bytes();
         test_stress_host_header_enforcement();
+        test_stress_path_normalization();
     }
 
     /* Input Validation Stress Tests */


### PR DESCRIPTION
## Summary

Closes internal audit finding 19 (MEDIUM, path confusion). `req->path` reached the router verbatim, and the two matchers disagreed on non-canonical paths:
- **`:param` routes** tokenize on `/` with `strtok_r`, which drops empty segments → `/a//b`, `/a/b/`, `//a//b//` match **loosely**.
- **literal routes** use `strcmp` → **strict**.

So `/users//123`, `/users/123/`, `//users//123//` all aliased onto `/users/:id`, yet a literal `/users/list/` did **not** match `/users/list`. That's an inconsistency and a path-confusion / ACL-or-cache-key divergence class: a front-end keying an ACL or cache on the raw path can disagree with how this origin routes it.

## Fix — canonicalize at the trust boundary
`normalize_path()` collapses runs of `/` into one and strips a single trailing `/` (except root `/`), applied to `req->path` **once** in `parse_request_line` right after it's set. The router — and every handler/middleware reading `req->path` — now sees one canonical form, so literal and `:param` routes behave consistently and the weird forms can't alias. The in-place rewrite is safe (output ≤ input length).

Scope notes: percent-encoded slashes (`%2F`) are untouched (no path-decoding happens), and `..` is still handled by the static-file middleware's realpath-based traversal check — this change is complementary.

## Test
`test_stress_path_normalization` drives literal, `:param`, and root routes with `//`, trailing-slash, and leading-slash variants; asserts each routes correctly **and** that the handler sees the canonical path (echoed in the body); and that an unregistered path still 404s. Negative control (disable the normalize call) fails the `//` cases (literal `strcmp` 404s them).

## Verification
- `-Wall -Wextra -pedantic` (gnu11): zero warnings
- `ctest`: 6/6 (normal + ASan/UBSan)

_"audit 19" refers to the internal working audit (docs/audit/), not a GitHub issue._

🤖 Generated with [Claude Code](https://claude.com/claude-code)