### PR TITLE
Harden JWT verification: exact alg parse, nbf, optional require_exp (audit #32)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -290,7 +290,8 @@ apikey_auth_middleware_destroy();
 jwt_auth_config_t config = {
     .secret = "my-secret-key",
     .secret_len = 13,
-    .header_name = NULL  // Defaults to "Authorization"
+    .header_name = NULL,  // Defaults to "Authorization"
+    .require_exp = false  // Set true to reject tokens that carry no "exp" claim
 };
 
 middleware_fn_t mw = jwt_auth_middleware_create(&config);
@@ -298,6 +299,12 @@ router_use_middleware(router, mw);
 // ...
 jwt_auth_middleware_destroy();
 ```
+
+The verifier accepts **only** `alg: "HS256"` (the header's `alg` field is parsed and
+compared exactly — not substring-matched) and validates the time claims when present:
+an expired `exp` or a not-yet-valid `nbf` is rejected. `exp` is OPTIONAL by default
+(RFC 7519); set `require_exp = true` so a token lacking `exp` is refused, preventing a
+leaked exp-less token from replaying indefinitely.
 
 ---
 

--- a/include/kamran.k
+++ b/include/kamran.k
@@ -1339,6 +1339,9 @@ typedef struct jwt_auth_config {
     const char *secret;          /* HMAC-SHA256 secret key */
     size_t secret_len;           /* Secret key length */
     const char *header_name;     /* Header name (default: "Authorization") */
+    bool require_exp;            /* if true, reject a token that has no exp claim
+                                    (default false — exp remains optional per
+                                    RFC 7519, but strict callers can require it) */
 } jwt_auth_config_t;
 
 /**

--- a/src/middleware_auth.c
+++ b/src/middleware_auth.c
@@ -709,6 +709,24 @@ void apikey_auth_middleware_destroy(void)
 
 static jwt_auth_config_t *g_jwt_auth_config = NULL;
 
+/* Advance *pp past optional whitespace, exactly one ':' name/value separator, and
+ * more optional whitespace — i.e. to the first byte of a JSON member's value.
+ * Requiring precisely one colon keeps this a real structural parse: a member with
+ * no separator ({"alg""HS256"}) or a repeated one ({"alg":::"HS256"}) is malformed
+ * JSON and is rejected rather than leniently accepted. Returns false if the single
+ * required colon is absent. */
+static bool json_skip_to_value(const char **pp) {
+    const char *v = *pp;
+    while (*v == ' ' || *v == '\t' || *v == '\n' || *v == '\r') v++;
+    if (*v != ':') {
+        return false;                 /* missing name:value separator */
+    }
+    v++;
+    while (*v == ' ' || *v == '\t' || *v == '\n' || *v == '\r') v++;
+    *pp = v;
+    return true;
+}
+
 /* Return true only if the JWT header's "alg" parameter is exactly the string
  * "HS256". A PARSED check (find the "alg" key, read its quoted value) rather than
  * a substring match: HMAC-SHA256 is the only algorithm this verifier supports,
@@ -731,8 +749,8 @@ static bool jwt_header_alg_is_hs256(const char *header_json) {
         return false;                 /* no alg header -> reject */
     }
     const char *v = key + 5;          /* past the "alg" key token */
-    while (*v == ' ' || *v == '\t' || *v == '\n' || *v == '\r' || *v == ':') {
-        v++;
+    if (!json_skip_to_value(&v)) {
+        return false;                 /* malformed: no name:value separator */
     }
     if (*v != '"') {
         return false;                 /* alg value must be a JSON string */
@@ -761,8 +779,8 @@ static bool jwt_claim_int(const char *payload_json, const char *key, long *out) 
         return false;
     }
     const char *v = found + keylen;
-    while (*v == ' ' || *v == ':' || *v == '\t' || *v == '\n' || *v == '\r') {
-        v++;
+    if (!json_skip_to_value(&v)) {
+        return false;                 /* malformed: no key:value separator */
     }
     char *endptr = NULL;
     long val = strtol(v, &endptr, 10);

--- a/src/middleware_auth.c
+++ b/src/middleware_auth.c
@@ -709,6 +709,70 @@ void apikey_auth_middleware_destroy(void)
 
 static jwt_auth_config_t *g_jwt_auth_config = NULL;
 
+/* Return true only if the JWT header's "alg" parameter is exactly the string
+ * "HS256". A PARSED check (find the "alg" key, read its quoted value) rather than
+ * a substring match: HMAC-SHA256 is the only algorithm this verifier supports,
+ * and parsing the field — instead of accepting any header that merely contains
+ * the text "HS256" — forecloses alg-confusion should other algorithms ever be
+ * added. Rejects a missing alg, a non-string alg, or any value other than
+ * "HS256". */
+static bool jwt_header_alg_is_hs256(const char *header_json) {
+    const char *p = header_json;
+    const char *key = NULL;
+    while ((p = strstr(p, "\"alg\"")) != NULL) {
+        if (p == header_json || p[-1] == '{' || p[-1] == ',' ||
+            p[-1] == ' ' || p[-1] == '\t' || p[-1] == '\n' || p[-1] == '\r') {
+            key = p;
+            break;
+        }
+        p += 5;
+    }
+    if (!key) {
+        return false;                 /* no alg header -> reject */
+    }
+    const char *v = key + 5;          /* past the "alg" key token */
+    while (*v == ' ' || *v == '\t' || *v == '\n' || *v == '\r' || *v == ':') {
+        v++;
+    }
+    if (*v != '"') {
+        return false;                 /* alg value must be a JSON string */
+    }
+    v++;
+    return strncmp(v, "HS256", 5) == 0 && v[5] == '"';
+}
+
+/* Look up a base-10 integer JSON claim (e.g. `key` == "\"exp\"") in the flat JWT
+ * payload. Matches only a real key — one preceded by '{', ',' or whitespace, not
+ * a substring inside some string value. Returns true and sets *out when found
+ * with a numeric value. */
+static bool jwt_claim_int(const char *payload_json, const char *key, long *out) {
+    size_t keylen = strlen(key);
+    const char *p = payload_json;
+    const char *found = NULL;
+    while ((p = strstr(p, key)) != NULL) {
+        if (p == payload_json || p[-1] == '{' || p[-1] == ',' ||
+            p[-1] == ' ' || p[-1] == '\t' || p[-1] == '\n' || p[-1] == '\r') {
+            found = p;
+            break;
+        }
+        p += keylen;
+    }
+    if (!found) {
+        return false;
+    }
+    const char *v = found + keylen;
+    while (*v == ' ' || *v == ':' || *v == '\t' || *v == '\n' || *v == '\r') {
+        v++;
+    }
+    char *endptr = NULL;
+    long val = strtol(v, &endptr, 10);
+    if (endptr == v) {
+        return false;                 /* non-numeric value */
+    }
+    *out = val;
+    return true;
+}
+
 /**
  * parse_jwt_token - Parse and verify JWT token
  * @token: JWT token string
@@ -721,6 +785,7 @@ static jwt_auth_config_t *g_jwt_auth_config = NULL;
  */
 static bool parse_jwt_token(const char *token,
                            const uint8_t *secret, size_t secret_len,
+                           bool require_exp,
                            char *payload_out, size_t payload_size)
 {
     const char *dot1, *dot2;
@@ -756,8 +821,9 @@ static bool parse_jwt_token(const char *token,
     }
     header_decoded[decoded_len] = '\0';
 
-    /* Verify algorithm is HS256 */
-    if (!strstr((char *)header_decoded, "\"HS256\"")) {
+    /* Verify the algorithm is exactly HS256 (a parsed field check, not a
+     * substring match on the decoded header). */
+    if (!jwt_header_alg_is_hs256((char *)header_decoded)) {
         goto cleanup; /* Only HS256 supported */
     }
 
@@ -798,38 +864,27 @@ static bool parse_jwt_token(const char *token,
         goto cleanup;
     }
 
-    /* Validate expiration claim if present.
-     * Parse properly: find "exp" key as a JSON key (preceded by quote),
-     * not just any occurrence of "exp" in a string value. */
+    /* Validate the time-based claims. exp/nbf are matched as real JSON keys, not
+     * substrings of a string value (jwt_claim_int). */
     {
-        const char *search = (const char *)payload_decoded;
-        const char *exp_str = NULL;
-        while ((search = strstr(search, "\"exp\"")) != NULL) {
-            /* Verify this is a key: check that the character before the opening
-             * quote is either '{', ',' or whitespace (not inside a string value) */
-            if (search == (const char *)payload_decoded || 
-                search[-1] == '{' || search[-1] == ',' || 
-                search[-1] == ' ' || search[-1] == '\t' ||
-                search[-1] == '\n' || search[-1] == '\r') {
-                exp_str = search;
-                break;
-            }
-            search += 5;
+        time_t now = time(NULL);
+        long exp_val = 0, nbf_val = 0;
+        bool have_exp = jwt_claim_int((const char *)payload_decoded, "\"exp\"", &exp_val);
+
+        /* exp: reject an expired token. */
+        if (have_exp && exp_val > 0 && (time_t)exp_val < now) {
+            goto cleanup; /* Token expired */
         }
-        if (exp_str) {
-            /* Skip to the value: past "exp" and any whitespace/colon */
-            exp_str += 5; /* skip "exp"" */
-            while (*exp_str == ' ' || *exp_str == ':' || *exp_str == '\t') {
-                exp_str++;
-            }
-            char *endptr = NULL;
-            long exp_val = strtol(exp_str, &endptr, 10);
-            if (endptr != exp_str && exp_val > 0) {
-                time_t now = time(NULL);
-                if ((time_t)exp_val < now) {
-                    goto cleanup; /* Token expired */
-                }
-            }
+        /* Optionally require exp to be present at all (RFC 7519 leaves it OPTIONAL;
+         * strict callers can opt in so a leaked exp-less token can't replay
+         * forever). */
+        if (require_exp && !have_exp) {
+            goto cleanup; /* exp claim required but absent */
+        }
+        /* nbf: reject a token that is not yet valid. */
+        if (jwt_claim_int((const char *)payload_decoded, "\"nbf\"", &nbf_val) &&
+            nbf_val > 0 && now < (time_t)nbf_val) {
+            goto cleanup; /* Token not yet valid */
         }
     }
 
@@ -888,6 +943,7 @@ static bool jwt_auth_handler(http_request_t *req, http_response_t *res, void *us
     if (!parse_jwt_token(token,
                         (const uint8_t *)config->secret,
                         config->secret_len,
+                        config->require_exp,
                         payload, sizeof(payload))) {
         goto unauthorized;
     }

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1864,6 +1864,85 @@ void test_jwt_auth_create_destroy(void) {
     PASS();
 }
 
+/* HS256 JWTs signed with JWT_TEST_SECRET (generated offline via HMAC-SHA256 over
+ * the exact base64url `header.payload`). Header/payload are chosen to exercise the
+ * alg/exp/nbf hardening in parse_jwt_token() — audit finding #32. Every token below
+ * carries a *valid* HMAC-SHA256 signature, so each assertion isolates one claim
+ * check rather than a signature mismatch. */
+#define JWT_TEST_SECRET "test-jwt-secret-0123456789"
+#define JWT_VALID_EXP    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5fQ.1S-DqJFMD1KXliurgo-QhUSDn3ALevStVN384iHy36A"
+#define JWT_NO_EXP       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1In0.6RGrNIPesWnxkwWH5JlP_fH7INktz6XGM6vEySxWah0"
+#define JWT_EXPIRED      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjoxfQ.8NjcsSJ7rP8HTHu01MltkchCtgiaoMYgsVipujwY6Zc"
+#define JWT_FUTURE_NBF   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5LCJuYmYiOjk5OTk5OTk5OTl9.Z0TIpqNNWC3jwaS__rghJIYYaGYibq39l7gXeDwciuo"
+#define JWT_ALG_HS384    "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5fQ.kUv6SgP8oAsgTUZj5bvK7QB3FCTxE5SRsZwuLJsCifA"
+#define JWT_ALG_NONE     "eyJhbGciOiJub25lIiwibm90ZSI6IkhTMjU2In0.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5fQ.hRfopXAWpAFoPocoGWBNyugSqvpmQqToBhzha-qWHNQ"
+/* Identical header.payload to JWT_VALID_EXP but signed with a DIFFERENT secret,
+ * so only the HMAC signature differs — isolates the signature-verification gate. */
+#define JWT_BAD_SIG      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5fQ.VPFqsu6N89mLUKTsD4tXMRStoLRZw2zavoNy58X1YT4"
+
+/* Run the JWT middleware over a request carrying `Authorization: Bearer <token>`
+ * and return whether it authorized the request (true) or rejected it (false/401). */
+static bool _jwt_authorizes(middleware_fn_t mw, const char *token) {
+    http_request_t req = {0};
+    http_response_t res = {0};
+    char auth[1024];
+    snprintf(auth, sizeof(auth), "Bearer %s", token);
+    _test_add_header(&req.headers, "authorization", auth);
+
+    bool ok = mw(&req, &res, NULL);
+
+    _test_free_header_list(req.headers);
+    _test_free_header_list(res.headers);   /* 401 path sets WWW-Authenticate */
+    free(res.body);                        /* 401 path sets a body; NULL on success */
+    return ok;
+}
+
+/* Test auth middleware - JWT verification (alg/exp/nbf hardening, audit #32) */
+void test_jwt_auth_verify(void) {
+    TEST("jwt_auth (verify: alg/exp/nbf)");
+
+    jwt_auth_config_t cfg = {
+        .secret = JWT_TEST_SECRET,
+        .secret_len = sizeof(JWT_TEST_SECRET) - 1,
+        .header_name = NULL,
+        .require_exp = false
+    };
+    middleware_fn_t mw = jwt_auth_middleware_create(&cfg);
+    ASSERT(mw != NULL);
+
+    /* Correctly-signed HS256 token with a far-future exp -> authorized. */
+    ASSERT(_jwt_authorizes(mw, JWT_VALID_EXP) == true);
+    /* A token whose HMAC was computed with a different secret is rejected — the
+     * signature is verified, not merely decoded. */
+    ASSERT(_jwt_authorizes(mw, JWT_BAD_SIG) == false);
+    /* exp is OPTIONAL by default (RFC 7519); a token without one still verifies. */
+    ASSERT(_jwt_authorizes(mw, JWT_NO_EXP) == true);
+    /* Expired token rejected on its exp claim. */
+    ASSERT(_jwt_authorizes(mw, JWT_EXPIRED) == false);
+    /* Not-yet-valid token rejected on its nbf claim. */
+    ASSERT(_jwt_authorizes(mw, JWT_FUTURE_NBF) == false);
+    /* alg must be exactly HS256: an HS384 header is rejected even though the token
+     * carries a valid HMAC-SHA256 signature. */
+    ASSERT(_jwt_authorizes(mw, JWT_ALG_HS384) == false);
+    /* alg-confusion guard: header is {"alg":"none","note":"HS256"} — the literal
+     * "HS256" appears only inside another field's value. A substring alg check
+     * would accept this validly-HMAC'd token; the parsed check rejects it. */
+    ASSERT(_jwt_authorizes(mw, JWT_ALG_NONE) == false);
+
+    jwt_auth_middleware_destroy();
+
+    /* With require_exp enabled, an otherwise-valid token that omits exp is
+     * rejected, while one that carries exp still authorizes. */
+    cfg.require_exp = true;
+    mw = jwt_auth_middleware_create(&cfg);
+    ASSERT(mw != NULL);
+    ASSERT(_jwt_authorizes(mw, JWT_NO_EXP) == false);
+    ASSERT(_jwt_authorizes(mw, JWT_VALID_EXP) == true);
+    jwt_auth_middleware_destroy();
+
+    PASS();
+}
+
 /* Test db_pool from PR #17 */
 void test_db_pool_create_destroy(void) {
     TEST("db_pool (create/destroy)");
@@ -4741,6 +4820,7 @@ int main(void) {
     test_basic_auth_create_destroy();
     test_apikey_auth_create_destroy();
     test_jwt_auth_create_destroy();
+    test_jwt_auth_verify();
 
     /* Phase 6: Database connection pool tests */
     test_db_pool_create_destroy();

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1879,6 +1879,10 @@ void test_jwt_auth_create_destroy(void) {
 /* Identical header.payload to JWT_VALID_EXP but signed with a DIFFERENT secret,
  * so only the HMAC signature differs — isolates the signature-verification gate. */
 #define JWT_BAD_SIG      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5fQ.VPFqsu6N89mLUKTsD4tXMRStoLRZw2zavoNy58X1YT4"
+/* Validly HMAC-signed but with a MALFORMED header {"alg""HS256"} (no ':' between
+ * the "alg" key and its value). A structural parse must reject it; a lenient skip
+ * that treats ':' like whitespace would accept it. */
+#define JWT_ALG_NO_COLON "eyJhbGciIkhTMjU2In0.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5fQ.e8_VDkko9gFLk-HO1bo1QpuDUilzF66p8A26jdNh6BA"
 
 /* Run the JWT middleware over a request carrying `Authorization: Bearer <token>`
  * and return whether it authorized the request (true) or rejected it (false/401). */
@@ -1928,6 +1932,9 @@ void test_jwt_auth_verify(void) {
      * "HS256" appears only inside another field's value. A substring alg check
      * would accept this validly-HMAC'd token; the parsed check rejects it. */
     ASSERT(_jwt_authorizes(mw, JWT_ALG_NONE) == false);
+    /* Structural-parse guard: a malformed header with no ':' after the "alg" key
+     * is rejected (a lenient colon-skip would wrongly accept it). */
+    ASSERT(_jwt_authorizes(mw, JWT_ALG_NO_COLON) == false);
 
     jwt_auth_middleware_destroy();
 


### PR DESCRIPTION
## Subsystem
`middleware_auth` — JWT (HS256) verification hardening. Closes audit finding **#32**.

## Problem
`parse_jwt_token()` gated the algorithm with a **substring** test:
```c
if (!strstr((char *)header_decoded, "\"HS256\"")) goto cleanup;
```
Any header whose decoded bytes merely *contained* the text `"HS256"` passed — e.g. `{"alg":"none","note":"HS256"}`. Combined with the fact that the verifier always computes an HMAC-SHA256 signature, a token that is validly HMAC'd but declares `alg:"none"` (or any other alg) would be accepted: a classic **algorithm-confusion** foothold if additional algorithms are ever added. Expiry parsing was also ad-hoc, and there was **no `nbf` (not-before) check**.

## Fix
Engineer the class out by *parsing* the fields instead of substring-scanning:

- **`jwt_header_alg_is_hs256()`** — locate the real `"alg"` JSON key and require its quoted value to be **exactly** `HS256`. Rejects a missing alg, a non-string alg, or any other value.
- **`jwt_claim_int()`** — shared "real JSON key → base-10 integer" lookup (key must be preceded by `{`, `,`, or whitespace, not sit inside a string value). Replaces the inline `exp` scan and is reused for `nbf`.
- **Enforce `nbf`** — reject not-yet-valid tokens.
- **`jwt_auth_config_t.require_exp`** (default `false`, so `exp` stays OPTIONAL per RFC 7519). When `true`, a token without `exp` is rejected — a leaked exp-less token can't replay forever.

Behavior is unchanged for existing callers (new field defaults to `false`; `memcpy` in `jwt_auth_middleware_create` picks it up automatically).

## Tests
New `test_jwt_auth_verify` — the first test to exercise real end-to-end token verification — runs **7 offline-signed HS256 vectors** (valid, no-exp, expired, future-nbf, HS384 header, `alg:"none"` with a `"HS256"` substring, wrong-signature) across both `require_exp` modes.

**Negative controls** (each reverted individually, rebuilt, confirmed the test fails on exactly that vector, then restored):
- alg parse → old `strstr` ⇒ `alg:"none"` vector wrongly accepted ✓
- `require_exp` disabled ⇒ no-exp vector wrongly accepted ✓
- exp-expiry disabled ⇒ expired vector wrongly accepted ✓
- nbf disabled ⇒ future-nbf vector wrongly accepted ✓

## Validation
- Normal build: `ctest` **6/6**, zero warnings.
- ASan/UBSan build: `ctest` **6/6** (no memory errors in the new request/response harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)