### PR TITLE
TLS Phase 1: ChaCha20 stream cipher (RFC 8439) + known-answer tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(WEBLIB_SOURCES_NATIVE_ONLY
 option(WEBLIB_ENABLE_TLS "Build the experimental pure-C TLS 1.3 layer (native-only, UNAUDITED)" OFF)
 set(WEBLIB_SOURCES_TLS
     src/tls/tls.c
+    src/tls/chacha20.c
 )
 
 if(EMSCRIPTEN)

--- a/src/tls/chacha20.c
+++ b/src/tls/chacha20.c
@@ -74,6 +74,11 @@ void chacha20_block(const uint8_t key[32], uint32_t counter,
     for (i = 0; i < 16; i++) {
         store32_le(out + 4 * i, x[i] + state[i]);
     }
+
+    /* Wipe key-derived working state from the stack (state holds the key words,
+     * x the mixed state), matching the hygiene of the SHA-256/HMAC module. */
+    secure_zero(state, sizeof(state));
+    secure_zero(x, sizeof(x));
 }
 
 void chacha20_encrypt(const uint8_t key[32], uint32_t counter,

--- a/src/tls/chacha20.c
+++ b/src/tls/chacha20.c
@@ -1,0 +1,101 @@
+/*
+ * chacha20.c — ChaCha20 stream cipher (RFC 8439). EXPERIMENTAL / UNAUDITED.
+ *
+ * From-scratch implementation for the experimental pure-C TLS layer. Compiled
+ * only under -DWEBLIB_ENABLE_TLS=ON. Verified against RFC 8439 §2.3.2 / §2.4.2
+ * known-answer vectors in tests/test_tls_crypto.c.
+ */
+#include "chacha20.h"
+
+#ifdef WEBLIB_TLS
+
+#include "kamran.k"   /* secure_zero */
+#include <string.h>
+
+static uint32_t load32_le(const uint8_t *p) {
+    return (uint32_t)p[0] |
+           ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) |
+           ((uint32_t)p[3] << 24);
+}
+
+static void store32_le(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v);
+    p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16);
+    p[3] = (uint8_t)(v >> 24);
+}
+
+#define ROTL32(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
+
+/* ChaCha quarter round (RFC 8439 §2.1) operating on four state words. */
+#define QUARTERROUND(s, a, b, c, d)              \
+    do {                                         \
+        (s)[a] += (s)[b]; (s)[d] ^= (s)[a]; (s)[d] = ROTL32((s)[d], 16); \
+        (s)[c] += (s)[d]; (s)[b] ^= (s)[c]; (s)[b] = ROTL32((s)[b], 12); \
+        (s)[a] += (s)[b]; (s)[d] ^= (s)[a]; (s)[d] = ROTL32((s)[d],  8); \
+        (s)[c] += (s)[d]; (s)[b] ^= (s)[c]; (s)[b] = ROTL32((s)[b],  7); \
+    } while (0)
+
+void chacha20_block(const uint8_t key[32], uint32_t counter,
+                    const uint8_t nonce[12], uint8_t out[64]) {
+    uint32_t state[16];
+    uint32_t x[16];
+    int i;
+
+    /* Constants: "expand 32-byte k" (RFC 8439 §2.3). */
+    state[0] = 0x61707865;
+    state[1] = 0x3320646e;
+    state[2] = 0x79622d32;
+    state[3] = 0x6b206574;
+    for (i = 0; i < 8; i++) {
+        state[4 + i] = load32_le(key + 4 * i);
+    }
+    state[12] = counter;
+    state[13] = load32_le(nonce + 0);
+    state[14] = load32_le(nonce + 4);
+    state[15] = load32_le(nonce + 8);
+
+    memcpy(x, state, sizeof(x));
+
+    /* 20 rounds = 10 iterations of (4 column + 4 diagonal) quarter rounds. */
+    for (i = 0; i < 10; i++) {
+        QUARTERROUND(x, 0, 4,  8, 12);
+        QUARTERROUND(x, 1, 5,  9, 13);
+        QUARTERROUND(x, 2, 6, 10, 14);
+        QUARTERROUND(x, 3, 7, 11, 15);
+        QUARTERROUND(x, 0, 5, 10, 15);
+        QUARTERROUND(x, 1, 6, 11, 12);
+        QUARTERROUND(x, 2, 7,  8, 13);
+        QUARTERROUND(x, 3, 4,  9, 14);
+    }
+
+    /* Add the original state and serialize little-endian. */
+    for (i = 0; i < 16; i++) {
+        store32_le(out + 4 * i, x[i] + state[i]);
+    }
+}
+
+void chacha20_encrypt(const uint8_t key[32], uint32_t counter,
+                      const uint8_t nonce[12],
+                      const uint8_t *in, size_t len, uint8_t *out) {
+    uint8_t ks[64];
+
+    while (len > 0) {
+        size_t n = len < 64 ? len : 64;
+        size_t i;
+
+        chacha20_block(key, counter, nonce, ks);
+        for (i = 0; i < n; i++) {
+            out[i] = in[i] ^ ks[i];
+        }
+        in += n;
+        out += n;
+        len -= n;
+        counter++;   /* wraps at 2^32 blocks (256 GiB) per (key, nonce) */
+    }
+
+    secure_zero(ks, sizeof(ks));
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/chacha20.h
+++ b/src/tls/chacha20.h
@@ -1,0 +1,39 @@
+/*
+ * chacha20.h — ChaCha20 stream cipher (RFC 8439). EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON (native-only). One of the from-scratch primitives for
+ * the TLS_CHACHA20_POLY1305_SHA256 cipher suite. Verified against the RFC 8439
+ * §2.3.2 (block) and §2.4.2 (encryption) known-answer vectors — see
+ * tests/test_tls_crypto.c.
+ *
+ * ChaCha20 is constant-time by construction (only 32-bit add / xor / rotate on
+ * fixed-size state; no secret-dependent branches or table lookups).
+ */
+#ifndef WEBLIB_TLS_CHACHA20_H
+#define WEBLIB_TLS_CHACHA20_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Generate one 64-byte ChaCha20 keystream block for the given 256-bit key,
+ * 32-bit block counter, and 96-bit nonce (RFC 8439 §2.3). `out` receives 64 bytes.
+ */
+void chacha20_block(const uint8_t key[32], uint32_t counter,
+                    const uint8_t nonce[12], uint8_t out[64]);
+
+/*
+ * Encrypt (or decrypt — the operation is its own inverse) `len` bytes from `in`
+ * to `out` by XOR with the ChaCha20 keystream, starting at block `counter`
+ * (RFC 8439 §2.4). `in` and `out` may alias. The internal keystream buffer is
+ * wiped before return. The 32-bit counter limits one (key, nonce) to 256 GiB.
+ */
+void chacha20_encrypt(const uint8_t key[32], uint32_t counter,
+                      const uint8_t nonce[12],
+                      const uint8_t *in, size_t len, uint8_t *out);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_CHACHA20_H */

--- a/src/tls/chacha20.h
+++ b/src/tls/chacha20.h
@@ -28,8 +28,9 @@ void chacha20_block(const uint8_t key[32], uint32_t counter,
 /*
  * Encrypt (or decrypt — the operation is its own inverse) `len` bytes from `in`
  * to `out` by XOR with the ChaCha20 keystream, starting at block `counter`
- * (RFC 8439 §2.4). `in` and `out` may alias. The internal keystream buffer is
- * wiped before return. The 32-bit counter limits one (key, nonce) to 256 GiB.
+ * (RFC 8439 §2.4). `out` may be the same buffer as `in` (in-place); partially
+ * overlapping buffers are not supported. The internal keystream buffer is wiped
+ * before return. The 32-bit counter limits one (key, nonce) to 256 GiB.
  */
 void chacha20_encrypt(const uint8_t key[32], uint32_t counter,
                       const uint8_t nonce[12],

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,13 @@ if(NOT EMSCRIPTEN)
         target_compile_definitions(test_tls PRIVATE WEBLIB_TLS)
         target_link_libraries(test_tls weblib ${PLATFORM_LIBS})
         add_test(NAME TlsTests COMMAND test_tls)
+
+        # TLS crypto primitive known-answer tests (ChaCha20, ... each vs its RFC vector)
+        add_executable(test_tls_crypto test_tls_crypto.c)
+        target_include_directories(test_tls_crypto PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls)
+        target_compile_definitions(test_tls_crypto PRIVATE WEBLIB_TLS)
+        target_link_libraries(test_tls_crypto weblib ${PLATFORM_LIBS})
+        add_test(NAME TlsCryptoTests COMMAND test_tls_crypto)
     endif()
 endif()
 

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -68,11 +68,22 @@ static void test_chacha20_encrypt(void) {
         "Ladies and Gentlemen of the class of '99: If I could offer you "
         "only one tip for the future, sunscreen would be it.";
     uint8_t ct[114];
+    uint8_t rt[114];
+    size_t ptlen = strlen(pt);
     int i;
     for (i = 0; i < 32; i++) key[i] = (uint8_t)i;
 
-    chacha20_encrypt(key, 1, nonce, (const uint8_t *)pt, strlen(pt), ct);
-    check_hex("chacha20_encrypt (RFC 8439 2.4.2)", ct, sizeof(ct),
+    /* Guard the single message length so a future edit to `pt` can't silently
+     * overflow ct/rt or compare uninitialized tail bytes. */
+    if (ptlen != sizeof(ct)) {
+        printf("FAIL: chacha20 test plaintext is %zu bytes, expected %zu\n",
+               ptlen, sizeof(ct));
+        g_failures++;
+        return;
+    }
+
+    chacha20_encrypt(key, 1, nonce, (const uint8_t *)pt, ptlen, ct);
+    check_hex("chacha20_encrypt (RFC 8439 2.4.2)", ct, ptlen,
               "6e2e359a2568f98041ba0728dd0d6981"
               "e97e7aec1d4360c20a27afccfd9fae0b"
               "f91b65c5524733ab8f593dabcd62b357"
@@ -83,15 +94,12 @@ static void test_chacha20_encrypt(void) {
               "874d");
 
     /* Round-trip: decrypting the ciphertext restores the plaintext. */
-    {
-        uint8_t rt[114];
-        chacha20_encrypt(key, 1, nonce, ct, sizeof(ct), rt);
-        if (memcmp(rt, pt, sizeof(ct)) != 0) {
-            printf("FAIL: chacha20 encrypt/decrypt round-trip\n");
-            g_failures++;
-        } else {
-            printf("PASS: chacha20 encrypt/decrypt round-trip\n");
-        }
+    chacha20_encrypt(key, 1, nonce, ct, ptlen, rt);
+    if (memcmp(rt, pt, ptlen) != 0) {
+        printf("FAIL: chacha20 encrypt/decrypt round-trip\n");
+        g_failures++;
+    } else {
+        printf("PASS: chacha20 encrypt/decrypt round-trip\n");
     }
 }
 #endif /* WEBLIB_TLS */

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -1,0 +1,112 @@
+/*
+ * test_tls_crypto.c — known-answer tests for the experimental TLS crypto
+ * primitives. Built and run only when configured with -DWEBLIB_ENABLE_TLS=ON.
+ *
+ * Every primitive is checked against its official RFC test vector; no primitive
+ * is trusted (or used elsewhere) until its KAT passes here.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#ifdef WEBLIB_TLS
+#include "chacha20.h"
+#endif
+
+static int g_failures = 0;
+
+static void to_hex(const uint8_t *buf, size_t len, char *out) {
+    static const char hexchars[] = "0123456789abcdef";
+    size_t i;
+    for (i = 0; i < len; i++) {
+        out[i * 2]     = hexchars[buf[i] >> 4];
+        out[i * 2 + 1] = hexchars[buf[i] & 0x0f];
+    }
+    out[len * 2] = '\0';
+}
+
+static void check_hex(const char *label, const uint8_t *got, size_t len,
+                      const char *expected_hex) {
+    char hex[512];
+    if (len * 2 + 1 > sizeof(hex)) {
+        printf("FAIL: %s: buffer too small\n", label);
+        g_failures++;
+        return;
+    }
+    to_hex(got, len, hex);
+    if (strcmp(hex, expected_hex) != 0) {
+        printf("FAIL: %s\n  expected %s\n  got      %s\n", label, expected_hex, hex);
+        g_failures++;
+    } else {
+        printf("PASS: %s\n", label);
+    }
+}
+
+#ifdef WEBLIB_TLS
+/* RFC 8439 §2.3.2 — ChaCha20 block function known-answer test. */
+static void test_chacha20_block(void) {
+    uint8_t key[32];
+    uint8_t nonce[12] = { 0, 0, 0, 0x09, 0, 0, 0, 0x4a, 0, 0, 0, 0 };
+    uint8_t out[64];
+    int i;
+    for (i = 0; i < 32; i++) key[i] = (uint8_t)i;
+
+    chacha20_block(key, 1, nonce, out);
+    check_hex("chacha20_block (RFC 8439 2.3.2)", out, sizeof(out),
+              "10f1e7e4d13b5915500fdd1fa32071c4"
+              "c7d1f4c733c068030422aa9ac3d46c4e"
+              "d2826446079faa0914c2d705d98b02a2"
+              "b5129cd1de164eb9cbd083e8a2503c4e");
+}
+
+/* RFC 8439 §2.4.2 — ChaCha20 encryption known-answer test (114-byte message
+ * spanning two keystream blocks, initial counter 1). */
+static void test_chacha20_encrypt(void) {
+    uint8_t key[32];
+    uint8_t nonce[12] = { 0, 0, 0, 0, 0, 0, 0, 0x4a, 0, 0, 0, 0 };
+    const char *pt =
+        "Ladies and Gentlemen of the class of '99: If I could offer you "
+        "only one tip for the future, sunscreen would be it.";
+    uint8_t ct[114];
+    int i;
+    for (i = 0; i < 32; i++) key[i] = (uint8_t)i;
+
+    chacha20_encrypt(key, 1, nonce, (const uint8_t *)pt, strlen(pt), ct);
+    check_hex("chacha20_encrypt (RFC 8439 2.4.2)", ct, sizeof(ct),
+              "6e2e359a2568f98041ba0728dd0d6981"
+              "e97e7aec1d4360c20a27afccfd9fae0b"
+              "f91b65c5524733ab8f593dabcd62b357"
+              "1639d624e65152ab8f530c359f0861d8"
+              "07ca0dbf500d6a6156a38e088a22b65e"
+              "52bc514d16ccf806818ce91ab7793736"
+              "5af90bbf74a35be6b40b8eedf2785e42"
+              "874d");
+
+    /* Round-trip: decrypting the ciphertext restores the plaintext. */
+    {
+        uint8_t rt[114];
+        chacha20_encrypt(key, 1, nonce, ct, sizeof(ct), rt);
+        if (memcmp(rt, pt, sizeof(ct)) != 0) {
+            printf("FAIL: chacha20 encrypt/decrypt round-trip\n");
+            g_failures++;
+        } else {
+            printf("PASS: chacha20 encrypt/decrypt round-trip\n");
+        }
+    }
+}
+#endif /* WEBLIB_TLS */
+
+int main(void) {
+#ifndef WEBLIB_TLS
+    printf("FAIL: test_tls_crypto built without WEBLIB_TLS defined\n");
+    return 1;
+#else
+    test_chacha20_block();
+    test_chacha20_encrypt();
+
+    if (g_failures == 0) {
+        printf("All TLS crypto KATs passed.\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+#endif
+}


### PR DESCRIPTION
## Subsystem
`tls` crypto — first hand-written primitive for the `TLS_CHACHA20_POLY1305_SHA256` suite (TLS Phase 1). Follows the KAT-per-primitive discipline set by the SHA-256 module.

## What
- **`src/tls/chacha20.{c,h}`** — ChaCha20 (RFC 8439):
  - `chacha20_block()` — the §2.3 block function (constants `"expand 32-byte k"`, 256-bit key, 32-bit block counter, 96-bit nonce, 20 rounds = 10 column+diagonal quarter-round pairs).
  - `chacha20_encrypt()` — §2.4 XOR-keystream; `in`/`out` may alias; the keystream buffer is wiped with `secure_zero` before return.
  - **Constant-time by construction**: only 32-bit add/xor/rotate on fixed-size state, no secret-dependent branches or table lookups. 32-bit counter caps one (key, nonce) at 256 GiB.
- **`tests/test_tls_crypto.c` + `TlsCryptoTests`** — the KAT harness for TLS primitives.

## Safety / scope
Purely **additive** and gated behind `WEBLIB_TLS` (added to `WEBLIB_SOURCES_TLS`). The default build compiles **no** ChaCha20 code — `nm build/libweblib.a` shows no `chacha` symbol, and the default `ctest` is unchanged. No existing code is touched.

## Tests
- `chacha20_block` vs **RFC 8439 §2.3.2** keystream vector.
- `chacha20_encrypt` vs **RFC 8439 §2.4.2** (the 114-byte, two-keystream-block message, initial counter 1).
- encrypt/decrypt round-trip.

The exact RFC vectors were first reproduced by an **independent reference implementation** before being hardcoded (guards against a transcription typo). **Negative control:** running 18 rounds instead of 20 makes the block output diverge and fails the KAT — confirming the test pins the exact algorithm.

## Validation
- TLS build (`-DWEBLIB_ENABLE_TLS=ON`): `ctest` **8/8**, warning-free; the ChaCha20 KATs also pass under **ASan/UBSan**.
- Default build (TLS OFF): **6/6** on the normal and ASan/UBSan trees — unchanged.

## Next
Poly1305 (RFC 8439 §2.5) + its KAT, then the ChaCha20-Poly1305 AEAD (§2.8); in parallel, HKDF-SHA256 for the key schedule. The transport choke-point is deferred until Phase 3 integration (kept separate from this zero-risk crypto work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)