### PR TITLE
TLS Phase 1: ChaCha20-Poly1305 AEAD (RFC 8439 §2.8) + KAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/tls.c
     src/tls/chacha20.c
     src/tls/poly1305.c
+    src/tls/chacha20poly1305.c
 )
 
 if(EMSCRIPTEN)

--- a/src/tls/chacha20poly1305.c
+++ b/src/tls/chacha20poly1305.c
@@ -1,0 +1,122 @@
+/*
+ * chacha20poly1305.c — ChaCha20-Poly1305 AEAD (RFC 8439 §2.8). EXPERIMENTAL / UNAUDITED.
+ *
+ * Combines the chacha20 and poly1305 primitives. Compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON. Verified against RFC 8439 §2.8.2 in
+ * tests/test_tls_crypto.c.
+ *
+ * Construction (RFC 8439 §2.8):
+ *   otk        = chacha20_block(key, counter=0, nonce)[0..31]   (one-time Poly1305 key)
+ *   ciphertext = chacha20_encrypt(key, counter=1, nonce, plaintext)
+ *   mac_data   = aad || pad16(aad) || ct || pad16(ct) || le64(len aad) || le64(len ct)
+ *   tag        = poly1305(otk, mac_data)
+ */
+#include "chacha20poly1305.h"
+
+#ifdef WEBLIB_TLS
+
+#include "chacha20.h"
+#include "poly1305.h"
+#include "kamran.k"   /* secure_zero, secure_compare */
+#include <stdlib.h>
+#include <string.h>
+
+static void store64_le(uint8_t *p, uint64_t v) {
+    int i;
+    for (i = 0; i < 8; i++) {
+        p[i] = (uint8_t)(v >> (8 * i));
+    }
+}
+
+/*
+ * Compute the Poly1305 tag over the AEAD MAC input for (aad, ct) under the
+ * one-time key `otk`. The MAC input (aad, ciphertext, and 16 length bytes) is all
+ * public data, so the scratch buffer is not secret; it is heap-allocated because
+ * its size is unbounded. Returns 1 on success, 0 on allocation failure.
+ */
+static int aead_tag(const uint8_t otk[32],
+                    const uint8_t *aad, size_t aad_len,
+                    const uint8_t *ct, size_t ct_len,
+                    uint8_t tag[16]) {
+    size_t aad_pad = (16 - (aad_len % 16)) % 16;
+    size_t ct_pad  = (16 - (ct_len  % 16)) % 16;
+    size_t mac_len = aad_len + aad_pad + ct_len + ct_pad + 16;
+    uint8_t *m;
+    size_t off = 0;
+
+    m = (uint8_t *)malloc(mac_len);
+    if (m == NULL) {
+        return 0;
+    }
+
+    if (aad_len > 0) {
+        memcpy(m + off, aad, aad_len);
+    }
+    off += aad_len;
+    memset(m + off, 0, aad_pad);
+    off += aad_pad;
+    if (ct_len > 0) {
+        memcpy(m + off, ct, ct_len);
+    }
+    off += ct_len;
+    memset(m + off, 0, ct_pad);
+    off += ct_pad;
+    store64_le(m + off, (uint64_t)aad_len);
+    off += 8;
+    store64_le(m + off, (uint64_t)ct_len);
+
+    poly1305_mac(otk, m, mac_len, tag);
+
+    free(m);
+    return 1;
+}
+
+int chacha20poly1305_seal(const uint8_t key[32], const uint8_t nonce[12],
+                          const uint8_t *aad, size_t aad_len,
+                          const uint8_t *pt, size_t pt_len,
+                          uint8_t *ct, uint8_t tag[16]) {
+    uint8_t block0[64];
+    int ok;
+
+    /* One-time Poly1305 key = first 32 bytes of the counter-0 keystream block. */
+    chacha20_block(key, 0, nonce, block0);
+
+    /* Encrypt starting at block counter 1. */
+    chacha20_encrypt(key, 1, nonce, pt, pt_len, ct);
+
+    ok = aead_tag(block0, aad, aad_len, ct, pt_len, tag);
+
+    secure_zero(block0, sizeof(block0));   /* wipe the derived Poly1305 key */
+    return ok;
+}
+
+int chacha20poly1305_open(const uint8_t key[32], const uint8_t nonce[12],
+                          const uint8_t *aad, size_t aad_len,
+                          const uint8_t *ct, size_t ct_len,
+                          const uint8_t tag[16], uint8_t *pt) {
+    uint8_t block0[64];
+    uint8_t computed_tag[16];
+
+    chacha20_block(key, 0, nonce, block0);
+
+    if (!aead_tag(block0, aad, aad_len, ct, ct_len, computed_tag)) {
+        secure_zero(block0, sizeof(block0));
+        return 0;                          /* allocation failure */
+    }
+
+    /* Verify the tag in constant time BEFORE decrypting — never release plaintext
+     * on an authentication failure. */
+    if (!secure_compare(computed_tag, tag, 16)) {
+        secure_zero(block0, sizeof(block0));
+        secure_zero(computed_tag, sizeof(computed_tag));
+        return 0;                          /* authentication failed */
+    }
+
+    chacha20_encrypt(key, 1, nonce, ct, ct_len, pt);
+
+    secure_zero(block0, sizeof(block0));
+    secure_zero(computed_tag, sizeof(computed_tag));
+    return 1;
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/chacha20poly1305.c
+++ b/src/tls/chacha20poly1305.c
@@ -38,11 +38,22 @@ static int aead_tag(const uint8_t otk[32],
                     const uint8_t *aad, size_t aad_len,
                     const uint8_t *ct, size_t ct_len,
                     uint8_t tag[16]) {
-    size_t aad_pad = (16 - (aad_len % 16)) % 16;
-    size_t ct_pad  = (16 - (ct_len  % 16)) % 16;
-    size_t mac_len = aad_len + aad_pad + ct_len + ct_pad + 16;
+    size_t aad_pad, ct_pad, mac_len;
     uint8_t *m;
     size_t off = 0;
+
+    /* Guard against size_t overflow when sizing the MAC input. Each pad adds < 16
+     * bytes and the length block adds 16, so the total is at most aad_len + ct_len
+     * + 46; an overflow here would under-size the malloc and lead to out-of-bounds
+     * writes below. (In TLS these lengths are bounded by the record size, but the
+     * primitive must be safe for any caller.) */
+    if (ct_len > SIZE_MAX - 46 || aad_len > SIZE_MAX - 46 - ct_len) {
+        return 0;
+    }
+
+    aad_pad = (16 - (aad_len % 16)) % 16;
+    ct_pad  = (16 - (ct_len  % 16)) % 16;
+    mac_len = aad_len + aad_pad + ct_len + ct_pad + 16;
 
     m = (uint8_t *)malloc(mac_len);
     if (m == NULL) {

--- a/src/tls/chacha20poly1305.h
+++ b/src/tls/chacha20poly1305.h
@@ -1,0 +1,46 @@
+/*
+ * chacha20poly1305.h — ChaCha20-Poly1305 AEAD (RFC 8439 §2.8). EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON (native-only). This is the AEAD of the
+ * TLS_CHACHA20_POLY1305_SHA256 cipher suite, built from the chacha20 and
+ * poly1305 primitives. Verified against the RFC 8439 §2.8.2 known-answer vector —
+ * see tests/test_tls_crypto.c.
+ *
+ * The nonce is the 96-bit per-record nonce (in TLS 1.3, the sequence number XORed
+ * with the write IV). A given (key, nonce) pair must NEVER be reused to seal two
+ * different messages.
+ */
+#ifndef WEBLIB_TLS_CHACHA20POLY1305_H
+#define WEBLIB_TLS_CHACHA20POLY1305_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Seal: encrypt `pt` (`pt_len` bytes) and authenticate it together with `aad`
+ * (`aad_len` bytes). Writes `pt_len` bytes of ciphertext to `ct` and the 16-byte
+ * authentication tag to `tag`. `ct` may equal `pt` (in-place). `aad` may be NULL
+ * iff `aad_len` is 0. Returns 1 on success, 0 on internal allocation failure.
+ */
+int chacha20poly1305_seal(const uint8_t key[32], const uint8_t nonce[12],
+                          const uint8_t *aad, size_t aad_len,
+                          const uint8_t *pt, size_t pt_len,
+                          uint8_t *ct, uint8_t tag[16]);
+
+/*
+ * Open: verify `tag` over `aad` + `ct`, and ONLY if it is authentic decrypt `ct`
+ * (`ct_len` bytes) into `pt`. `pt` may equal `ct` (in-place). Returns 1 if the tag
+ * is valid (and `pt` has been written), 0 otherwise — on failure `pt` is left
+ * untouched. The tag comparison is constant-time; plaintext is never released on a
+ * verification failure.
+ */
+int chacha20poly1305_open(const uint8_t key[32], const uint8_t nonce[12],
+                          const uint8_t *aad, size_t aad_len,
+                          const uint8_t *ct, size_t ct_len,
+                          const uint8_t tag[16], uint8_t *pt);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_CHACHA20POLY1305_H */

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -178,6 +178,27 @@ static void test_poly1305(void) {
     }
 }
 
+/* Assert open() both rejected the input (returned 0) AND left the output buffer
+ * untouched (still the 0xEE sentinel it was pre-filled with) — i.e. no plaintext
+ * was released on an authentication failure. */
+static void check_aead_rejected(const char *label, int open_result,
+                                const uint8_t *out, size_t out_len) {
+    size_t i;
+    int untouched = 1;
+    for (i = 0; i < out_len; i++) {
+        if (out[i] != 0xEE) { untouched = 0; break; }
+    }
+    if (open_result != 0) {
+        printf("FAIL: %s: open() accepted tampered input\n", label);
+        g_failures++;
+    } else if (!untouched) {
+        printf("FAIL: %s: open() wrote to the output buffer on failure\n", label);
+        g_failures++;
+    } else {
+        printf("PASS: %s\n", label);
+    }
+}
+
 /* ChaCha20-Poly1305 AEAD — RFC 8439 §2.8.2 KAT, a seal/open round-trip, and
  * tamper-detection on the ciphertext, tag, and AAD. */
 static void test_chacha20poly1305(void) {
@@ -226,33 +247,28 @@ static void test_chacha20poly1305(void) {
     }
 
     /* Tamper detection: a single-bit change in ct, tag, or aad must be rejected,
-     * and the plaintext buffer must not be touched. */
+     * and the output buffer must be left untouched (no plaintext released). Each
+     * case pre-fills `out` with a 0xEE sentinel that check_aead_rejected verifies. */
     {
         uint8_t bad[114];
         uint8_t btag[16];
         uint8_t baad[12];
+        int r;
 
         memcpy(bad, ct, pt_len); bad[0] ^= 0x01;
         memset(out, 0xEE, sizeof(out));
-        if (chacha20poly1305_open(key, nonce, aad, sizeof(aad), bad, pt_len, tag, out) != 0) {
-            printf("FAIL: aead accepted tampered ciphertext\n"); g_failures++;
-        } else {
-            printf("PASS: aead rejects tampered ciphertext\n");
-        }
+        r = chacha20poly1305_open(key, nonce, aad, sizeof(aad), bad, pt_len, tag, out);
+        check_aead_rejected("aead rejects tampered ciphertext", r, out, sizeof(out));
 
         memcpy(btag, tag, 16); btag[15] ^= 0x80;
-        if (chacha20poly1305_open(key, nonce, aad, sizeof(aad), ct, pt_len, btag, out) != 0) {
-            printf("FAIL: aead accepted tampered tag\n"); g_failures++;
-        } else {
-            printf("PASS: aead rejects tampered tag\n");
-        }
+        memset(out, 0xEE, sizeof(out));
+        r = chacha20poly1305_open(key, nonce, aad, sizeof(aad), ct, pt_len, btag, out);
+        check_aead_rejected("aead rejects tampered tag", r, out, sizeof(out));
 
         memcpy(baad, aad, sizeof(baad)); baad[0] ^= 0x01;
-        if (chacha20poly1305_open(key, nonce, baad, sizeof(baad), ct, pt_len, tag, out) != 0) {
-            printf("FAIL: aead accepted tampered AAD\n"); g_failures++;
-        } else {
-            printf("PASS: aead rejects tampered AAD\n");
-        }
+        memset(out, 0xEE, sizeof(out));
+        r = chacha20poly1305_open(key, nonce, baad, sizeof(baad), ct, pt_len, tag, out);
+        check_aead_rejected("aead rejects tampered AAD", r, out, sizeof(out));
     }
 }
 #endif /* WEBLIB_TLS */

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -12,6 +12,7 @@
 #ifdef WEBLIB_TLS
 #include "chacha20.h"
 #include "poly1305.h"
+#include "chacha20poly1305.h"
 #endif
 
 static int g_failures = 0;
@@ -176,6 +177,84 @@ static void test_poly1305(void) {
         check_hex("poly1305 (r=0 -> tag=s)", tag, 16, "36e5f6b5c5e06070f0efca96227a863e");
     }
 }
+
+/* ChaCha20-Poly1305 AEAD — RFC 8439 §2.8.2 KAT, a seal/open round-trip, and
+ * tamper-detection on the ciphertext, tag, and AAD. */
+static void test_chacha20poly1305(void) {
+    uint8_t key[32];
+    uint8_t nonce[12];
+    uint8_t aad[12];
+    const char *pt = "Ladies and Gentlemen of the class of '99: If I could offer you "
+                     "only one tip for the future, sunscreen would be it.";
+    size_t pt_len = strlen(pt);
+    uint8_t ct[114];
+    uint8_t tag[16];
+    uint8_t out[114];
+    int i;
+
+    if (pt_len != sizeof(ct)) {
+        printf("FAIL: aead test plaintext is %zu bytes, expected %zu\n", pt_len, sizeof(ct));
+        g_failures++;
+        return;
+    }
+
+    for (i = 0; i < 32; i++) key[i] = (uint8_t)(0x80 + i);        /* key = 0x80..0x9f */
+    from_hex("070000004041424344454647", nonce, 12);
+    from_hex("50515253c0c1c2c3c4c5c6c7", aad, 12);
+
+    /* Seal and check against the RFC vector. */
+    if (!chacha20poly1305_seal(key, nonce, aad, sizeof(aad), (const uint8_t *)pt, pt_len, ct, tag)) {
+        printf("FAIL: chacha20poly1305_seal returned 0\n");
+        g_failures++;
+        return;
+    }
+    check_hex("chacha20poly1305 seal ciphertext (RFC 8439 2.8.2)", ct, pt_len,
+              "d31a8d34648e60db7b86afbc53ef7ec2a4aded51296e08fea9e2b5a736ee62d6"
+              "3dbea45e8ca9671282fafb69da92728b1a71de0a9e060b2905d6a5b67ecd3b36"
+              "92ddbd7f2d778b8c9803aee328091b58fab324e4fad675945585808b4831d7bc"
+              "3ff4def08e4b7a9de576d26586cec64b6116");
+    check_hex("chacha20poly1305 seal tag (RFC 8439 2.8.2)", tag, 16,
+              "1ae10b594f09e26a7e902ecbd0600691");
+
+    /* Open round-trip: authentic input decrypts to the original plaintext. */
+    if (chacha20poly1305_open(key, nonce, aad, sizeof(aad), ct, pt_len, tag, out) != 1 ||
+        memcmp(out, pt, pt_len) != 0) {
+        printf("FAIL: chacha20poly1305 open round-trip\n");
+        g_failures++;
+    } else {
+        printf("PASS: chacha20poly1305 open round-trip\n");
+    }
+
+    /* Tamper detection: a single-bit change in ct, tag, or aad must be rejected,
+     * and the plaintext buffer must not be touched. */
+    {
+        uint8_t bad[114];
+        uint8_t btag[16];
+        uint8_t baad[12];
+
+        memcpy(bad, ct, pt_len); bad[0] ^= 0x01;
+        memset(out, 0xEE, sizeof(out));
+        if (chacha20poly1305_open(key, nonce, aad, sizeof(aad), bad, pt_len, tag, out) != 0) {
+            printf("FAIL: aead accepted tampered ciphertext\n"); g_failures++;
+        } else {
+            printf("PASS: aead rejects tampered ciphertext\n");
+        }
+
+        memcpy(btag, tag, 16); btag[15] ^= 0x80;
+        if (chacha20poly1305_open(key, nonce, aad, sizeof(aad), ct, pt_len, btag, out) != 0) {
+            printf("FAIL: aead accepted tampered tag\n"); g_failures++;
+        } else {
+            printf("PASS: aead rejects tampered tag\n");
+        }
+
+        memcpy(baad, aad, sizeof(baad)); baad[0] ^= 0x01;
+        if (chacha20poly1305_open(key, nonce, baad, sizeof(baad), ct, pt_len, tag, out) != 0) {
+            printf("FAIL: aead accepted tampered AAD\n"); g_failures++;
+        } else {
+            printf("PASS: aead rejects tampered AAD\n");
+        }
+    }
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -186,6 +265,7 @@ int main(void) {
     test_chacha20_block();
     test_chacha20_encrypt();
     test_poly1305();
+    test_chacha20poly1305();
 
     if (g_failures == 0) {
         printf("All TLS crypto KATs passed.\n");


### PR DESCRIPTION
## Subsystem
`tls` crypto — the AEAD of `TLS_CHACHA20_POLY1305_SHA256`, combining the merged ChaCha20 (#98) and Poly1305 (#99) primitives. Completes the **symmetric** side of the cipher suite.

## What
- **`src/tls/chacha20poly1305.{c,h}`** — `chacha20poly1305_seal()` / `chacha20poly1305_open()`, RFC 8439 §2.8:
  - One-time Poly1305 key = ChaCha20 block at **counter 0**; ciphertext = ChaCha20 from **counter 1**.
  - Tag = Poly1305 over `aad ‖ pad16(aad) ‖ ct ‖ pad16(ct) ‖ le64(aad_len) ‖ le64(ct_len)`.
  - `open()` verifies the tag with the existing **constant-time `secure_compare` BEFORE decrypting**, and never writes plaintext on failure. The derived Poly1305 key is wiped.

## Design note
The MAC input (`aad`, `ciphertext`, and the length block — **all public, non-secret**) is assembled in a heap buffer so the **already-verified** one-shot `poly1305_mac` is reused unchanged, rather than refactoring the verified limb arithmetic into a streaming API. A streaming Poly1305 that avoids the temp buffer is noted as a future optimization (lower priority; correctness/low-risk first).

## Safety / scope
Purely **additive**, gated behind `WEBLIB_TLS` (in `WEBLIB_SOURCES_TLS`). Default build compiles no AEAD — `nm build/libweblib.a` shows no `chacha20poly1305`/`aead_tag` symbol; default `ctest` unchanged. No existing code touched.

## Tests
- **RFC 8439 §2.8.2** KAT — the full 114-byte ciphertext **and** the tag.
- **seal → open round-trip** returns the original plaintext.
- **tamper detection** — a single-bit flip in the **ciphertext**, the **tag**, or the **AAD** is each rejected by `open()` (returns 0, plaintext not written).

The §2.8.2 vector was reproduced by an **independent reference** (ChaCha20 + Poly1305 + the §2.8 construction) before hardcoding. **Negative control:** disabling the tag check makes all three tamper tests fail — so they genuinely exercise authentication.

## Validation
- TLS build (`-DWEBLIB_ENABLE_TLS=ON`): `ctest` **8/8**, warning-free; the AEAD — including the `malloc`/`free` MAC path — is clean under **ASan/UBSan** (no leak, no OOB).
- Default build (TLS OFF): **6/6** on the normal and ASan/UBSan trees — unchanged.

## Next
The symmetric suite is complete (ChaCha20 + Poly1305 + AEAD). Next: the **key schedule** — HKDF-Extract/Expand + HKDF-Expand-Label over the existing shared SHA-256 (RFC 5869 / RFC 8446 §7.1), then the X25519 and Ed25519 asymmetric primitives, before the record layer and handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)