### PR TITLE
Fix /healthz emitting two conflicting Content-Type headers (audit 34)

### DIFF
--- a/src/health_check.c
+++ b/src/health_check.c
@@ -50,8 +50,18 @@ void health_check_handler(http_request_t *req, http_response_t *res) {
         return;
     }
 
-    http_response_set_header(res, "Content-Type", "application/json");
+    /* Send the body first (http_response_send_text appends a text/plain
+     * Content-Type with replace_existing=false), THEN set the JSON Content-Type:
+     * http_response_set_header replaces the existing node, yielding a single
+     * `Content-Type: application/json`. Doing it the other way round emitted two
+     * conflicting Content-Type headers (audit #34). */
+    /* Send the body first (http_response_send_text appends a text/plain
+     * Content-Type with replace_existing=false), THEN set the JSON Content-Type:
+     * http_response_set_header replaces the existing node, yielding a single
+     * `Content-Type: application/json`. Doing it the other way round emitted two
+     * conflicting Content-Type headers (audit #34). */
     http_response_send_text(res, HTTP_OK, body);
+    http_response_set_header(res, "Content-Type", "application/json");
     free(body);
 }
 

--- a/src/health_check.c
+++ b/src/health_check.c
@@ -55,11 +55,6 @@ void health_check_handler(http_request_t *req, http_response_t *res) {
      * http_response_set_header replaces the existing node, yielding a single
      * `Content-Type: application/json`. Doing it the other way round emitted two
      * conflicting Content-Type headers (audit #34). */
-    /* Send the body first (http_response_send_text appends a text/plain
-     * Content-Type with replace_existing=false), THEN set the JSON Content-Type:
-     * http_response_set_header replaces the existing node, yielding a single
-     * `Content-Type: application/json`. Doing it the other way round emitted two
-     * conflicting Content-Type headers (audit #34). */
     http_response_send_text(res, HTTP_OK, body);
     http_response_set_header(res, "Content-Type", "application/json");
     free(body);

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -3186,9 +3186,12 @@ void test_health_check_endpoint(void) {
     ASSERT(strstr(buf, "\"status\"") != NULL);
     ASSERT(strstr(buf, "\"ok\"") != NULL);
     ASSERT(strstr(buf, "\"uptime_seconds\"") != NULL);
-    /* Exactly one Content-Type: application/json — not a second, conflicting
-     * text/plain from send_text (audit #34). */
-    ASSERT(strstr(buf, "application/json") != NULL);
+    /* Exactly one Content-Type header, application/json — not a second,
+     * conflicting or duplicate Content-Type from send_text (audit #34). */
+    const char *ct = strstr(buf, "Content-Type:");
+    ASSERT(ct != NULL);
+    ASSERT(strstr(ct, "application/json") != NULL);
+    ASSERT(strstr(ct + 1, "\r\nContent-Type:") == NULL); /* no duplicate header line */
     ASSERT(strstr(buf, "text/plain") == NULL);
 
     http_server_stop(server);

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -3186,6 +3186,10 @@ void test_health_check_endpoint(void) {
     ASSERT(strstr(buf, "\"status\"") != NULL);
     ASSERT(strstr(buf, "\"ok\"") != NULL);
     ASSERT(strstr(buf, "\"uptime_seconds\"") != NULL);
+    /* Exactly one Content-Type: application/json — not a second, conflicting
+     * text/plain from send_text (audit #34). */
+    ASSERT(strstr(buf, "application/json") != NULL);
+    ASSERT(strstr(buf, "text/plain") == NULL);
 
     http_server_stop(server);
     http_server_destroy(server);


### PR DESCRIPTION
## Summary

Closes internal audit finding 34. `health_check_handler` set `Content-Type: application/json` **before** calling `http_response_send_text`, which appends its own `Content-Type: text/plain` (with `replace_existing=false`). The response therefore carried **two conflicting `Content-Type` headers** — invalid per RFC 7230 for a non-list header, and strict clients/proxies may reject it or read the body as `text/plain`.

## Fix
Reorder: send the body first, then set the JSON `Content-Type`. Since `http_response_set_header` uses `replace_existing=true`, it overwrites the `text/plain` node that `send_text` appended, leaving a single `Content-Type: application/json`.

## Test
`test_health_check_endpoint` now asserts the response contains `application/json` and does **not** contain `text/plain`. Negative control (the old order) fails on the `text/plain`-absent assertion.

## Verification
- `-Wall -Wextra -pedantic` (gnu11): zero warnings
- `ctest`: 6/6 (normal + ASan/UBSan)

_"audit 34" refers to the internal working audit (docs/audit/), not a GitHub issue._

🤖 Generated with [Claude Code](https://claude.com/claude-code)