### PR TITLE
Strict JWT exp/nbf claim validation (Copilot #92 follow-up)

### DIFF
--- a/src/middleware_auth.c
+++ b/src/middleware_auth.c
@@ -793,10 +793,16 @@ static jwt_claim_status_t jwt_claim_int(const char *payload_json, const char *ke
     if (!json_skip_to_value(&v)) {
         return JWT_CLAIM_INVALID;      /* no key:value separator */
     }
+    /* A JSON number starts with '-' or a digit. strtol() would also accept a leading
+     * '+' and further leading whitespace, neither of which is valid JSON, so gate the
+     * first byte explicitly. */
+    if (*v != '-' && !(*v >= '0' && *v <= '9')) {
+        return JWT_CLAIM_INVALID;      /* not a bare number (quoted string, '+', ...) */
+    }
     char *endptr = NULL;
     long val = strtol(v, &endptr, 10);
     if (endptr == v) {
-        return JWT_CLAIM_INVALID;      /* not a bare number (e.g. a quoted string) */
+        return JWT_CLAIM_INVALID;      /* e.g. a lone '-' */
     }
     /* The integer must be terminated by optional whitespace then a value delimiter;
      * anything else (e.g. "123abc") is malformed. */

--- a/src/middleware_auth.c
+++ b/src/middleware_auth.c
@@ -774,7 +774,7 @@ typedef enum {
  * by optional whitespace and a JSON object terminator (',' or '}'): a quoted string
  * ("exp":"123"), trailing garbage ("exp":123abc), or a missing ':' all yield INVALID
  * so the caller can reject the token rather than treat the claim as absent. */
-static jwt_claim_status_t jwt_claim_int(const char *payload_json, const char *key, long *out) {
+static jwt_claim_status_t jwt_claim_int(const char *payload_json, const char *key, long long *out) {
     size_t keylen = strlen(key);
     const char *p = payload_json;
     const char *found = NULL;
@@ -800,7 +800,9 @@ static jwt_claim_status_t jwt_claim_int(const char *payload_json, const char *ke
         return JWT_CLAIM_INVALID;      /* not a bare number (quoted string, '+', ...) */
     }
     char *endptr = NULL;
-    long val = strtol(v, &endptr, 10);
+    /* NumericDate (RFC 7519) can exceed 2^31 (year 2038+), and `long` is only 32-bit
+     * on wasm32/LLP64 — parse into long long so exp/nbf are platform-independent. */
+    long long val = strtoll(v, &endptr, 10);
     if (endptr == v) {
         return JWT_CLAIM_INVALID;      /* e.g. a lone '-' */
     }
@@ -912,7 +914,7 @@ static bool parse_jwt_token(const char *token,
      * substrings of a string value (jwt_claim_int). */
     {
         time_t now = time(NULL);
-        long exp_val = 0, nbf_val = 0;
+        long long exp_val = 0, nbf_val = 0;
         jwt_claim_status_t exp_st = jwt_claim_int((const char *)payload_decoded, "\"exp\"", &exp_val);
         jwt_claim_status_t nbf_st = jwt_claim_int((const char *)payload_decoded, "\"nbf\"", &nbf_val);
 
@@ -924,7 +926,7 @@ static bool parse_jwt_token(const char *token,
         /* exp: RFC 7519 §4.1.4 requires the current time to be BEFORE exp, so reject
          * at or after it. No sign guard: a non-positive exp is at/before the epoch,
          * i.e. already expired. */
-        if (exp_st == JWT_CLAIM_OK && now >= (time_t)exp_val) {
+        if (exp_st == JWT_CLAIM_OK && (long long)now >= exp_val) {
             goto cleanup; /* Token expired */
         }
         /* Optionally require exp to be present at all (RFC 7519 leaves it OPTIONAL;
@@ -934,7 +936,7 @@ static bool parse_jwt_token(const char *token,
             goto cleanup; /* exp claim required but absent */
         }
         /* nbf: reject a token that is not yet valid (§4.1.5: not before nbf). */
-        if (nbf_st == JWT_CLAIM_OK && now < (time_t)nbf_val) {
+        if (nbf_st == JWT_CLAIM_OK && (long long)now < nbf_val) {
             goto cleanup; /* Token not yet valid */
         }
     }

--- a/src/middleware_auth.c
+++ b/src/middleware_auth.c
@@ -759,11 +759,22 @@ static bool jwt_header_alg_is_hs256(const char *header_json) {
     return strncmp(v, "HS256", 5) == 0 && v[5] == '"';
 }
 
+/* Tri-state result of looking up an integer JWT claim. A security-critical claim
+ * that is PRESENT but malformed must not be silently ignored, so ABSENT (key not
+ * found) is distinguished from INVALID (key found but not a well-formed integer). */
+typedef enum {
+    JWT_CLAIM_ABSENT = 0,   /* key not present in the payload */
+    JWT_CLAIM_INVALID,      /* key present but its value is not a bare base-10 int */
+    JWT_CLAIM_OK            /* key present with a valid integer; *out is set */
+} jwt_claim_status_t;
+
 /* Look up a base-10 integer JSON claim (e.g. `key` == "\"exp\"") in the flat JWT
- * payload. Matches only a real key — one preceded by '{', ',' or whitespace, not
- * a substring inside some string value. Returns true and sets *out when found
- * with a numeric value. */
-static bool jwt_claim_int(const char *payload_json, const char *key, long *out) {
+ * payload. Matches only a real key — one preceded by '{', ',' or whitespace, not a
+ * substring inside some string value. The value must be a bare integer followed only
+ * by optional whitespace and a JSON object terminator (',' or '}'): a quoted string
+ * ("exp":"123"), trailing garbage ("exp":123abc), or a missing ':' all yield INVALID
+ * so the caller can reject the token rather than treat the claim as absent. */
+static jwt_claim_status_t jwt_claim_int(const char *payload_json, const char *key, long *out) {
     size_t keylen = strlen(key);
     const char *p = payload_json;
     const char *found = NULL;
@@ -776,19 +787,28 @@ static bool jwt_claim_int(const char *payload_json, const char *key, long *out) 
         p += keylen;
     }
     if (!found) {
-        return false;
+        return JWT_CLAIM_ABSENT;
     }
     const char *v = found + keylen;
     if (!json_skip_to_value(&v)) {
-        return false;                 /* malformed: no key:value separator */
+        return JWT_CLAIM_INVALID;      /* no key:value separator */
     }
     char *endptr = NULL;
     long val = strtol(v, &endptr, 10);
     if (endptr == v) {
-        return false;                 /* non-numeric value */
+        return JWT_CLAIM_INVALID;      /* not a bare number (e.g. a quoted string) */
+    }
+    /* The integer must be terminated by optional whitespace then a value delimiter;
+     * anything else (e.g. "123abc") is malformed. */
+    const char *e = endptr;
+    while (*e == ' ' || *e == '\t' || *e == '\n' || *e == '\r') {
+        e++;
+    }
+    if (*e != ',' && *e != '}') {
+        return JWT_CLAIM_INVALID;
     }
     *out = val;
-    return true;
+    return JWT_CLAIM_OK;
 }
 
 /**
@@ -887,21 +907,28 @@ static bool parse_jwt_token(const char *token,
     {
         time_t now = time(NULL);
         long exp_val = 0, nbf_val = 0;
-        bool have_exp = jwt_claim_int((const char *)payload_decoded, "\"exp\"", &exp_val);
+        jwt_claim_status_t exp_st = jwt_claim_int((const char *)payload_decoded, "\"exp\"", &exp_val);
+        jwt_claim_status_t nbf_st = jwt_claim_int((const char *)payload_decoded, "\"nbf\"", &nbf_val);
 
-        /* exp: reject an expired token. */
-        if (have_exp && exp_val > 0 && (time_t)exp_val < now) {
+        /* A present-but-malformed security claim (non-integer, trailing garbage,
+         * quoted string) is rejected outright — never silently treated as absent. */
+        if (exp_st == JWT_CLAIM_INVALID || nbf_st == JWT_CLAIM_INVALID) {
+            goto cleanup;
+        }
+        /* exp: RFC 7519 §4.1.4 requires the current time to be BEFORE exp, so reject
+         * at or after it. No sign guard: a non-positive exp is at/before the epoch,
+         * i.e. already expired. */
+        if (exp_st == JWT_CLAIM_OK && now >= (time_t)exp_val) {
             goto cleanup; /* Token expired */
         }
         /* Optionally require exp to be present at all (RFC 7519 leaves it OPTIONAL;
          * strict callers can opt in so a leaked exp-less token can't replay
          * forever). */
-        if (require_exp && !have_exp) {
+        if (require_exp && exp_st != JWT_CLAIM_OK) {
             goto cleanup; /* exp claim required but absent */
         }
-        /* nbf: reject a token that is not yet valid. */
-        if (jwt_claim_int((const char *)payload_decoded, "\"nbf\"", &nbf_val) &&
-            nbf_val > 0 && now < (time_t)nbf_val) {
+        /* nbf: reject a token that is not yet valid (§4.1.5: not before nbf). */
+        if (nbf_st == JWT_CLAIM_OK && now < (time_t)nbf_val) {
             goto cleanup; /* Token not yet valid */
         }
     }

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1968,6 +1968,16 @@ void test_jwt_auth_create_destroy(void) {
  * the "alg" key and its value). A structural parse must reject it; a lenient skip
  * that treats ':' like whitespace would accept it. */
 #define JWT_ALG_NO_COLON "eyJhbGciIkhTMjU2In0.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5fQ.e8_VDkko9gFLk-HO1bo1QpuDUilzF66p8A26jdNh6BA"
+/* Validly-signed tokens exercising strict exp/nbf claim validation. Each is rejected
+ * only by the claim checks (alg/signature are fine):
+ *   ZERO    exp=0        -> at/before epoch = expired (no positive-only skip)
+ *   STRING  exp="9999.." -> present but a quoted string, not an integer
+ *   GARBAGE exp=9999..abc-> integer prefix with trailing garbage
+ *   NBFSTR  nbf="9999.." -> present-but-non-integer nbf (exp itself valid/future) */
+#define JWT_EXP_ZERO     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjowfQ.9bCfFADcsL8Ok2dN6ZlMsrB4thCkp1-J4eZ2_snAJLE"
+#define JWT_EXP_STRING   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjoiOTk5OTk5OTk5OSJ9.E_TSFaWjg6DdtrW9TIMz0Ahw2E4Q91u1my_iPq0Qxzw"
+#define JWT_EXP_GARBAGE  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5YWJjfQ.luT8G7r8RZlY2Cmqa9CYUGaYv5afPe8e5FOdwJFB_Ck"
+#define JWT_NBF_STRING   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5LCJuYmYiOiI5OTk5OTk5OTk5In0.jxTPLugrKJQGqQmA1te8TQJ10oAKN-Oxp14fU60cb7U"
 
 /* Run the JWT middleware over a request carrying `Authorization: Bearer <token>`
  * and return whether it authorized the request (true) or rejected it (false/401). */
@@ -2020,6 +2030,13 @@ void test_jwt_auth_verify(void) {
     /* Structural-parse guard: a malformed header with no ':' after the "alg" key
      * is rejected (a lenient colon-skip would wrongly accept it). */
     ASSERT(_jwt_authorizes(mw, JWT_ALG_NO_COLON) == false);
+
+    /* Strict claim validation: a present exp/nbf that is non-positive, a quoted
+     * string, or has trailing garbage must be rejected — not silently ignored. */
+    ASSERT(_jwt_authorizes(mw, JWT_EXP_ZERO) == false);     /* exp=0 -> expired */
+    ASSERT(_jwt_authorizes(mw, JWT_EXP_STRING) == false);   /* exp is a string */
+    ASSERT(_jwt_authorizes(mw, JWT_EXP_GARBAGE) == false);  /* exp=9999999999abc */
+    ASSERT(_jwt_authorizes(mw, JWT_NBF_STRING) == false);   /* nbf is a string */
 
     jwt_auth_middleware_destroy();
 

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -1978,6 +1978,8 @@ void test_jwt_auth_create_destroy(void) {
 #define JWT_EXP_STRING   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjoiOTk5OTk5OTk5OSJ9.E_TSFaWjg6DdtrW9TIMz0Ahw2E4Q91u1my_iPq0Qxzw"
 #define JWT_EXP_GARBAGE  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5YWJjfQ.luT8G7r8RZlY2Cmqa9CYUGaYv5afPe8e5FOdwJFB_Ck"
 #define JWT_NBF_STRING   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjo5OTk5OTk5OTk5LCJuYmYiOiI5OTk5OTk5OTk5In0.jxTPLugrKJQGqQmA1te8TQJ10oAKN-Oxp14fU60cb7U"
+/* exp with a leading '+': strtol tolerates it but JSON does not. */
+#define JWT_EXP_PLUS     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1IiwiZXhwIjorOTk5OTk5OTk5OX0.fblFCsz1pZkpFEkZ4Dptv_R_UE71Mjdwi3sSuZFCGBw"
 
 /* Run the JWT middleware over a request carrying `Authorization: Bearer <token>`
  * and return whether it authorized the request (true) or rejected it (false/401). */
@@ -2037,6 +2039,7 @@ void test_jwt_auth_verify(void) {
     ASSERT(_jwt_authorizes(mw, JWT_EXP_STRING) == false);   /* exp is a string */
     ASSERT(_jwt_authorizes(mw, JWT_EXP_GARBAGE) == false);  /* exp=9999999999abc */
     ASSERT(_jwt_authorizes(mw, JWT_NBF_STRING) == false);   /* nbf is a string */
+    ASSERT(_jwt_authorizes(mw, JWT_EXP_PLUS) == false);     /* exp=+9999999999 */
 
     jwt_auth_middleware_destroy();
 


### PR DESCRIPTION
## Subsystem
`middleware_auth` — JWT claim-validation hardening. Follow-up to the Copilot review on #92 (audit #32).

## Problem
Copilot's review of #92 raised three claim-validation gaps. None is exploitable without the HMAC secret (forging any claim requires re-signing), but each is the wrong behavior for a security-critical field:

1. **Present-but-non-integer claim silently ignored.** `jwt_claim_int` returned a plain `false` both when a key was absent *and* when it was present with a malformed value — so `"exp":"9999999999"` (a quoted string) or `"exp":9999999999abc` (trailing garbage) caused exp/nbf enforcement to be **skipped**, not to fail.
2. **Non-positive exp skipped.** The check `exp_val > 0 && exp_val < now` ignored `exp <= 0`, i.e. a timestamp at/before the epoch (definitely expired) was accepted.
3. **`exp == now` treated as valid.** RFC 7519 §4.1.4 requires the current time to be *before* exp.

## Fix
`jwt_claim_int()` now returns a tri-state:
```c
typedef enum { JWT_CLAIM_ABSENT, JWT_CLAIM_INVALID, JWT_CLAIM_OK } jwt_claim_status_t;
```
A key present with a non-integer value, or an integer followed by anything other than optional whitespace and then a `,` or `}` (a JSON object value terminator), is **INVALID**. `parse_jwt_token()`:
- rejects the token when exp **or** nbf is `INVALID`;
- rejects exp when `now >= exp` (no sign guard — a non-positive exp is at/before the epoch);
- rejects nbf when `now < nbf`;
- keys `require_exp` off `exp_st != OK`.

## Tests
Four validly-HMAC-signed vectors added to `test_jwt_auth_verify` (so only the claim checks can gate them): `JWT_EXP_ZERO` (`exp=0`), `JWT_EXP_STRING` (`exp="9999999999"`), `JWT_EXP_GARBAGE` (`exp=9999999999abc`), `JWT_NBF_STRING` (`nbf="9999999999"`, exp itself valid). All are now rejected; each was accepted before.

**Negative controls:** (a) restoring the `exp_val > 0` skip re-accepts `JWT_EXP_ZERO`; (b) disabling the INVALID-claim rejection re-accepts the malformed-claim vectors. Both confirmed, then restored. All prior vectors (valid / expired / no-exp / future-nbf / HS384 / alg-none / bad-sig / no-colon) still pass.

_Not unit-tested:_ the `exp == now` boundary (item 3) — it needs a token minted at test time with `exp = time(NULL)`, and the library intentionally exposes no JWT-minting helper. `JWT_EXP_ZERO` covers the removal of the sign guard against a fixed boundary.

## Validation
- Normal build: `ctest` **6/6**, zero warnings.
- ASan/UBSan build: `ctest` **6/6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)