### PR TITLE
Parse Accept-Encoding q-values without strtod (locale-independent)

### DIFF
--- a/src/compression.c
+++ b/src/compression.c
@@ -527,7 +527,7 @@ static double _parse_quality(const char *param) {
     }
     
     param += 2;
-    while (*param == ' ' || *param == '\t') {   /* tolerate "q= 0.8" like strtod did */
+    while (*param && isspace((unsigned char)*param)) {   /* match strtod's leading-ws skip */
         param++;
     }
 

--- a/src/compression.c
+++ b/src/compression.c
@@ -527,13 +527,34 @@ static double _parse_quality(const char *param) {
     }
     
     param += 2;
-    char *endptr;
-    double q = strtod(param, &endptr);
-    
-    if (endptr == param || q < 0.0) {
-        return 1.0;
+    while (*param == ' ' || *param == '\t') {   /* tolerate "q= 0.8" like strtod did */
+        param++;
     }
-    
+
+    /* RFC 7231 §5.3.1  qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] ).
+     * Parse it by hand rather than via strtod(), whose decimal-point handling
+     * follows LC_NUMERIC: under a comma-decimal locale (de_DE, fr_FR, ...)
+     * strtod("0.8") stops at the '.', yields 0.0, and silently refuses an encoding
+     * the client actually accepts. The fixed grammar makes a direct parse trivial
+     * and locale-independent by construction. */
+    int whole;
+    if (param[0] == '0') {
+        whole = 0;
+    } else if (param[0] == '1') {
+        whole = 1;
+    } else {
+        return 1.0;                   /* missing/invalid qvalue -> default 1.0 */
+    }
+    const char *p = param + 1;
+    long frac = 0, scale = 1;
+    if (*p == '.') {
+        p++;
+        for (int digits = 0; digits < 3 && *p >= '0' && *p <= '9'; digits++, p++) {
+            frac = frac * 10 + (*p - '0');
+            scale *= 10;
+        }
+    }
+    double q = (double)whole + (double)frac / (double)scale;
     return q > 1.0 ? 1.0 : q;
 }
 

--- a/tests/test_weblib.c
+++ b/tests/test_weblib.c
@@ -3712,6 +3712,62 @@ void test_compression_negotiate(void) {
     PASS();
 }
 
+/* Regression (task #20): Accept-Encoding q-values use '.' as the decimal separator,
+ * but _parse_quality() used strtod(), which honors LC_NUMERIC. Under a comma-decimal
+ * locale strtod("0.8") stopped at the '.' -> q=0.0 -> an encoding the client accepts
+ * was silently refused. Verify negotiation is locale-independent (skipping cleanly if
+ * no comma-decimal locale is installed). */
+void test_compression_negotiate_locale(void) {
+    TEST("compression_negotiate (locale-independent q-value)");
+
+    const char *cur = setlocale(LC_NUMERIC, NULL);
+    char saved[128];
+    saved[0] = '\0';
+    if (cur) {
+        strncpy(saved, cur, sizeof(saved) - 1);
+        saved[sizeof(saved) - 1] = '\0';
+    }
+
+    static const char *comma[] = {
+        "de_DE.UTF-8", "fr_FR.UTF-8", "de_DE", "fr_FR", "nl_NL.UTF-8"
+    };
+    bool have_comma = false;
+    for (size_t i = 0; i < sizeof(comma) / sizeof(comma[0]); i++) {
+        if (setlocale(LC_NUMERIC, comma[i]) &&
+            localeconv()->decimal_point[0] == ',') {
+            have_comma = true;
+            break;
+        }
+    }
+
+    if (!have_comma) {
+        setlocale(LC_NUMERIC, saved[0] ? saved : "C");
+        printf("[SKIP: no comma-decimal locale] ");
+        PASS();
+        return;
+    }
+
+    /* Compute under the comma locale, then restore BEFORE asserting (ASSERT returns). */
+    const char *r_frac = compression_negotiate("gzip;q=0.8");   /* 0.8 > 0  -> gzip */
+    const char *r_tiny = compression_negotiate("gzip;q=0.001"); /* 0.001 > 0 -> gzip */
+    const char *r_zero = compression_negotiate("gzip;q=0");     /* 0 -> refused */
+    const char *r_wild = compression_negotiate("*;q=0.5");      /* wildcard -> gzip */
+
+    bool frac_ok = (r_frac && strcmp(r_frac, "gzip") == 0);
+    bool tiny_ok = (r_tiny && strcmp(r_tiny, "gzip") == 0);
+    bool zero_ok = (r_zero == NULL);
+    bool wild_ok = (r_wild && strcmp(r_wild, "gzip") == 0);
+
+    setlocale(LC_NUMERIC, saved[0] ? saved : "C");
+
+    ASSERT(frac_ok);   /* q=0.8 must not collapse to 0 under a comma locale */
+    ASSERT(tiny_ok);   /* q=0.001 is still > 0 */
+    ASSERT(zero_ok);   /* q=0 still refuses */
+    ASSERT(wild_ok);
+
+    PASS();
+}
+
 void test_compression_should_compress(void) {
     TEST("compression_should_compress");
 
@@ -5023,6 +5079,7 @@ int main(void) {
     /* Phase 9: Compression tests */
     test_crc32_compute();
     test_compression_negotiate();
+    test_compression_negotiate_locale();
     test_compression_should_compress();
     test_gzip_compress_valid();
 


### PR DESCRIPTION
## Subsystem
`compression` — Accept-Encoding q-value parsing. Follow-up to audit #9 (same `strtod`/`LC_NUMERIC` class, different subsystem; discovered during PR #93).

## Problem
`_parse_quality()` read the quality value with `strtod()`, whose decimal-point handling follows `LC_NUMERIC`. Under a comma-decimal locale (`de_DE`, `fr_FR`, …) `strtod("0.8")` stops at the `.`, returns `0.0`, and `compression_negotiate()` then sees quality `0` → **refuses an encoding the client actually accepts**. So a server started in such a locale silently stops honoring `gzip;q=0.8` (and any fractional weight). `q=1.0` happened to survive (parses `1`), which is why it went unnoticed.

## Fix
A q-value has a tiny fixed grammar — RFC 7231 §5.3.1: `( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )` — so parse it **directly**, with no `strtod` at all: read `0`/`1`, then an optional `.` and up to three fractional digits, and combine. Locale-independent by construction (engineers the class out rather than translating around it). Leading whitespace after `q=` is still skipped so `"q= 0"` keeps refusing as before.

## Tests
`test_compression_negotiate_locale` sets a comma-decimal locale (skipping cleanly if none is installed — it verifies `decimal_point[0] == ','` before asserting), then checks:
- `gzip;q=0.8` → `gzip` (was NULL under the bug)
- `gzip;q=0.001` → `gzip` (tiny but > 0)
- `gzip;q=0` → NULL (still refused)
- `*;q=0.5` → `gzip` (wildcard)

**Negative control:** restoring the `strtod` path makes `gzip;q=0.8` collapse to `0` and the test fails on that assertion — confirmed, then restored. The existing default-locale `test_compression_negotiate` is unchanged and still passes.

## Validation
- Normal build: `ctest` **6/6**, zero warnings.
- ASan/UBSan build: `ctest` **6/6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)