### PR TITLE
TLS Phase 1: Poly1305 one-time authenticator (RFC 8439) + KATs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ option(WEBLIB_ENABLE_TLS "Build the experimental pure-C TLS 1.3 layer (native-on
 set(WEBLIB_SOURCES_TLS
     src/tls/tls.c
     src/tls/chacha20.c
+    src/tls/poly1305.c
 )
 
 if(EMSCRIPTEN)

--- a/src/tls/poly1305.c
+++ b/src/tls/poly1305.c
@@ -1,0 +1,171 @@
+/*
+ * poly1305.c — Poly1305 one-time authenticator (RFC 8439 §2.5). EXPERIMENTAL / UNAUDITED.
+ *
+ * From-scratch implementation for the experimental pure-C TLS layer. Compiled
+ * only under -DWEBLIB_ENABLE_TLS=ON. Verified against RFC 8439 §2.5.2 (and edge
+ * cases) in tests/test_tls_crypto.c.
+ *
+ * The accumulator is held in five 26-bit limbs (h0..h4). Each 16-byte message
+ * block, taken as a little-endian integer with an appended high bit, is added to
+ * the accumulator, which is then multiplied by the clamped key r modulo the prime
+ * 2^130-5. All arithmetic is on fixed-size integers with no secret-dependent
+ * branch, index, or memory access.
+ */
+#include "poly1305.h"
+
+#ifdef WEBLIB_TLS
+
+#include "kamran.k"   /* secure_zero */
+#include <string.h>
+
+static uint32_t load32_le(const uint8_t *p) {
+    return (uint32_t)p[0] |
+           ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) |
+           ((uint32_t)p[3] << 24);
+}
+
+static void store32_le(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v);
+    p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16);
+    p[3] = (uint8_t)(v >> 24);
+}
+
+void poly1305_mac(const uint8_t key[32], const uint8_t *msg, size_t len,
+                  uint8_t tag[16]) {
+    uint32_t r0, r1, r2, r3, r4;
+    uint32_t s1, s2, s3, s4;
+    uint32_t h0, h1, h2, h3, h4;
+    uint32_t t0, t1, t2, t3;
+    uint32_t c;
+    uint8_t final_block[16];
+
+    /* Load and clamp r (the low 16 bytes of the key) into five 26-bit limbs.
+     * Clamp mask overall: 0x0ffffffc0ffffffc0ffffffc0fffffff. */
+    t0 = load32_le(key + 0);
+    t1 = load32_le(key + 4);
+    t2 = load32_le(key + 8);
+    t3 = load32_le(key + 12);
+    r0 =  t0                        & 0x03ffffff;
+    r1 = ((t0 >> 26) | (t1 <<  6))  & 0x03ffff03;
+    r2 = ((t1 >> 20) | (t2 << 12))  & 0x03ffc0ff;
+    r3 = ((t2 >> 14) | (t3 << 18))  & 0x03f03fff;
+    r4 =  (t3 >>  8)                & 0x000fffff;
+
+    /* Precompute 5*r1..5*r4 for the reduction mod 2^130-5. */
+    s1 = r1 * 5;
+    s2 = r2 * 5;
+    s3 = r3 * 5;
+    s4 = r4 * 5;
+
+    h0 = h1 = h2 = h3 = h4 = 0;
+
+    while (len > 0) {
+        const uint8_t *block;
+        uint32_t hibit;
+        uint64_t d0, d1, d2, d3, d4;
+
+        if (len >= 16) {
+            block = msg;
+            hibit = (UINT32_C(1) << 24);   /* 2^128: full block appends 0x01 at byte 16 */
+            msg += 16;
+            len -= 16;
+        } else {
+            /* Final partial block: copy, append the 0x01 bit right after the data. */
+            memset(final_block, 0, sizeof(final_block));
+            memcpy(final_block, msg, len);
+            final_block[len] = 1;
+            block = final_block;
+            hibit = 0;                       /* the high bit is explicit in the buffer */
+            len = 0;
+        }
+
+        /* h += block */
+        t0 = load32_le(block + 0);
+        t1 = load32_le(block + 4);
+        t2 = load32_le(block + 8);
+        t3 = load32_le(block + 12);
+        h0 +=  t0                       & 0x03ffffff;
+        h1 += ((t0 >> 26) | (t1 <<  6)) & 0x03ffffff;
+        h2 += ((t1 >> 20) | (t2 << 12)) & 0x03ffffff;
+        h3 += ((t2 >> 14) | (t3 << 18)) & 0x03ffffff;
+        h4 +=  (t3 >>  8) | hibit;
+
+        /* h *= r (schoolbook, folding the 2^130 overflow back with the *5 terms) */
+        d0 = (uint64_t)h0 * r0 + (uint64_t)h1 * s4 + (uint64_t)h2 * s3 + (uint64_t)h3 * s2 + (uint64_t)h4 * s1;
+        d1 = (uint64_t)h0 * r1 + (uint64_t)h1 * r0 + (uint64_t)h2 * s4 + (uint64_t)h3 * s3 + (uint64_t)h4 * s2;
+        d2 = (uint64_t)h0 * r2 + (uint64_t)h1 * r1 + (uint64_t)h2 * r0 + (uint64_t)h3 * s4 + (uint64_t)h4 * s3;
+        d3 = (uint64_t)h0 * r3 + (uint64_t)h1 * r2 + (uint64_t)h2 * r1 + (uint64_t)h3 * r0 + (uint64_t)h4 * s4;
+        d4 = (uint64_t)h0 * r4 + (uint64_t)h1 * r3 + (uint64_t)h2 * r2 + (uint64_t)h3 * r1 + (uint64_t)h4 * r0;
+
+        /* Partial carry propagation back into 26-bit limbs. */
+        c  = (uint32_t)(d0 >> 26); h0 = (uint32_t)d0 & 0x03ffffff;
+        d1 += c; c = (uint32_t)(d1 >> 26); h1 = (uint32_t)d1 & 0x03ffffff;
+        d2 += c; c = (uint32_t)(d2 >> 26); h2 = (uint32_t)d2 & 0x03ffffff;
+        d3 += c; c = (uint32_t)(d3 >> 26); h3 = (uint32_t)d3 & 0x03ffffff;
+        d4 += c; c = (uint32_t)(d4 >> 26); h4 = (uint32_t)d4 & 0x03ffffff;
+        h0 += c * 5; c = h0 >> 26; h0 &= 0x03ffffff;
+        h1 += c;
+    }
+
+    /* Fully carry h. */
+    c = h1 >> 26; h1 &= 0x03ffffff; h2 += c;
+    c = h2 >> 26; h2 &= 0x03ffffff; h3 += c;
+    c = h3 >> 26; h3 &= 0x03ffffff; h4 += c;
+    c = h4 >> 26; h4 &= 0x03ffffff; h0 += c * 5;
+    c = h0 >> 26; h0 &= 0x03ffffff; h1 += c;
+
+    /* Compute g = h - p = h + 5 - 2^130, then select g if h >= p else h. */
+    {
+        uint32_t g0, g1, g2, g3, g4;
+        uint32_t mask;
+
+        g0 = h0 + 5; c = g0 >> 26; g0 &= 0x03ffffff;
+        g1 = h1 + c; c = g1 >> 26; g1 &= 0x03ffffff;
+        g2 = h2 + c; c = g2 >> 26; g2 &= 0x03ffffff;
+        g3 = h3 + c; c = g3 >> 26; g3 &= 0x03ffffff;
+        g4 = h4 + c - (UINT32_C(1) << 26);
+
+        /* mask = 0xffffffff if h >= p (g did not borrow), else 0. */
+        mask = (g4 >> 31) - 1;
+        g0 &= mask; g1 &= mask; g2 &= mask; g3 &= mask; g4 &= mask;
+        mask = ~mask;
+        h0 = (h0 & mask) | g0;
+        h1 = (h1 & mask) | g1;
+        h2 = (h2 & mask) | g2;
+        h3 = (h3 & mask) | g3;
+        h4 = (h4 & mask) | g4;
+    }
+
+    /* Reassemble the 130-bit value into four 32-bit words (mod 2^128). */
+    {
+        uint32_t hh0, hh1, hh2, hh3;
+        uint64_t f;
+
+        hh0 = ((h0)       | (h1 << 26));
+        hh1 = ((h1 >>  6) | (h2 << 20));
+        hh2 = ((h2 >> 12) | (h3 << 14));
+        hh3 = ((h3 >> 18) | (h4 <<  8));
+
+        /* tag = (h + s) mod 2^128, where s is the high 16 bytes of the key. */
+        f = (uint64_t)hh0 + load32_le(key + 16);                 hh0 = (uint32_t)f;
+        f = (uint64_t)hh1 + load32_le(key + 20) + (f >> 32);     hh1 = (uint32_t)f;
+        f = (uint64_t)hh2 + load32_le(key + 24) + (f >> 32);     hh2 = (uint32_t)f;
+        f = (uint64_t)hh3 + load32_le(key + 28) + (f >> 32);     hh3 = (uint32_t)f;
+
+        store32_le(tag + 0,  hh0);
+        store32_le(tag + 4,  hh1);
+        store32_le(tag + 8,  hh2);
+        store32_le(tag + 12, hh3);
+    }
+
+    /* Wipe the stack copy of the last message block. The key-derived scalars
+     * (r/s) and accumulator (h) are held in local scalars that a portable C
+     * implementation cannot reliably clear (the compiler may keep register-only
+     * copies), so they are not "wiped" with an ineffective self-assignment; the
+     * one-time key they derive from is the caller's to manage. */
+    secure_zero(final_block, sizeof(final_block));
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/poly1305.h
+++ b/src/tls/poly1305.h
@@ -1,0 +1,32 @@
+/*
+ * poly1305.h — Poly1305 one-time authenticator (RFC 8439 §2.5). EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON (native-only). Pairs with ChaCha20 to form the
+ * TLS_CHACHA20_POLY1305_SHA256 AEAD. Verified against the RFC 8439 §2.5.2
+ * known-answer vector (and several edge cases) — see tests/test_tls_crypto.c.
+ *
+ * Implementation uses 26-bit limbs with 64-bit products (the well-known
+ * constant-time approach): the field arithmetic mod 2^130-5 has no
+ * secret-dependent branches, indexing, or table lookups.
+ *
+ * SECURITY: the 32-byte key is a ONE-TIME key — a given key must authenticate at
+ * most one message. In the AEAD it is derived per-record from ChaCha20.
+ */
+#ifndef WEBLIB_TLS_POLY1305_H
+#define WEBLIB_TLS_POLY1305_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Compute the 16-byte Poly1305 tag of `msg` (`len` bytes) under the 32-byte
+ * one-time `key` (r || s), writing it to `tag`. `len` may be zero.
+ */
+void poly1305_mac(const uint8_t key[32], const uint8_t *msg, size_t len,
+                  uint8_t tag[16]);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_POLY1305_H */

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -11,9 +11,24 @@
 
 #ifdef WEBLIB_TLS
 #include "chacha20.h"
+#include "poly1305.h"
 #endif
 
 static int g_failures = 0;
+
+static int hexval(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return 0;
+}
+
+static void from_hex(const char *hex, uint8_t *out, size_t out_len) {
+    size_t i;
+    for (i = 0; i < out_len; i++) {
+        out[i] = (uint8_t)((hexval(hex[i * 2]) << 4) | hexval(hex[i * 2 + 1]));
+    }
+}
 
 static void to_hex(const uint8_t *buf, size_t len, char *out) {
     static const char hexchars[] = "0123456789abcdef";
@@ -102,6 +117,48 @@ static void test_chacha20_encrypt(void) {
         printf("PASS: chacha20 encrypt/decrypt round-trip\n");
     }
 }
+
+/* Poly1305 one-time authenticator — RFC 8439 §2.5.2 plus edge cases (empty,
+ * exact block boundary, multi-block, all-zero, and r==0 -> tag==s). */
+static void test_poly1305(void) {
+    uint8_t key[32];
+    uint8_t tag[16];
+
+    /* §2.5.2: 34-byte message = two full blocks + a 2-byte partial. */
+    from_hex("85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b", key, 32);
+    poly1305_mac(key, (const uint8_t *)"Cryptographic Forum Research Group", 34, tag);
+    check_hex("poly1305 (RFC 8439 2.5.2)", tag, 16, "a8061dc1305136c6c22b8baf0c0127a9");
+
+    /* Empty message: h stays 0, so tag == s (low 16 key bytes). */
+    poly1305_mac(key, (const uint8_t *)"", 0, tag);
+    check_hex("poly1305 (empty message)", tag, 16, "0103808afb0db2fd4abff6af4149f51b");
+
+    /* Exactly one full block (no partial tail). */
+    poly1305_mac(key, (const uint8_t *)"AAAAAAAAAAAAAAAA", 16, tag);
+    check_hex("poly1305 (16-byte exact block)", tag, 16, "de2bee86006afbcacfa53531f0e8a349");
+
+    /* Three full blocks. */
+    {
+        uint8_t m48[48];
+        memset(m48, 'A', sizeof(m48));
+        poly1305_mac(key, m48, sizeof(m48), tag);
+        check_hex("poly1305 (48-byte, 3 blocks)", tag, 16, "15ca928ec41e68d06bc625c742b0c956");
+    }
+
+    /* RFC 8439 A.3 #1: all-zero key + 64-byte zero message -> all-zero tag. */
+    {
+        uint8_t zk[32] = { 0 };
+        uint8_t zm[64] = { 0 };
+        poly1305_mac(zk, zm, sizeof(zm), tag);
+        check_hex("poly1305 (A.3 #1, all zero)", tag, 16, "00000000000000000000000000000000");
+    }
+
+    /* r == 0 (clamped) -> accumulator stays 0 -> tag == s. Exercises the case
+     * where no reduction subtraction is needed. */
+    from_hex("0000000000000000000000000000000036e5f6b5c5e06070f0efca96227a863e", key, 32);
+    poly1305_mac(key, (const uint8_t *)"any message here, r is zero so tag=s", 36, tag);
+    check_hex("poly1305 (r=0 -> tag=s)", tag, 16, "36e5f6b5c5e06070f0efca96227a863e");
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -111,6 +168,7 @@ int main(void) {
 #else
     test_chacha20_block();
     test_chacha20_encrypt();
+    test_poly1305();
 
     if (g_failures == 0) {
         printf("All TLS crypto KATs passed.\n");

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -20,13 +20,24 @@ static int hexval(char c) {
     if (c >= '0' && c <= '9') return c - '0';
     if (c >= 'a' && c <= 'f') return c - 'a' + 10;
     if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-    return 0;
+    return -1;   /* not a hex digit */
 }
 
+/* Decode exactly out_len bytes of hex from `hex`. Fails (marks g_failures, zeroes
+ * out) if the string is too short or contains a non-hex character — never reads
+ * past the terminating NUL. */
 static void from_hex(const char *hex, uint8_t *out, size_t out_len) {
     size_t i;
     for (i = 0; i < out_len; i++) {
-        out[i] = (uint8_t)((hexval(hex[i * 2]) << 4) | hexval(hex[i * 2 + 1]));
+        int hi = 0, lo = 0;
+        if (hex[i * 2] == '\0' || hex[i * 2 + 1] == '\0' ||
+            (hi = hexval(hex[i * 2])) < 0 || (lo = hexval(hex[i * 2 + 1])) < 0) {
+            printf("FAIL: from_hex: short or non-hex input\n");
+            g_failures++;
+            memset(out, 0, out_len);
+            return;
+        }
+        out[i] = (uint8_t)((hi << 4) | lo);
     }
 }
 
@@ -125,11 +136,14 @@ static void test_poly1305(void) {
     uint8_t tag[16];
 
     /* §2.5.2: 34-byte message = two full blocks + a 2-byte partial. */
-    from_hex("85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b", key, 32);
-    poly1305_mac(key, (const uint8_t *)"Cryptographic Forum Research Group", 34, tag);
-    check_hex("poly1305 (RFC 8439 2.5.2)", tag, 16, "a8061dc1305136c6c22b8baf0c0127a9");
+    {
+        const char *msg = "Cryptographic Forum Research Group";
+        from_hex("85d6be7857556d337f4452fe42d506a80103808afb0db2fd4abff6af4149f51b", key, 32);
+        poly1305_mac(key, (const uint8_t *)msg, strlen(msg), tag);
+        check_hex("poly1305 (RFC 8439 2.5.2)", tag, 16, "a8061dc1305136c6c22b8baf0c0127a9");
+    }
 
-    /* Empty message: h stays 0, so tag == s (low 16 key bytes). */
+    /* Empty message: h stays 0, so tag == s (the HIGH 16 key bytes, 0103...f51b). */
     poly1305_mac(key, (const uint8_t *)"", 0, tag);
     check_hex("poly1305 (empty message)", tag, 16, "0103808afb0db2fd4abff6af4149f51b");
 
@@ -155,9 +169,12 @@ static void test_poly1305(void) {
 
     /* r == 0 (clamped) -> accumulator stays 0 -> tag == s. Exercises the case
      * where no reduction subtraction is needed. */
-    from_hex("0000000000000000000000000000000036e5f6b5c5e06070f0efca96227a863e", key, 32);
-    poly1305_mac(key, (const uint8_t *)"any message here, r is zero so tag=s", 36, tag);
-    check_hex("poly1305 (r=0 -> tag=s)", tag, 16, "36e5f6b5c5e06070f0efca96227a863e");
+    {
+        const char *msg = "any message here, r is zero so tag=s";
+        from_hex("0000000000000000000000000000000036e5f6b5c5e06070f0efca96227a863e", key, 32);
+        poly1305_mac(key, (const uint8_t *)msg, strlen(msg), tag);
+        check_hex("poly1305 (r=0 -> tag=s)", tag, 16, "36e5f6b5c5e06070f0efca96227a863e");
+    }
 }
 #endif /* WEBLIB_TLS */
 


### PR DESCRIPTION
## Subsystem
`tls` crypto — second hand-written primitive for `TLS_CHACHA20_POLY1305_SHA256` (follows the ChaCha20 PR). Pairs with ChaCha20 to build the AEAD next.

## What
- **`src/tls/poly1305.{c,h}`** — `poly1305_mac(key[32], msg, len, tag[16])`, the RFC 8439 §2.5 one-time authenticator.
  - Field arithmetic **mod 2^130-5 in five 26-bit limbs** with 64-bit products — the standard constant-time formulation: no secret-dependent branch, index, or table lookup.
  - Correct handling of the final **partial block** (explicit `0x01` high bit placed after the data) and the **constant-time `h >= p` final reduction** (compute `g = h − p`, select via a mask, no branch).
  - `r` clamp `0x0ffffffc0ffffffc0ffffffc0fffffff`; tag = `(h + s) mod 2^128`.

## Safety / scope
Purely **additive**, gated behind `WEBLIB_TLS` (in `WEBLIB_SOURCES_TLS`). Default build compiles no Poly1305 — `nm build/libweblib.a` shows no `poly1305` symbol; default `ctest` unchanged. No existing code touched.

## Tests (6 KATs)
- **RFC 8439 §2.5.2** — the 34-byte message (two full blocks **+ a 2-byte partial**, so both paths are covered).
- **empty** message → tag == `s`.
- **16-byte exact** block (no partial tail).
- **48-byte** three-block message.
- **RFC A.3 #1** — all-zero key + 64-byte zero message → all-zero tag.
- **r == 0** (clamped) → accumulator stays 0 → tag == `s`.

RFC-published vectors plus edge cases were **cross-checked against an independent big-integer reference** before hardcoding. **Negative control:** a wrong `r` clamp fails exactly the nonzero-`r` vectors (§2.5.2/16B/48B) while the r=0/empty/all-zero cases correctly still pass — so the KATs pin the arithmetic.

## Validation
- TLS build (`-DWEBLIB_ENABLE_TLS=ON`): `ctest` **8/8**, warning-free; Poly1305 KATs pass under **ASan/UBSan** (no overflow/UB in the limb arithmetic).
- Default build (TLS OFF): **6/6** on the normal and ASan/UBSan trees — unchanged.

## Note
`poly1305_mac` wipes the stack copy of the last message block; the `r`/`h` values live in scalar locals that portable C can't reliably clear (register copies), so they're not wiped with an ineffective self-assignment — documented in the source.

## Next
The ChaCha20-Poly1305 AEAD (RFC 8439 §2.8) combining these two, with its §2.8.2 KAT — including the Poly1305 key derivation (ChaCha20 block 0) and the AAD/ciphertext/length MAC construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)