### PR TITLE
TLS Phase 1: SHA-512 (FIPS 180-4) + known-answer tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/chacha20poly1305.c
     src/tls/hkdf.c
     src/tls/x25519.c
+    src/tls/sha512.c
 )
 
 if(EMSCRIPTEN)

--- a/src/tls/sha512.c
+++ b/src/tls/sha512.c
@@ -1,0 +1,164 @@
+/*
+ * sha512.c — SHA-512 (FIPS 180-4). EXPERIMENTAL / UNAUDITED.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. Provided for Ed25519 (RFC 8032),
+ * which hashes with SHA-512. Verified against the FIPS 180-4 / NIST vectors in
+ * tests/test_tls_crypto.c.
+ */
+#include "sha512.h"
+
+#ifdef WEBLIB_TLS
+
+#include <string.h>
+
+/* First 64 bits of the fractional parts of the cube roots of the first 80 primes. */
+static const uint64_t sha512_k[80] = {
+    0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL,
+    0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL, 0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL,
+    0xd807aa98a3030242ULL, 0x12835b0145706fbeULL, 0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL,
+    0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL, 0x9bdc06a725c71235ULL, 0xc19bf174cf692694ULL,
+    0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL, 0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL,
+    0x2de92c6f592b0275ULL, 0x4a7484aa6ea6e483ULL, 0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL,
+    0x983e5152ee66dfabULL, 0xa831c66d2db43210ULL, 0xb00327c898fb213fULL, 0xbf597fc7beef0ee4ULL,
+    0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL, 0x06ca6351e003826fULL, 0x142929670a0e6e70ULL,
+    0x27b70a8546d22ffcULL, 0x2e1b21385c26c926ULL, 0x4d2c6dfc5ac42aedULL, 0x53380d139d95b3dfULL,
+    0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL, 0x81c2c92e47edaee6ULL, 0x92722c851482353bULL,
+    0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL, 0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL,
+    0xd192e819d6ef5218ULL, 0xd69906245565a910ULL, 0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL,
+    0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL, 0x2748774cdf8eeb99ULL, 0x34b0bcb5e19b48a8ULL,
+    0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL, 0x5b9cca4f7763e373ULL, 0x682e6ff3d6b2b8a3ULL,
+    0x748f82ee5defb2fcULL, 0x78a5636f43172f60ULL, 0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
+    0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL, 0xbef9a3f7b2c67915ULL, 0xc67178f2e372532bULL,
+    0xca273eceea26619cULL, 0xd186b8c721c0c207ULL, 0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL,
+    0x06f067aa72176fbaULL, 0x0a637dc5a2c898a6ULL, 0x113f9804bef90daeULL, 0x1b710b35131c471bULL,
+    0x28db77f523047d84ULL, 0x32caab7b40c72493ULL, 0x3c9ebe0a15c9bebcULL, 0x431d67c49c100d4cULL,
+    0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL, 0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
+};
+
+#define ROTR64(x, n) (((x) >> (n)) | ((x) << (64 - (n))))
+#define CH(x, y, z)  (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define BSIG0(x) (ROTR64(x, 28) ^ ROTR64(x, 34) ^ ROTR64(x, 39))
+#define BSIG1(x) (ROTR64(x, 14) ^ ROTR64(x, 18) ^ ROTR64(x, 41))
+#define SSIG0(x) (ROTR64(x, 1)  ^ ROTR64(x, 8)  ^ ((x) >> 7))
+#define SSIG1(x) (ROTR64(x, 19) ^ ROTR64(x, 61) ^ ((x) >> 6))
+
+static void sha512_transform(sha512_ctx_t *ctx, const uint8_t *data) {
+    uint64_t a, b, c, d, e, f, g, h, t1, t2;
+    uint64_t w[80];
+    int i;
+
+    for (i = 0; i < 16; i++) {
+        w[i] = ((uint64_t)data[i * 8]     << 56) |
+               ((uint64_t)data[i * 8 + 1] << 48) |
+               ((uint64_t)data[i * 8 + 2] << 40) |
+               ((uint64_t)data[i * 8 + 3] << 32) |
+               ((uint64_t)data[i * 8 + 4] << 24) |
+               ((uint64_t)data[i * 8 + 5] << 16) |
+               ((uint64_t)data[i * 8 + 6] << 8)  |
+               ((uint64_t)data[i * 8 + 7]);
+    }
+    for (i = 16; i < 80; i++) {
+        w[i] = SSIG1(w[i - 2]) + w[i - 7] + SSIG0(w[i - 15]) + w[i - 16];
+    }
+
+    a = ctx->state[0]; b = ctx->state[1]; c = ctx->state[2]; d = ctx->state[3];
+    e = ctx->state[4]; f = ctx->state[5]; g = ctx->state[6]; h = ctx->state[7];
+
+    for (i = 0; i < 80; i++) {
+        t1 = h + BSIG1(e) + CH(e, f, g) + sha512_k[i] + w[i];
+        t2 = BSIG0(a) + MAJ(a, b, c);
+        h = g; g = f; f = e; e = d + t1;
+        d = c; c = b; b = a; a = t1 + t2;
+    }
+
+    ctx->state[0] += a; ctx->state[1] += b; ctx->state[2] += c; ctx->state[3] += d;
+    ctx->state[4] += e; ctx->state[5] += f; ctx->state[6] += g; ctx->state[7] += h;
+}
+
+void sha512_init(sha512_ctx_t *ctx) {
+    ctx->state[0] = 0x6a09e667f3bcc908ULL;
+    ctx->state[1] = 0xbb67ae8584caa73bULL;
+    ctx->state[2] = 0x3c6ef372fe94f82bULL;
+    ctx->state[3] = 0xa54ff53a5f1d36f1ULL;
+    ctx->state[4] = 0x510e527fade682d1ULL;
+    ctx->state[5] = 0x9b05688c2b3e6c1fULL;
+    ctx->state[6] = 0x1f83d9abfb41bd6bULL;
+    ctx->state[7] = 0x5be0cd19137e2179ULL;
+    ctx->count = 0;
+}
+
+void sha512_update(sha512_ctx_t *ctx, const uint8_t *data, size_t len) {
+    size_t index = (size_t)(ctx->count % SHA512_BLOCK_SIZE);
+
+    ctx->count += len;
+
+    if (index > 0) {
+        size_t space = SHA512_BLOCK_SIZE - index;
+        if (len < space) {
+            memcpy(&ctx->buffer[index], data, len);
+            return;
+        }
+        memcpy(&ctx->buffer[index], data, space);
+        sha512_transform(ctx, ctx->buffer);
+        data += space;
+        len -= space;
+    }
+    while (len >= SHA512_BLOCK_SIZE) {
+        sha512_transform(ctx, data);
+        data += SHA512_BLOCK_SIZE;
+        len -= SHA512_BLOCK_SIZE;
+    }
+    if (len > 0) {
+        memcpy(ctx->buffer, data, len);
+    }
+}
+
+void sha512_final(sha512_ctx_t *ctx, uint8_t *digest) {
+    size_t i;
+    size_t index = (size_t)(ctx->count % SHA512_BLOCK_SIZE);
+    /* 128-bit big-endian bit length. count is bytes; bits = count*8. */
+    uint64_t bits_low = ctx->count << 3;
+    uint64_t bits_high = ctx->count >> 61;
+
+    ctx->buffer[index++] = 0x80;
+
+    /* Need 16 bytes at the end for the length; if not enough room, flush. */
+    if (index > SHA512_BLOCK_SIZE - 16) {
+        while (index < SHA512_BLOCK_SIZE) {
+            ctx->buffer[index++] = 0x00;
+        }
+        sha512_transform(ctx, ctx->buffer);
+        index = 0;
+    }
+    while (index < SHA512_BLOCK_SIZE - 16) {
+        ctx->buffer[index++] = 0x00;
+    }
+    for (i = 0; i < 8; i++) {
+        ctx->buffer[112 + i] = (uint8_t)(bits_high >> (56 - 8 * i));
+    }
+    for (i = 0; i < 8; i++) {
+        ctx->buffer[120 + i] = (uint8_t)(bits_low >> (56 - 8 * i));
+    }
+    sha512_transform(ctx, ctx->buffer);
+
+    for (i = 0; i < 8; i++) {
+        digest[i * 8]     = (uint8_t)(ctx->state[i] >> 56);
+        digest[i * 8 + 1] = (uint8_t)(ctx->state[i] >> 48);
+        digest[i * 8 + 2] = (uint8_t)(ctx->state[i] >> 40);
+        digest[i * 8 + 3] = (uint8_t)(ctx->state[i] >> 32);
+        digest[i * 8 + 4] = (uint8_t)(ctx->state[i] >> 24);
+        digest[i * 8 + 5] = (uint8_t)(ctx->state[i] >> 16);
+        digest[i * 8 + 6] = (uint8_t)(ctx->state[i] >> 8);
+        digest[i * 8 + 7] = (uint8_t)(ctx->state[i]);
+    }
+}
+
+void sha512(const uint8_t *data, size_t len, uint8_t *digest) {
+    sha512_ctx_t ctx;
+    sha512_init(&ctx);
+    sha512_update(&ctx, data, len);
+    sha512_final(&ctx, digest);
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/sha512.h
+++ b/src/tls/sha512.h
@@ -1,0 +1,36 @@
+/*
+ * sha512.h — SHA-512 (FIPS 180-4). EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON (native-only). Implemented here because Ed25519
+ * (RFC 8032) hashes with SHA-512; kept TLS-gated since no non-TLS subsystem needs
+ * it (unlike the shared SHA-256 in src/crypto). Verified against the FIPS 180-4 /
+ * NIST test vectors — see tests/test_tls_crypto.c.
+ */
+#ifndef WEBLIB_TLS_SHA512_H
+#define WEBLIB_TLS_SHA512_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SHA512_BLOCK_SIZE  128
+#define SHA512_DIGEST_SIZE 64
+
+typedef struct {
+    uint64_t state[8];
+    uint64_t count;      /* total message bytes (bit length is count*8) */
+    uint8_t  buffer[SHA512_BLOCK_SIZE];
+} sha512_ctx_t;
+
+/* Streaming SHA-512. */
+void sha512_init(sha512_ctx_t *ctx);
+void sha512_update(sha512_ctx_t *ctx, const uint8_t *data, size_t len);
+void sha512_final(sha512_ctx_t *ctx, uint8_t *digest);   /* SHA512_DIGEST_SIZE bytes */
+
+/* One-shot SHA-512 of `data` into `digest` (SHA512_DIGEST_SIZE bytes). */
+void sha512(const uint8_t *data, size_t len, uint8_t *digest);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_SHA512_H */

--- a/src/tls/sha512.h
+++ b/src/tls/sha512.h
@@ -20,7 +20,12 @@
 
 typedef struct {
     uint64_t state[8];
-    uint64_t count;      /* total message bytes (bit length is count*8) */
+    /* Total message bytes. This is a 64-bit byte counter, so the maximum
+     * supported message length is 2^64-1 bytes (~1.8e19). SHA-512's padding
+     * carries a 128-bit *bit* length; the bits above what a 64-bit byte count can
+     * express are always 0 here — that ceiling is unreachable for any real input
+     * (and vastly exceeds the tiny messages Ed25519 hashes). */
+    uint64_t count;
     uint8_t  buffer[SHA512_BLOCK_SIZE];
 } sha512_ctx_t;
 

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -15,6 +15,7 @@
 #include "chacha20poly1305.h"
 #include "hkdf.h"
 #include "x25519.h"
+#include "sha512.h"
 #endif
 
 static int g_failures = 0;
@@ -362,6 +363,55 @@ static void test_hkdf(void) {
     }
 }
 
+/* SHA-512 (FIPS 180-4) known-answer tests, incl. a multi-block message and a
+ * streaming-equals-one-shot check. */
+static void test_sha512(void) {
+    uint8_t d[SHA512_DIGEST_SIZE];
+
+    sha512((const uint8_t *)"abc", 3, d);
+    check_hex("sha512 (\"abc\")", d, 64,
+              "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a"
+              "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f");
+
+    sha512((const uint8_t *)"", 0, d);
+    check_hex("sha512 (empty)", d, 64,
+              "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce"
+              "47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");
+
+    /* 112-byte (two-block) NIST vector. */
+    sha512((const uint8_t *)"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmno"
+                            "ijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu", 112, d);
+    check_hex("sha512 (896-bit, 2 blocks)", d, 64,
+              "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018"
+              "501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909");
+
+    /* Streaming (odd chunk sizes over a 1000-byte message) must equal one-shot. */
+    {
+        uint8_t big[1000];
+        uint8_t one[SHA512_DIGEST_SIZE];
+        sha512_ctx_t ctx;
+        size_t off = 0;
+        size_t chunk = 1;
+        memset(big, 'a', sizeof(big));
+        sha512(big, sizeof(big), one);
+        sha512_init(&ctx);
+        while (off < sizeof(big)) {
+            size_t n = (sizeof(big) - off < chunk) ? (sizeof(big) - off) : chunk;
+            sha512_update(&ctx, big + off, n);
+            off += n;
+            chunk = chunk * 2 + 1;   /* 1,3,7,15,... spans multiple blocks */
+        }
+        sha512_final(&ctx, d);
+        if (memcmp(d, one, sizeof(d)) != 0) {
+            printf("FAIL: sha512 streaming != one-shot\n"); g_failures++;
+        } else {
+            check_hex("sha512 (1000 'a', streaming==one-shot)", d, 64,
+                      "67ba5535a46e3f86dbfbed8cbbaf0125c76ed549ff8b0b9e03e0c88cf90fa634"
+                      "fa7b12b47d77b694de488ace8d9a65967dc96df599727d3292a8d9d447709c97");
+        }
+    }
+}
+
 /* X25519 ECDH (RFC 7748) — §5.2 scalar-mult vectors, §6.1 base point + agreement,
  * and the iterated test (1 and 1000 rounds exercise the ladder end to end). */
 static void test_x25519(void) {
@@ -442,6 +492,7 @@ int main(void) {
     test_poly1305();
     test_chacha20poly1305();
     test_hkdf();
+    test_sha512();
     test_x25519();
 
     if (g_failures == 0) {

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -410,6 +410,21 @@ static void test_sha512(void) {
                       "fa7b12b47d77b694de488ace8d9a65967dc96df599727d3292a8d9d447709c97");
         }
     }
+
+    /* Input sensitivity: a single-bit change in the message must change the
+     * digest. A committed guard against a degenerate/stub or constant-returning
+     * implementation (complements the dev-time known-answer negative controls). */
+    {
+        uint8_t da[SHA512_DIGEST_SIZE];
+        uint8_t db[SHA512_DIGEST_SIZE];
+        sha512((const uint8_t *)"abc", 3, da);
+        sha512((const uint8_t *)"abd", 3, db);   /* 'c' ^ 0x07 = 'd' */
+        if (memcmp(da, db, sizeof(da)) == 0) {
+            printf("FAIL: sha512 not input-sensitive (digest unchanged)\n"); g_failures++;
+        } else {
+            printf("PASS: sha512 input-sensitive (1-byte change alters digest)\n");
+        }
+    }
 }
 
 /* X25519 ECDH (RFC 7748) — §5.2 scalar-mult vectors, §6.1 base point + agreement,


### PR DESCRIPTION
## Subsystem
`tls` crypto — **SHA-512**, needed by Ed25519 (RFC 8032 hashes with SHA-512). Split out as its own focused primitive before Ed25519.

## What
- **`src/tls/sha512.{c,h}`** — streaming `sha512_init/update/final` + one-shot `sha512()`. Standard FIPS 180-4 (64-bit words, 80 rounds, 128-byte blocks, 128-bit big-endian length field). Mirrors the existing SHA-256 module's shape.

## Placement
Kept **TLS-gated** (`src/tls/`, behind `WEBLIB_TLS`) rather than in the shared `src/crypto/`, because — unlike SHA-256, which the JWT middleware uses on every target — no non-TLS subsystem needs SHA-512. So the default build carries no `sha512` symbol (`nm`-confirmed) and its `ctest` is unchanged. It can be promoted to `src/crypto/` later if a non-TLS caller appears.

## Tests
- FIPS/NIST vectors: `"abc"`, empty, and the **112-byte (two-block)** vector.
- A **1000-byte** message fed in **growing odd-size chunks** (1, 3, 7, 15, … spanning multiple blocks) to verify **streaming == one-shot**.

Vectors were confirmed against `hashlib.sha512` first. **Negative control:** a wrong init constant fails every vector.

## Validation
- TLS build (`-DWEBLIB_ENABLE_TLS=ON`): `ctest` **8/8**, warning-free; clean under **ASan/UBSan**.
- Default build (TLS OFF): **6/6** on the normal and ASan/UBSan trees — unchanged.

## Next
**Ed25519** (RFC 8032) sign + verify, using this SHA-512 and the curve field arithmetic — the final crypto primitive. After it, the crypto foundation for the handshake is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)