### PR TITLE
TLS Phase 1: X25519 ECDH (RFC 7748) + known-answer tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/poly1305.c
     src/tls/chacha20poly1305.c
     src/tls/hkdf.c
+    src/tls/x25519.c
 )
 
 if(EMSCRIPTEN)

--- a/src/tls/x25519.c
+++ b/src/tls/x25519.c
@@ -1,0 +1,217 @@
+/*
+ * x25519.c — X25519 ECDH (RFC 7748). EXPERIMENTAL / UNAUDITED.
+ *
+ * Constant-time Montgomery ladder over GF(2^255-19). The field element is 16
+ * signed 16-bit-radix limbs held in int64 (so 16x16 schoolbook products stay well
+ * within int64); reduction folds the 2^256 overflow with the constant 38 = 2*19.
+ * This is the compact, widely-reviewed formulation from TweetNaCl (public domain),
+ * adapted to this codebase — chosen over a from-first-principles field
+ * implementation to minimise the risk inherent in hand-rolled bignum crypto. It is
+ * fully constant-time: the ladder's conditional swaps are arithmetic (no branch on
+ * secret bits), and there are no secret-indexed memory accesses.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. Verified against RFC 7748 §5.2/§6.1
+ * and the iterated test in tests/test_tls_crypto.c.
+ */
+#include "x25519.h"
+
+#ifdef WEBLIB_TLS
+
+#include "kamran.k"   /* secure_zero */
+#include <string.h>
+
+typedef int64_t gf[16];
+
+/* 121665 = (A-2)/4 for the Montgomery curve, in 16-bit-limb radix. */
+static const gf gf_121665 = { 0xDB41, 1 };
+
+/* Carry/reduce a field element into 16-bit limbs, folding bit 256 back via *38. */
+static void car25519(gf o) {
+    int i;
+    int64_t c;
+    for (i = 0; i < 16; i++) {
+        o[i] += (int64_t)1 << 16;
+        c = o[i] >> 16;
+        o[(i + 1) * (i < 15)] += c - 1 + 37 * (c - 1) * (i == 15);
+        o[i] -= c << 16;
+    }
+}
+
+/* Constant-time conditional swap of p and q when b == 1. */
+static void sel25519(gf p, gf q, int b) {
+    int i;
+    int64_t t;
+    int64_t c = ~((int64_t)b - 1);
+    for (i = 0; i < 16; i++) {
+        t = c & (p[i] ^ q[i]);
+        p[i] ^= t;
+        q[i] ^= t;
+    }
+}
+
+/* Serialize a field element to 32 little-endian bytes (fully reduced mod p). */
+static void pack25519(uint8_t *o, const gf n) {
+    int i, j, b;
+    gf m, t;
+    for (i = 0; i < 16; i++) {
+        t[i] = n[i];
+    }
+    car25519(t);
+    car25519(t);
+    car25519(t);
+    for (j = 0; j < 2; j++) {
+        m[0] = t[0] - 0xffed;
+        for (i = 1; i < 15; i++) {
+            m[i] = t[i] - 0xffff - ((m[i - 1] >> 16) & 1);
+            m[i - 1] &= 0xffff;
+        }
+        m[15] = t[15] - 0x7fff - ((m[14] >> 16) & 1);
+        b = (int)((m[15] >> 16) & 1);
+        m[14] &= 0xffff;
+        sel25519(t, m, 1 - b);
+    }
+    for (i = 0; i < 16; i++) {
+        o[2 * i]     = (uint8_t)(t[i] & 0xff);
+        o[2 * i + 1] = (uint8_t)(t[i] >> 8);
+    }
+}
+
+/* Parse 32 little-endian bytes into a field element (masking the high bit). */
+static void unpack25519(gf o, const uint8_t *n) {
+    int i;
+    for (i = 0; i < 16; i++) {
+        o[i] = n[2 * i] + ((int64_t)n[2 * i + 1] << 8);
+    }
+    o[15] &= 0x7fff;
+}
+
+static void fadd(gf o, const gf a, const gf b) {
+    int i;
+    for (i = 0; i < 16; i++) {
+        o[i] = a[i] + b[i];
+    }
+}
+
+static void fsub(gf o, const gf a, const gf b) {
+    int i;
+    for (i = 0; i < 16; i++) {
+        o[i] = a[i] - b[i];
+    }
+}
+
+static void fmul(gf o, const gf a, const gf b) {
+    int64_t t[31];
+    int i, j;
+    for (i = 0; i < 31; i++) {
+        t[i] = 0;
+    }
+    for (i = 0; i < 16; i++) {
+        for (j = 0; j < 16; j++) {
+            t[i + j] += a[i] * b[j];
+        }
+    }
+    for (i = 0; i < 15; i++) {
+        t[i] += 38 * t[i + 16];
+    }
+    for (i = 0; i < 16; i++) {
+        o[i] = t[i];
+    }
+    car25519(o);
+    car25519(o);
+}
+
+static void fsquare(gf o, const gf a) {
+    fmul(o, a, a);
+}
+
+/* Field inverse via Fermat: o = i^(p-2) mod p, by a fixed square-and-multiply
+ * chain (constant-time; the exceptions at exponent bits 2 and 4 are the two zero
+ * bits of p-2). */
+static void finverse(gf o, const gf i) {
+    gf c;
+    int a;
+    for (a = 0; a < 16; a++) {
+        c[a] = i[a];
+    }
+    for (a = 253; a >= 0; a--) {
+        fsquare(c, c);
+        if (a != 2 && a != 4) {
+            fmul(c, c, i);
+        }
+    }
+    for (a = 0; a < 16; a++) {
+        o[a] = c[a];
+    }
+    secure_zero(c, sizeof(c));
+}
+
+void x25519(uint8_t out[32], const uint8_t scalar[32], const uint8_t u[32]) {
+    uint8_t z[32];
+    gf x1, a, b, c, d, e, f;
+    int i;
+
+    /* Clamp the scalar (RFC 7748 §5). */
+    for (i = 0; i < 31; i++) {
+        z[i] = scalar[i];
+    }
+    z[31] = (scalar[31] & 127) | 64;
+    z[0] &= 248;
+
+    unpack25519(x1, u);
+    for (i = 0; i < 16; i++) {
+        b[i] = x1[i];
+        d[i] = a[i] = c[i] = 0;
+    }
+    a[0] = d[0] = 1;
+
+    /* Montgomery ladder over the 255 scalar bits, high to low. */
+    for (i = 254; i >= 0; i--) {
+        int64_t r = (z[i >> 3] >> (i & 7)) & 1;
+        sel25519(a, b, (int)r);
+        sel25519(c, d, (int)r);
+        fadd(e, a, c);
+        fsub(a, a, c);
+        fadd(c, b, d);
+        fsub(b, b, d);
+        fsquare(d, e);
+        fsquare(f, a);
+        fmul(a, c, a);
+        fmul(c, b, e);
+        fadd(e, a, c);
+        fsub(a, a, c);
+        fsquare(b, a);
+        fsub(c, d, f);
+        fmul(a, c, gf_121665);
+        fadd(a, a, d);
+        fmul(c, c, a);
+        fmul(a, d, f);
+        fmul(d, b, x1);
+        fsquare(b, e);
+        sel25519(a, b, (int)r);
+        sel25519(c, d, (int)r);
+    }
+
+    /* out = x2 / z2 = a * c^(p-2). */
+    finverse(c, c);
+    fmul(a, a, c);
+    pack25519(out, a);
+
+    /* Wipe the clamped scalar and all working field elements. */
+    secure_zero(z, sizeof(z));
+    secure_zero(x1, sizeof(x1));
+    secure_zero(a, sizeof(a));
+    secure_zero(b, sizeof(b));
+    secure_zero(c, sizeof(c));
+    secure_zero(d, sizeof(d));
+    secure_zero(e, sizeof(e));
+    secure_zero(f, sizeof(f));
+}
+
+void x25519_base(uint8_t out[32], const uint8_t scalar[32]) {
+    uint8_t basepoint[32];
+    memset(basepoint, 0, sizeof(basepoint));
+    basepoint[0] = 9;
+    x25519(out, scalar, basepoint);
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/x25519.h
+++ b/src/tls/x25519.h
@@ -1,0 +1,35 @@
+/*
+ * x25519.h — X25519 Elliptic-Curve Diffie-Hellman (RFC 7748). EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON (native-only). The key-exchange group for TLS 1.3 with
+ * this cipher suite. Verified against RFC 7748 §5.2 / §6.1 and the iterated test
+ * — see tests/test_tls_crypto.c.
+ *
+ * The scalar multiplication is a constant-time Montgomery ladder over field
+ * arithmetic mod 2^255-19 (16 x 16-bit limbs, int64 products — portable, no
+ * __int128). This is the compact, widely-reviewed formulation from TweetNaCl;
+ * there are no secret-dependent branches or memory accesses.
+ */
+#ifndef WEBLIB_TLS_X25519_H
+#define WEBLIB_TLS_X25519_H
+
+#ifdef WEBLIB_TLS
+
+#include <stdint.h>
+
+/*
+ * X25519 scalar multiplication (RFC 7748 §5): out = scalar * u-coordinate. The
+ * scalar is clamped and the u-coordinate's high bit masked internally, per the RFC.
+ * `out` may alias neither `scalar` nor `u`. All three buffers are 32 bytes.
+ */
+void x25519(uint8_t out[32], const uint8_t scalar[32], const uint8_t u[32]);
+
+/*
+ * X25519 with the base point (u = 9): derive the public key for a private
+ * `scalar`. `out` and `scalar` are 32 bytes.
+ */
+void x25519_base(uint8_t out[32], const uint8_t scalar[32]);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_X25519_H */

--- a/src/tls/x25519.h
+++ b/src/tls/x25519.h
@@ -2,9 +2,10 @@
  * x25519.h — X25519 Elliptic-Curve Diffie-Hellman (RFC 7748). EXPERIMENTAL / UNAUDITED.
  *
  * Part of the experimental pure-C TLS layer; compiled only under
- * -DWEBLIB_ENABLE_TLS=ON (native-only). The key-exchange group for TLS 1.3 with
- * this cipher suite. Verified against RFC 7748 §5.2 / §6.1 and the iterated test
- * — see tests/test_tls_crypto.c.
+ * -DWEBLIB_ENABLE_TLS=ON (native-only). X25519 is a TLS 1.3 key-exchange group
+ * (RFC 8446), negotiated via the supported_groups extension independently of the
+ * cipher suite. Verified against RFC 7748 §5.2 / §6.1 and the iterated test — see
+ * tests/test_tls_crypto.c.
  *
  * The scalar multiplication is a constant-time Montgomery ladder over field
  * arithmetic mod 2^255-19 (16 x 16-bit limbs, int64 products — portable, no

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -14,6 +14,7 @@
 #include "poly1305.h"
 #include "chacha20poly1305.h"
 #include "hkdf.h"
+#include "x25519.h"
 #endif
 
 static int g_failures = 0;
@@ -360,6 +361,75 @@ static void test_hkdf(void) {
         }
     }
 }
+
+/* X25519 ECDH (RFC 7748) — §5.2 scalar-mult vectors, §6.1 base point + agreement,
+ * and the iterated test (1 and 1000 rounds exercise the ladder end to end). */
+static void test_x25519(void) {
+    uint8_t k[32];
+    uint8_t u[32];
+    uint8_t out[32];
+
+    /* §5.2 Test 1. */
+    from_hex("a546e36bf0527c9d3b16154b82465edd62144c0ac1fc5a18506a2244ba449ac4", k, 32);
+    from_hex("e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c", u, 32);
+    x25519(out, k, u);
+    check_hex("x25519 (RFC 7748 5.2 #1)", out, 32,
+              "c3da55379de9c6908e94ea4df28d084f32eccf03491c71f754b4075577a28552");
+
+    /* §5.2 Test 2. */
+    from_hex("4b66e9d4d1b4673c5ad22691957d6af5c11b6421e0ea01d42ca4169e7918ba0d", k, 32);
+    from_hex("e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a493", u, 32);
+    x25519(out, k, u);
+    check_hex("x25519 (RFC 7748 5.2 #2)", out, 32,
+              "95cbde9476e8907d7aade45cb4b873f88b595a68799fa152e6f8f7647aac7957");
+
+    /* §6.1: derive Alice's public key from her private scalar via the base point. */
+    from_hex("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a", k, 32);
+    x25519_base(out, k);
+    check_hex("x25519_base (RFC 7748 6.1 Alice pubkey)", out, 32,
+              "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a");
+
+    /* §6.1: full ECDH — Alice and Bob compute the same shared secret. */
+    {
+        uint8_t apriv[32], bpriv[32], apub[32], bpub[32], ss1[32], ss2[32];
+        from_hex("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a", apriv, 32);
+        from_hex("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb", bpriv, 32);
+        x25519_base(apub, apriv);
+        x25519_base(bpub, bpriv);
+        check_hex("x25519_base (RFC 7748 6.1 Bob pubkey)", bpub, 32,
+                  "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f");
+        x25519(ss1, apriv, bpub);   /* Alice's view */
+        x25519(ss2, bpriv, apub);   /* Bob's view */
+        if (memcmp(ss1, ss2, 32) != 0) {
+            printf("FAIL: x25519 ECDH shared secrets differ\n"); g_failures++;
+        } else {
+            check_hex("x25519 ECDH shared secret (RFC 7748 6.1)", ss1, 32,
+                      "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742");
+        }
+    }
+
+    /* Iterated test (RFC 7748 §5.2): k=u=basepoint, then k = X25519(k,u), u = old k. */
+    {
+        uint8_t kk[32], uu[32], r[32];
+        int it;
+        memset(kk, 0, sizeof(kk));
+        kk[0] = 9;
+        memcpy(uu, kk, sizeof(uu));
+        for (it = 1; it <= 1000; it++) {
+            x25519(r, kk, uu);
+            memcpy(uu, kk, sizeof(uu));
+            memcpy(kk, r, sizeof(kk));
+            if (it == 1) {
+                check_hex("x25519 iterated (1 round)", kk, 32,
+                          "422c8e7a6227d7bca1350b3e2bb7279f7897b87bb6854b783c60e80311ae3079");
+            }
+            if (it == 1000) {
+                check_hex("x25519 iterated (1000 rounds)", kk, 32,
+                          "684cf59ba83309552800ef566f2f4d3c1c3887c49360e3875f2eb94d99532c51");
+            }
+        }
+    }
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -372,6 +442,7 @@ int main(void) {
     test_poly1305();
     test_chacha20poly1305();
     test_hkdf();
+    test_x25519();
 
     if (g_failures == 0) {
         printf("All TLS crypto KATs passed.\n");


### PR DESCRIPTION
## Subsystem
`tls` crypto — **X25519**, the TLS 1.3 key-exchange group and the first **asymmetric** primitive. This is the most intricate crypto in the effort.

## Approach (risk management)
Hand-rolling curve field arithmetic is the highest-risk crypto to write from scratch. To manage that, the scalar multiplication is the compact, **widely-reviewed TweetNaCl** formulation (public domain), adapted to the codebase — not a from-first-principles implementation. It is:
- **Constant-time**: a Montgomery ladder whose conditional swaps are arithmetic (`sel25519`, no branch on secret bits) with no secret-indexed memory access.
- **Portable**: 16 × 16-bit-radix limbs in `int64` (16×16 schoolbook products stay well within `int64`; reduction folds bit 256 via `38 = 2·19`) — **no `__int128`**, so `-pedantic` stays clean.
- Wipes the clamped scalar and every working field element before returning.

## What
- **`src/tls/x25519.{c,h}`** — `x25519(out, scalar, u)` and `x25519_base(out, scalar)` (base point u = 9).

## Safety / scope
Purely **additive**, gated behind `WEBLIB_TLS`. Default build has no X25519 — `nm build/libweblib.a` shows no `x25519`/`car25519`/`fmul` symbol; default `ctest` unchanged. No existing code touched.

## Tests
- **RFC 7748 §5.2** test 1 & 2 (scalar multiplication).
- **RFC 7748 §6.1** — Alice's and Bob's public keys via the base point, **and the full ECDH agreement** (both sides derive the identical shared secret `4a5d9d5b…`).
- **RFC 7748 §5.2 iterated test** at **1** and **1000** rounds — 1000 rounds drives the ladder + field arithmetic end-to-end 1000× (a strong whole-primitive check).

All vectors were reproduced by an **independent pure-Python RFC 7748 reference** before hardcoding. **Negative control:** changing the field-reduction constant `38 → 37` fails **all** seven vectors.

## Validation
- TLS build (`-DWEBLIB_ENABLE_TLS=ON`): `ctest` **8/8**, warning-free; the ladder + field arithmetic are clean under **ASan/UBSan** — notably **no signed-overflow UB** in the `int64` products.
- Default build (TLS OFF): **6/6** on the normal and ASan/UBSan trees — unchanged.

## Next
**Ed25519** (RFC 8032) for the server's certificate signature — which also requires **SHA-512** (I'll add it alongside). After the asymmetric primitives, the remaining work is certificate/key parsing (Phase 2) and the record layer + handshake state machine (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)