### PR TITLE
TLS Phase 1: HKDF-SHA256 + HKDF-Expand-Label (RFC 5869 / RFC 8446) + KATs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/chacha20.c
     src/tls/poly1305.c
     src/tls/chacha20poly1305.c
+    src/tls/hkdf.c
 )
 
 if(EMSCRIPTEN)

--- a/src/tls/hkdf.c
+++ b/src/tls/hkdf.c
@@ -40,6 +40,11 @@ int hkdf_expand(const uint8_t prk[HKDF_SHA256_LEN],
     if (okm_len == 0) {
         return 1;
     }
+    /* Guard the scratch-buffer size against size_t overflow (info_len is
+     * caller-controlled); an overflow would under-size the malloc below. */
+    if (info_len > SIZE_MAX - HKDF_SHA256_LEN - 1) {
+        return 0;
+    }
 
     /* Scratch for one HMAC input: T(prev) || info || counter. */
     buf_len = HKDF_SHA256_LEN + info_len + 1;

--- a/src/tls/hkdf.c
+++ b/src/tls/hkdf.c
@@ -33,6 +33,11 @@ int hkdf_expand(const uint8_t prk[HKDF_SHA256_LEN],
     size_t done = 0;
     size_t i;
 
+    /* A NULL info is only valid with info_len 0 (otherwise the memcpy below would
+     * dereference NULL). */
+    if (info == NULL && info_len > 0) {
+        return 0;
+    }
     /* RFC 5869: L <= 255 * HashLen. */
     if (okm_len > (size_t)255 * HKDF_SHA256_LEN) {
         return 0;
@@ -95,6 +100,10 @@ int hkdf_expand_label(const uint8_t secret[HKDF_SHA256_LEN],
 
     if (out_len > 0xffff || full_label_len < 7 || full_label_len > 255 ||
         context_len > 255) {
+        return 0;
+    }
+    /* A NULL label/context is only valid with a zero length. */
+    if ((label == NULL && label_len > 0) || (context == NULL && context_len > 0)) {
         return 0;
     }
 

--- a/src/tls/hkdf.c
+++ b/src/tls/hkdf.c
@@ -1,0 +1,115 @@
+/*
+ * hkdf.c — HKDF-SHA256 (RFC 5869) and TLS 1.3 HKDF-Expand-Label (RFC 8446 §7.1).
+ * EXPERIMENTAL / UNAUDITED.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. Built on the shared SHA-256 /
+ * HMAC-SHA256 primitive. Verified against RFC 5869 §A.1/A.3 and the RFC 8448
+ * TLS 1.3 trace in tests/test_tls_crypto.c.
+ */
+#include "hkdf.h"
+
+#ifdef WEBLIB_TLS
+
+#include "crypto/sha256.h"   /* hmac_sha256, SHA256_DIGEST_SIZE */
+#include "kamran.k"          /* secure_zero */
+#include <stdlib.h>
+#include <string.h>
+
+void hkdf_extract(const uint8_t *salt, size_t salt_len,
+                  const uint8_t *ikm, size_t ikm_len,
+                  uint8_t prk[HKDF_SHA256_LEN]) {
+    /* PRK = HMAC(salt-as-key, ikm-as-message). A NULL/empty salt is HMAC-padded to
+     * a block of zeros, matching RFC 5869's "HashLen zero bytes" default. */
+    hmac_sha256(salt, salt_len, ikm, ikm_len, prk);
+}
+
+int hkdf_expand(const uint8_t prk[HKDF_SHA256_LEN],
+                const uint8_t *info, size_t info_len,
+                uint8_t *okm, size_t okm_len) {
+    uint8_t t[HKDF_SHA256_LEN];
+    uint8_t *buf;
+    size_t buf_len;
+    size_t t_len = 0;   /* length of the previous T block (0 on the first round) */
+    size_t done = 0;
+    size_t i;
+
+    /* RFC 5869: L <= 255 * HashLen. */
+    if (okm_len > (size_t)255 * HKDF_SHA256_LEN) {
+        return 0;
+    }
+    if (okm_len == 0) {
+        return 1;
+    }
+
+    /* Scratch for one HMAC input: T(prev) || info || counter. */
+    buf_len = HKDF_SHA256_LEN + info_len + 1;
+    buf = (uint8_t *)malloc(buf_len);
+    if (buf == NULL) {
+        return 0;
+    }
+
+    for (i = 1; done < okm_len; i++) {
+        size_t off = 0;
+        size_t n;
+
+        if (t_len > 0) {
+            memcpy(buf, t, t_len);
+            off = t_len;
+        }
+        if (info_len > 0) {
+            memcpy(buf + off, info, info_len);
+            off += info_len;
+        }
+        buf[off++] = (uint8_t)i;   /* i is in 1..255 given the L bound above */
+
+        hmac_sha256(prk, HKDF_SHA256_LEN, buf, off, t);
+
+        n = (okm_len - done < HKDF_SHA256_LEN) ? (okm_len - done) : HKDF_SHA256_LEN;
+        memcpy(okm + done, t, n);
+        done += n;
+        t_len = HKDF_SHA256_LEN;
+    }
+
+    /* Wipe intermediate key material. */
+    secure_zero(buf, buf_len);
+    secure_zero(t, sizeof(t));
+    free(buf);
+    return 1;
+}
+
+int hkdf_expand_label(const uint8_t secret[HKDF_SHA256_LEN],
+                      const char *label, size_t label_len,
+                      const uint8_t *context, size_t context_len,
+                      uint8_t *out, size_t out_len) {
+    static const char prefix[] = "tls13 ";   /* 6 bytes, no NUL */
+    const size_t prefix_len = 6;
+    size_t full_label_len = prefix_len + label_len;
+    /* HkdfLabel = uint16 length || opaque label<7..255> || opaque context<0..255>. */
+    uint8_t hkdf_label[2 + 1 + 255 + 1 + 255];
+    size_t off = 0;
+
+    if (out_len > 0xffff || full_label_len < 7 || full_label_len > 255 ||
+        context_len > 255) {
+        return 0;
+    }
+
+    hkdf_label[off++] = (uint8_t)(out_len >> 8);
+    hkdf_label[off++] = (uint8_t)(out_len & 0xff);
+    hkdf_label[off++] = (uint8_t)full_label_len;
+    memcpy(hkdf_label + off, prefix, prefix_len);
+    off += prefix_len;
+    if (label_len > 0) {
+        memcpy(hkdf_label + off, label, label_len);
+        off += label_len;
+    }
+    hkdf_label[off++] = (uint8_t)context_len;
+    if (context_len > 0) {
+        memcpy(hkdf_label + off, context, context_len);
+        off += context_len;
+    }
+
+    /* The HkdfLabel is public (label text + transcript-hash context), so no wipe. */
+    return hkdf_expand(secret, hkdf_label, off, out, out_len);
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/hkdf.h
+++ b/src/tls/hkdf.h
@@ -1,0 +1,55 @@
+/*
+ * hkdf.h — HKDF-SHA256 (RFC 5869) and TLS 1.3 HKDF-Expand-Label (RFC 8446 §7.1).
+ * EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON (native-only). This is the key-derivation core of the
+ * TLS 1.3 key schedule for the SHA-256 cipher suite. Built on the shared SHA-256 /
+ * HMAC-SHA256 module (src/crypto/sha256). Verified against RFC 5869 §A.1/A.3 and
+ * the RFC 8448 TLS 1.3 trace (early_secret / derived) — see tests/test_tls_crypto.c.
+ *
+ * Hash is fixed to SHA-256, so all PRK/secret values are 32 bytes.
+ */
+#ifndef WEBLIB_TLS_HKDF_H
+#define WEBLIB_TLS_HKDF_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define HKDF_SHA256_LEN 32   /* SHA-256 output size */
+
+/*
+ * HKDF-Extract (RFC 5869 §2.2): PRK = HMAC-SHA256(salt, ikm). `salt` may be NULL
+ * with salt_len 0, which (as HMAC zero-pads the key) is equivalent to the RFC's
+ * "salt not provided -> HashLen zero bytes". `prk` receives HKDF_SHA256_LEN bytes.
+ */
+void hkdf_extract(const uint8_t *salt, size_t salt_len,
+                  const uint8_t *ikm, size_t ikm_len,
+                  uint8_t prk[HKDF_SHA256_LEN]);
+
+/*
+ * HKDF-Expand (RFC 5869 §2.3): expand `prk` and `info` into `okm_len` bytes.
+ * Returns 1 on success, 0 if okm_len > 255*HKDF_SHA256_LEN or on allocation
+ * failure. Intermediate key material is wiped before returning.
+ */
+int hkdf_expand(const uint8_t prk[HKDF_SHA256_LEN],
+                const uint8_t *info, size_t info_len,
+                uint8_t *okm, size_t okm_len);
+
+/*
+ * HKDF-Expand-Label (RFC 8446 §7.1): builds the HkdfLabel struct
+ *   struct { uint16 length; opaque label<7..255> = "tls13 "+Label; opaque context<0..255>; }
+ * and calls HKDF-Expand. `label` is the bare label without the "tls13 " prefix
+ * (e.g. "derived"); its full length including the prefix must be 7..255. `context`
+ * is usually a transcript hash and may be NULL with context_len 0. Returns 1 on
+ * success, 0 on a length-constraint violation or allocation failure.
+ */
+int hkdf_expand_label(const uint8_t secret[HKDF_SHA256_LEN],
+                      const char *label, size_t label_len,
+                      const uint8_t *context, size_t context_len,
+                      uint8_t *out, size_t out_len);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_HKDF_H */

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -13,6 +13,7 @@
 #include "chacha20.h"
 #include "poly1305.h"
 #include "chacha20poly1305.h"
+#include "hkdf.h"
 #endif
 
 static int g_failures = 0;
@@ -271,6 +272,73 @@ static void test_chacha20poly1305(void) {
         check_aead_rejected("aead rejects tampered AAD", r, out, sizeof(out));
     }
 }
+
+/* HKDF-SHA256 (RFC 5869) + TLS 1.3 HKDF-Expand-Label (RFC 8446), checked against
+ * RFC 5869 §A.1/A.3 and the RFC 8448 TLS 1.3 trace (early_secret / derived). */
+static void test_hkdf(void) {
+    uint8_t prk[32];
+    uint8_t okm[64];
+
+    /* RFC 5869 A.1: Extract + Expand (L=42 spans two HMAC blocks). */
+    {
+        uint8_t ikm[22];
+        uint8_t salt[13];
+        uint8_t info[10];
+        memset(ikm, 0x0b, sizeof(ikm));
+        from_hex("000102030405060708090a0b0c", salt, sizeof(salt));
+        from_hex("f0f1f2f3f4f5f6f7f8f9", info, sizeof(info));
+
+        hkdf_extract(salt, sizeof(salt), ikm, sizeof(ikm), prk);
+        check_hex("hkdf_extract (RFC 5869 A.1 PRK)", prk, 32,
+                  "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5");
+        if (!hkdf_expand(prk, info, sizeof(info), okm, 42)) {
+            printf("FAIL: hkdf_expand A.1 returned 0\n"); g_failures++;
+        } else {
+            check_hex("hkdf_expand (RFC 5869 A.1 OKM)", okm, 42,
+                      "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56e"
+                      "cc4c5bf34007208d5b887185865");
+        }
+    }
+
+    /* RFC 5869 A.3: zero-length salt and info (empty salt == HashLen zeros). */
+    {
+        uint8_t ikm[22];
+        memset(ikm, 0x0b, sizeof(ikm));
+
+        hkdf_extract(NULL, 0, ikm, sizeof(ikm), prk);
+        check_hex("hkdf_extract (RFC 5869 A.3 PRK, empty salt)", prk, 32,
+                  "19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04");
+        if (!hkdf_expand(prk, NULL, 0, okm, 42)) {
+            printf("FAIL: hkdf_expand A.3 returned 0\n"); g_failures++;
+        } else {
+            check_hex("hkdf_expand (RFC 5869 A.3 OKM, empty info)", okm, 42,
+                      "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f"
+                      "3c738d2d9d201395faa4b61a96c8");
+        }
+    }
+
+    /* RFC 8448 TLS 1.3: early_secret = HKDF-Extract(0^32, 0^32);
+     * derived = HKDF-Expand-Label(early_secret, "derived", SHA256(""), 32). */
+    {
+        uint8_t zeros[32] = { 0 };
+        uint8_t early[32];
+        uint8_t empty_hash[32];
+        uint8_t derived[32];
+
+        hkdf_extract(zeros, sizeof(zeros), zeros, sizeof(zeros), early);
+        check_hex("hkdf early_secret (RFC 8448 Extract)", early, 32,
+                  "33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a");
+
+        from_hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                 empty_hash, 32);   /* SHA256("") */
+        if (!hkdf_expand_label(early, "derived", 7, empty_hash, 32, derived, 32)) {
+            printf("FAIL: hkdf_expand_label returned 0\n"); g_failures++;
+        } else {
+            check_hex("hkdf_expand_label \"derived\" (RFC 8448)", derived, 32,
+                      "6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba");
+        }
+    }
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -282,6 +350,7 @@ int main(void) {
     test_chacha20_encrypt();
     test_poly1305();
     test_chacha20poly1305();
+    test_hkdf();
 
     if (g_failures == 0) {
         printf("All TLS crypto KATs passed.\n");

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -338,6 +338,27 @@ static void test_hkdf(void) {
                       "6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba");
         }
     }
+
+    /* Invalid-input guards: a NULL pointer paired with a non-zero length must be
+     * rejected (returning 0) rather than dereferenced. */
+    {
+        uint8_t junk[32];
+        if (hkdf_expand(prk, NULL, 5, junk, 32) != 0) {
+            printf("FAIL: hkdf_expand accepted NULL info with non-zero length\n"); g_failures++;
+        } else {
+            printf("PASS: hkdf_expand rejects NULL info + non-zero length\n");
+        }
+        if (hkdf_expand_label(prk, NULL, 5, NULL, 0, junk, 32) != 0) {
+            printf("FAIL: hkdf_expand_label accepted NULL label with non-zero length\n"); g_failures++;
+        } else {
+            printf("PASS: hkdf_expand_label rejects NULL label + non-zero length\n");
+        }
+        if (hkdf_expand_label(prk, "x", 1, NULL, 5, junk, 32) != 0) {
+            printf("FAIL: hkdf_expand_label accepted NULL context with non-zero length\n"); g_failures++;
+        } else {
+            printf("PASS: hkdf_expand_label rejects NULL context + non-zero length\n");
+        }
+    }
 }
 #endif /* WEBLIB_TLS */
 


### PR DESCRIPTION
## Subsystem
`tls` crypto — the **key-derivation core** of the TLS 1.3 key schedule, built on the shared SHA-256/HMAC module (#97). This is the last symmetric-side crypto piece before the asymmetric primitives (X25519/Ed25519).

## What
- **`src/tls/hkdf.{c,h}`**:
  - `hkdf_extract()` — RFC 5869 §2.2: `PRK = HMAC-SHA256(salt, ikm)`. A NULL/empty salt is HMAC-padded to zeros, matching the RFC's "salt not provided → HashLen zeros".
  - `hkdf_expand()` — RFC 5869 §2.3: the `T(i) = HMAC(PRK, T(i-1) ‖ info ‖ i)` chaining; enforces `L ≤ 255·HashLen`; **wipes** intermediate `T` material.
  - `hkdf_expand_label()` — RFC 8446 §7.1: assembles the `HkdfLabel` struct (`uint16 length ‖ "tls13 "+label ‖ context`) and calls `hkdf_expand`, validating the `label<7..255>` / `context<0..255>` constraints.

## Safety / scope
Purely **additive**, gated behind `WEBLIB_TLS`. Default build has no HKDF — `nm build/libweblib.a` shows no `hkdf` symbol; default `ctest` unchanged. No existing code touched.

## Tests
- **RFC 5869 §A.1** — Extract PRK **and** a 42-byte (two-HMAC-block) Expand OKM.
- **RFC 5869 §A.3** — zero-length salt and info.
- **RFC 8448 (TLS 1.3 trace)** — `early_secret = HKDF-Extract(0³², 0³²)` **and** `derived = HKDF-Expand-Label(early_secret, "derived", SHA256(""), 32)`. This pins the `HkdfLabel` encoding against an **authoritative TLS 1.3 value**, not just a self-consistent construction.

All vectors were reproduced by an **independent reference** before hardcoding. **Negative control:** starting the Expand counter at 0 (RFC requires `T(1)` to use counter 1) fails every Expand vector while the Extract-only checks still pass — so the tests target the right code.

## Validation
- TLS build (`-DWEBLIB_ENABLE_TLS=ON`): `ctest` **8/8**, warning-free; HKDF (incl. the `malloc` path in `hkdf_expand`) clean under **ASan/UBSan**.
- Default build (TLS OFF): **6/6** on the normal and ASan/UBSan trees — unchanged.

## Next
With the AEAD and the HKDF key schedule done, the symmetric + KDF crypto is complete. Next is the **asymmetric** side: **X25519** (RFC 7748 — the most intricate primitive, needs careful constant-time field arithmetic over 2^255-19) for key exchange, then **Ed25519** (RFC 8032) for signatures — after which certificate/key parsing (Phase 2) and the record layer + handshake (Phase 3) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)