### PR TITLE
Reject control chars / whitespace in input_validate_email (audit 29)

### DIFF
--- a/src/input_validation.c
+++ b/src/input_validation.c
@@ -61,6 +61,18 @@ bool input_validate_integer(const char *str, long long min_val, long long max_va
 bool input_validate_email(const char *str) {
     if (str == NULL || str[0] == '\0') return false;
 
+    /* Reject control characters (incl. CR/LF and HTAB), DEL, and spaces anywhere
+     * in the address. A raw CR/LF or other control byte in a value that a caller
+     * later places into an email header, a log line, or another protocol field
+     * is a header/log-injection primitive (CRLF injection) — and no legitimate
+     * addr-spec contains these unquoted. High bytes (0x80-0xFF) are left alone so
+     * internationalized (EAI/UTF-8) local/domain parts still validate. */
+    for (const unsigned char *p = (const unsigned char *)str; *p != '\0'; p++) {
+        if (*p < 0x20 || *p == 0x7f || *p == ' ') {
+            return false;
+        }
+    }
+
     /* Find '@' */
     const char *at = strchr(str, '@');
     if (at == NULL) return false;       /* no '@' */

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -2755,6 +2755,16 @@ void test_input_validate_email(void) {
     ASSERT(input_validate_email("")                     == false);
     ASSERT(input_validate_email(NULL)                   == false);
 
+    /* Control characters / whitespace must be rejected (header/log injection). */
+    ASSERT(input_validate_email("user@example.com\r\nBcc: evil@x.com") == false); /* CRLF injection */
+    ASSERT(input_validate_email("user\r@example.com")   == false); /* bare CR */
+    ASSERT(input_validate_email("user\n@example.com")   == false); /* bare LF */
+    ASSERT(input_validate_email("user\t@example.com")   == false); /* HTAB */
+    ASSERT(input_validate_email("user @example.com")    == false); /* space */
+    ASSERT(input_validate_email("user@exa mple.com")    == false); /* interior space */
+    ASSERT(input_validate_email("user@example.com\x01") == false); /* C0 control */
+    ASSERT(input_validate_email("user@example.com\x7f") == false); /* DEL */
+
     PASS();
 }
 


### PR DESCRIPTION
## Summary

Closes internal audit finding 29 (email-validation CRLF/log injection). `input_validate_email()` validated only structure (an `@`, a domain `.`, a single `@`) and accepted **embedded control characters** — so `user@example.com\r\nBcc: evil@x.com` and `user\r@example.com` both validated `true`. When a caller places such an "address" into an email header, a log line, or another protocol field, the embedded CR/LF is a header/log-injection (CRLF injection) primitive.

## Fix
Reject any byte `< 0x20` (C0 controls incl. CR/LF/HTAB), `0x7F` (DEL), or space anywhere in the address — no legitimate unquoted addr-spec contains these. High bytes (`0x80-0xFF`) are intentionally left alone so internationalized (EAI/UTF-8) local/domain parts still validate. Same "reject control bytes at the boundary" class as the header-value and request-target validation.

## Test
`test_input_validate_email` gains CRLF / bare-CR / bare-LF / HTAB / space / C0 / DEL vectors (all → `false`); the existing valid cases still pass. Negative control (disable the scan) fails the bare-CR case.

## Verification
- `-Wall -Wextra -pedantic` (gnu11): zero warnings
- `ctest`: 6/6 (normal + ASan/UBSan)

_"audit 29" refers to the internal working audit (docs/audit/), not a GitHub issue._

🤖 Generated with [Claude Code](https://claude.com/claude-code)