### PR TITLE
TLS Phase 0: build scaffold for experimental pure-C TLS (OFF by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ dkms.conf
 
 # CMake build files
 build/
+build-asan/
+build-tls/
 CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,21 @@ set(WEBLIB_SOURCES_NATIVE_ONLY
     src/benchmark.c
 )
 
+# Experimental pure-C TLS 1.3 layer (native-only, UNAUDITED). OFF by default: with
+# the option off, nothing below is added and the build is byte-identical to a
+# no-TLS build. Mirrors the WEBLIB_SOURCES_NATIVE_ONLY split (see src/tls/README.md).
+option(WEBLIB_ENABLE_TLS "Build the experimental pure-C TLS 1.3 layer (native-only, UNAUDITED)" OFF)
+set(WEBLIB_SOURCES_TLS
+    src/tls/tls.c
+)
+
 if(EMSCRIPTEN)
     set(WEBLIB_SOURCES ${WEBLIB_SOURCES_WASM_SAFE})
 else()
     set(WEBLIB_SOURCES ${WEBLIB_SOURCES_WASM_SAFE} ${WEBLIB_SOURCES_NATIVE_ONLY})
+    if(WEBLIB_ENABLE_TLS)
+        list(APPEND WEBLIB_SOURCES ${WEBLIB_SOURCES_TLS})
+    endif()
 endif()
 
 # Create static library
@@ -95,6 +106,12 @@ target_compile_definitions(weblib PRIVATE
     CMAKE_VERSION_PATCH=${PROJECT_VERSION_PATCH}
 )
 
+# Experimental TLS layer: define WEBLIB_TLS only when explicitly enabled on a
+# native target (its sources were added to WEBLIB_SOURCES above under the same guard).
+if(WEBLIB_ENABLE_TLS AND NOT EMSCRIPTEN)
+    target_compile_definitions(weblib PRIVATE WEBLIB_TLS)
+endif()
+
 if(NOT EMSCRIPTEN)
     # Create shared library (not supported for WASM)
     add_library(weblib_shared SHARED ${WEBLIB_SOURCES})
@@ -109,6 +126,9 @@ if(NOT EMSCRIPTEN)
         CMAKE_VERSION_MINOR=${PROJECT_VERSION_MINOR}
         CMAKE_VERSION_PATCH=${PROJECT_VERSION_PATCH}
     )
+    if(WEBLIB_ENABLE_TLS)
+        target_compile_definitions(weblib_shared PRIVATE WEBLIB_TLS)
+    endif()
 endif()
 
 # Build examples

--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -1,0 +1,61 @@
+# `src/tls/` — Experimental pure-C TLS 1.3 (EXPERIMENTAL · UNAUDITED)
+
+> **Status: scaffold only.** There is **no** working TLS here yet — no handshake,
+> no record layer, no cryptography. Do **not** rely on this for any security
+> property. This directory is the foundation for an incremental, from-scratch
+> TLS build; every cryptographic primitive will land with a known-answer test
+> against its official RFC vector before anything depends on it.
+
+## Why hand-written TLS
+
+The library's identity is *zero external dependencies, pure ISO C*. Its one
+missing production capability is TLS — today HTTPS requires an external reverse
+proxy. The owner chose **Option A: hand-write TLS in pure C from scratch**
+(nginx-inspired), matching the repo's own ADR (`NEXT_PHASE.md`). No OpenSSL,
+mbedTLS, or any crypto library is linked; `PLATFORM_LIBS` gains no new dependency.
+
+## Scope (first milestone — planned, not yet built)
+
+- **In:** TLS 1.3 (RFC 8446), **server-side only**; one cipher suite
+  `TLS_CHACHA20_POLY1305_SHA256`; group **X25519**; signature **Ed25519**; one
+  self-supplied Ed25519 certificate.
+- **Out (documented future):** TLS 1.2; AES-GCM and any other suite; RSA / ECDSA /
+  P-256 / bignum; client-certificate verification; session resumption / tickets /
+  0-RTT.
+- **Rationale:** ChaCha20-Poly1305 + X25519 + Ed25519 are constant-time by
+  construction and need no big-integer machinery — the only responsible choice for
+  hand-rolled crypto — and curl and every modern browser speak them.
+
+## Build
+
+TLS is **off by default** and **native-only**.
+
+```sh
+cmake -S . -B build-tls -DWEBLIB_ENABLE_TLS=ON
+cmake --build build-tls
+ctest --test-dir build-tls
+```
+
+- `WEBLIB_ENABLE_TLS=OFF` (the default): the build is byte-identical to a build
+  with no TLS code — nothing in this directory is compiled.
+- `WEBLIB_ENABLE_TLS=ON` on a native target: defines `WEBLIB_TLS`, compiles
+  `src/tls/*.c`, and builds the guarded `TlsTests` suite.
+- WASM / Emscripten builds ignore the option entirely (no sockets to wrap; the
+  browser / Cloudflare edge terminates TLS).
+
+## Roadmap (incremental, each step independently verifiable)
+
+- **Phase 0 (this scaffold):** build option + `-DWEBLIB_TLS` wiring + a linkable
+  smoke symbol (`wl_tls_build_info`). Default build proven unchanged.
+- **Phase 0 (next):** shared crypto module — promote the existing static SHA-256 /
+  HMAC-SHA256 / base64 out of `middleware_auth.c` / `websocket.c`; transport
+  choke-point (`conn_read` / `conn_write`) proving no behavior change.
+- **Phase 1:** primitives from scratch, each with an RFC known-answer test
+  (ChaCha20, Poly1305, ChaCha20-Poly1305, HKDF, SHA-384/512, X25519, Ed25519).
+- **Phase 2:** PEM + minimal ASN.1/DER + X.509 loading.
+- **Phase 3:** TLS 1.3 record layer + server handshake state machine + key schedule.
+- **Phase 4:** integration (`http_server_enable_tls`), config, `curl` / `openssl
+  s_client` interop, ClientHello fuzzing, honest security labeling.
+
+Standing design reference: `docs/audit/TLS-RECON.md` (crypto inventory, socket
+seams, build integration).

--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -46,7 +46,7 @@ ctest --test-dir build-tls
 ## Roadmap (incremental, each step independently verifiable)
 
 - **Phase 0 (this scaffold):** build option + `-DWEBLIB_TLS` wiring + a linkable
-  smoke symbol (`wl_tls_build_info`). Default build proven unchanged.
+  smoke symbol (`tls_build_info`). Default build proven unchanged.
 - **Phase 0 (next):** shared crypto module — promote the existing static SHA-256 /
   HMAC-SHA256 / base64 out of `middleware_auth.c` / `websocket.c`; transport
   choke-point (`conn_read` / `conn_write`) proving no behavior change.
@@ -57,5 +57,7 @@ ctest --test-dir build-tls
 - **Phase 4:** integration (`http_server_enable_tls`), config, `curl` / `openssl
   s_client` interop, ClientHello fuzzing, honest security labeling.
 
-Standing design reference: `docs/audit/TLS-RECON.md` (crypto inventory, socket
-seams, build integration).
+Design references in-repo: the "Pure C TLS (not OpenSSL)" ADR in
+[`NEXT_PHASE.md`](../../NEXT_PHASE.md) and the Phase 11 TLS plan in
+[`TODO.md`](../../TODO.md). (The detailed crypto/transport/build recon lives in
+the maintainers' internal working notes, not in the public tree.)

--- a/src/tls/tls.c
+++ b/src/tls/tls.c
@@ -14,7 +14,7 @@
 
 #ifdef WEBLIB_TLS
 
-const char *wl_tls_build_info(void) {
+const char *tls_build_info(void) {
     return "modern-c-web-library TLS 1.3 (EXPERIMENTAL, UNAUDITED) — scaffold only; "
            "planned suite TLS_CHACHA20_POLY1305_SHA256, group X25519, sig Ed25519";
 }
@@ -25,6 +25,6 @@ const char *wl_tls_build_info(void) {
  * branch above always applies in practice. This typedef keeps the translation
  * unit non-empty if the file is ever compiled without the define, avoiding an
  * "ISO C forbids an empty translation unit" warning under -pedantic. */
-typedef int wl_tls_translation_unit_not_empty;
+typedef int tls_translation_unit_not_empty;
 
 #endif /* WEBLIB_TLS */

--- a/src/tls/tls.c
+++ b/src/tls/tls.c
@@ -1,0 +1,30 @@
+/*
+ * tls.c — Experimental pure-C TLS 1.3 layer, scaffold (EXPERIMENTAL, UNAUDITED).
+ *
+ * Phase 0: build foundation only. No cryptography, handshake, or record layer is
+ * implemented here yet — this translation unit exists so the CMake wiring
+ * (option WEBLIB_ENABLE_TLS -> -DWEBLIB_TLS -> native-only source -> linkable
+ * symbol) can be verified end to end before any security-critical code lands.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON on native targets; excluded from the
+ * default build and from WASM / Cloudflare Workers builds (which get HTTPS from
+ * the browser / edge). See src/tls/README.md for scope and status.
+ */
+#include "tls.h"
+
+#ifdef WEBLIB_TLS
+
+const char *wl_tls_build_info(void) {
+    return "modern-c-web-library TLS 1.3 (EXPERIMENTAL, UNAUDITED) — scaffold only; "
+           "planned suite TLS_CHACHA20_POLY1305_SHA256, group X25519, sig Ed25519";
+}
+
+#else
+
+/* The build system only compiles this file when WEBLIB_TLS is defined, so the
+ * branch above always applies in practice. This typedef keeps the translation
+ * unit non-empty if the file is ever compiled without the define, avoiding an
+ * "ISO C forbids an empty translation unit" warning under -pedantic. */
+typedef int wl_tls_translation_unit_not_empty;
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/tls.h
+++ b/src/tls/tls.h
@@ -34,8 +34,12 @@ extern "C" {
  * build pipeline (option WEBLIB_ENABLE_TLS -> -DWEBLIB_TLS -> compiled native
  * source -> linkable symbol -> smoke test) be verified end to end before any
  * cryptography exists. It performs no cryptographic or network operation.
+ *
+ * Naming: the tls_ prefix matches the subsystem-prefixed convention used across
+ * the library (http_server_*, websocket_*, ...) and the planned TLS API
+ * (tls_accept/tls_read/tls_write/tls_shutdown).
  */
-const char *wl_tls_build_info(void);
+const char *tls_build_info(void);
 
 #ifdef __cplusplus
 }

--- a/src/tls/tls.h
+++ b/src/tls/tls.h
@@ -1,0 +1,45 @@
+/*
+ * tls.h — Experimental pure-C TLS 1.3 layer (EXPERIMENTAL, UNAUDITED).
+ *
+ * SCAFFOLD ONLY. No handshake, record layer, key schedule, or cryptography is
+ * implemented yet. This header exists so the build wiring can be verified before
+ * any security-critical code lands.
+ *
+ * Compiled only when the project is configured with -DWEBLIB_ENABLE_TLS=ON, which
+ * defines WEBLIB_TLS and adds the src/tls sources to the native-only source list.
+ * The default build (WEBLIB_ENABLE_TLS=OFF) does not include this file at all, and is
+ * byte-identical to a build without any TLS code. TLS is native-only: WASM and
+ * Cloudflare Workers get HTTPS from the browser / edge, so nothing here is built
+ * for those targets. See src/tls/README.md.
+ *
+ * Planned first milestone (NOT yet implemented): TLS 1.3 (RFC 8446), server-side
+ * only, one cipher suite TLS_CHACHA20_POLY1305_SHA256, key-exchange group X25519,
+ * signature scheme Ed25519 — all constant-time by construction (no bignum / RSA /
+ * AES-GCM / P-256).
+ */
+#ifndef WEBLIB_TLS_H
+#define WEBLIB_TLS_H
+
+#ifdef WEBLIB_TLS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Return a human-readable banner describing this experimental TLS build and its
+ * planned scope. Never returns NULL or an empty string.
+ *
+ * This is intentionally the only symbol the Phase 0 scaffold exports: it lets the
+ * build pipeline (option WEBLIB_ENABLE_TLS -> -DWEBLIB_TLS -> compiled native
+ * source -> linkable symbol -> smoke test) be verified end to end before any
+ * cryptography exists. It performs no cryptographic or network operation.
+ */
+const char *wl_tls_build_info(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,16 @@ if(NOT EMSCRIPTEN)
 
     # Add worker test to CTest
     add_test(NAME WorkerTests COMMAND test_worker)
+
+    # Experimental TLS scaffold smoke test -- only when TLS is enabled. Verifies the
+    # option -> -DWEBLIB_TLS -> compiled native source -> linkable symbol wiring.
+    if(WEBLIB_ENABLE_TLS)
+        add_executable(test_tls test_tls.c)
+        target_include_directories(test_tls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls)
+        target_compile_definitions(test_tls PRIVATE WEBLIB_TLS)
+        target_link_libraries(test_tls weblib ${PLATFORM_LIBS})
+        add_test(NAME TlsTests COMMAND test_tls)
+    endif()
 endif()
 
 # WASM capability test (runs on both native and WASM builds)

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -1,0 +1,51 @@
+/*
+ * test_tls.c — smoke test for the experimental TLS scaffold (Phase 0).
+ *
+ * Built and run only when configured with -DWEBLIB_ENABLE_TLS=ON. It asserts that
+ * the build wiring (option -> -DWEBLIB_TLS -> compiled native source -> linkable
+ * symbol) works and that the layer honestly labels itself as experimental. There
+ * is no cryptography to test yet.
+ */
+#include "tls.h"
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+    int failures = 0;
+
+#ifndef WEBLIB_TLS
+    /* This executable is only added to the build when WEBLIB_TLS is defined; if we
+     * somehow got here without it, the wiring is broken. */
+    printf("FAIL: test_tls built without WEBLIB_TLS defined\n");
+    return 1;
+#else
+    const char *info = wl_tls_build_info();
+
+    printf("TLS build info: %s\n", info ? info : "(null)");
+
+    if (info == NULL) {
+        printf("FAIL: wl_tls_build_info() returned NULL\n");
+        failures++;
+    } else {
+        if (info[0] == '\0') {
+            printf("FAIL: wl_tls_build_info() returned an empty string\n");
+            failures++;
+        }
+        /* The banner must keep advertising its unaudited/experimental status so the
+         * scaffold can never be mistaken for a production TLS stack. */
+        if (strstr(info, "EXPERIMENTAL") == NULL) {
+            printf("FAIL: build info does not carry the EXPERIMENTAL label\n");
+            failures++;
+        }
+        if (strstr(info, "UNAUDITED") == NULL) {
+            printf("FAIL: build info does not carry the UNAUDITED label\n");
+            failures++;
+        }
+    }
+
+    if (failures == 0) {
+        printf("PASS: TLS scaffold wiring verified (no crypto implemented yet)\n");
+    }
+    return failures == 0 ? 0 : 1;
+#endif
+}

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -19,16 +19,16 @@ int main(void) {
     printf("FAIL: test_tls built without WEBLIB_TLS defined\n");
     return 1;
 #else
-    const char *info = wl_tls_build_info();
+    const char *info = tls_build_info();
 
     printf("TLS build info: %s\n", info ? info : "(null)");
 
     if (info == NULL) {
-        printf("FAIL: wl_tls_build_info() returned NULL\n");
+        printf("FAIL: tls_build_info() returned NULL\n");
         failures++;
     } else {
         if (info[0] == '\0') {
-            printf("FAIL: wl_tls_build_info() returned an empty string\n");
+            printf("FAIL: tls_build_info() returned an empty string\n");
             failures++;
         }
         /* The banner must keep advertising its unaudited/experimental status so the


### PR DESCRIPTION
## Subsystem
`build` + new `src/tls/` — first step of the hand-written pure-C TLS 1.3 track (Option A, per `docs/audit/TLS-RECON.md`). Task #1 (TLS Phase 0), **build scaffold only.**

## What this is (and isn't)
This establishes the **build foundation** for TLS and nothing more. There is **no cryptography, handshake, key schedule, or record layer** here — those land in later, individually-verifiable PRs, each crypto primitive gated on its official RFC known-answer test. Shipping the scaffold first lets the option/define/link wiring be proven before any security-critical code exists.

## Changes
- **CMake:** `option(WEBLIB_ENABLE_TLS … OFF)`; a `WEBLIB_SOURCES_TLS` list appended to the sources **only** when `NOT EMSCRIPTEN AND WEBLIB_ENABLE_TLS`; `-DWEBLIB_TLS` pushed to `weblib`/`weblib_shared` under the same guard. Mirrors the existing `WEBLIB_SOURCES_NATIVE_ONLY` split. `PLATFORM_LIBS` gains **no** new link dependency — zero-dep preserved. TLS is native-only (WASM / Cloudflare Workers get HTTPS from the browser / edge).
- **`src/tls/{tls.h,tls.c}`:** a single linkable symbol `wl_tls_build_info()` behind `#ifdef WEBLIB_TLS`, so `option → -DWEBLIB_TLS → compiled native source → symbol → smoke test` is verifiable end to end. Performs no crypto or network I/O.
- **`tests/test_tls.c` + guarded `TlsTests`:** asserts the symbol links and that the banner honestly carries the `EXPERIMENTAL` / `UNAUDITED` labels.
- **`src/tls/README.md`:** scope (TLS 1.3 server-side, `TLS_CHACHA20_POLY1305_SHA256` / X25519 / Ed25519), status (scaffold — do not rely on it for any security property), and the incremental roadmap.
- **`.gitignore`:** ignore local `build-asan/` and `build-tls/` dirs.

## Verification
- **Default build (OFF) is byte-identical to before:** `ctest` **6/6** on both the normal and ASan/UBSan trees, and `nm build/libweblib.a` shows **no `wl_tls` symbol** — the scaffold is entirely absent when the option is off.
- **ON build** (`cmake -DWEBLIB_ENABLE_TLS=ON`): compiles **warning-free** (`-Wall -Wextra -pedantic`) and `ctest` is **7/7** (adds `TlsTests`).

## Next in the track
Shared crypto module (promote the static SHA-256 / HMAC / base64 out of `middleware_auth.c` / `websocket.c`) and the transport choke-point (`conn_read` / `conn_write`) proving no behavior change — then Phase 1 primitives with RFC KATs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)