### PR TITLE
TLS Phase 2: bounds-checked DER/ASN.1 reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(WEBLIB_SOURCES_NATIVE_ONLY
 option(WEBLIB_ENABLE_TLS "Build the experimental pure-C TLS 1.3 layer (native-only, UNAUDITED)" OFF)
 set(WEBLIB_SOURCES_TLS
     src/tls/tls.c
+    src/tls/der.c
     src/tls/chacha20.c
     src/tls/poly1305.c
     src/tls/chacha20poly1305.c

--- a/src/tls/der.c
+++ b/src/tls/der.c
@@ -3,49 +3,62 @@
  *
  * Compiled only under -DWEBLIB_ENABLE_TLS=ON. See der.h for the contract. The
  * guiding rule here is that the input is untrusted: no code path may read past
- * [pos, end), and every length is validated (definite + minimal) before its
- * value bytes are exposed. Malformed input is always a clean -1, never a crash.
+ * the cursor's remaining bytes, and every length is validated (definite +
+ * minimal) before its value bytes are exposed. Malformed input is always a clean
+ * -1, never a crash.
+ *
+ * The cursor carries a remaining-byte count, not an end pointer, so all bounds
+ * are size_t comparisons — no pointer subtraction or relational comparison is
+ * ever performed (which would be undefined behaviour on a NULL/empty buffer).
+ * `pos` is only offset or dereferenced after the count proves the bytes exist.
  */
 #include "der.h"
 
 #ifdef WEBLIB_TLS
 
-void der_init(der_reader *r, const uint8_t *data, size_t len) {
+void der_init(der_reader_t *r, const uint8_t *data, size_t len) {
+    /* A NULL buffer has nothing readable; forcing len to 0 means `pos` (NULL) is
+     * never dereferenced or offset, since every read checks the count first. */
+    if (data == NULL) {
+        len = 0;
+    }
     r->pos = data;
-    /* Avoid forming data+len when data is NULL (undefined pointer arithmetic);
-     * a NULL/empty range simply has nothing to read. */
-    r->end = (data != NULL) ? data + len : data;
+    r->len = len;
 }
 
-size_t der_remaining(const der_reader *r) {
-    return (size_t)(r->end - r->pos);
+size_t der_remaining(const der_reader_t *r) {
+    return r->len;
 }
 
-int der_at_end(const der_reader *r) {
-    return r->pos == r->end;
+int der_at_end(const der_reader_t *r) {
+    return r->len == 0;
 }
 
-int der_read_tlv(der_reader *r, uint8_t *tag, const uint8_t **val, size_t *val_len) {
+int der_read_tlv(der_reader_t *r, uint8_t *tag, const uint8_t **val, size_t *val_len) {
     const uint8_t *p = r->pos;
+    size_t avail = r->len;
+    size_t hdr;        /* bytes consumed by tag + length octets */
+    size_t len;        /* decoded value length */
     uint8_t t, lb;
-    size_t len;
 
     /* Identifier octet. */
-    if (p >= r->end) {
+    if (avail < 1) {
         return -1;
     }
-    t = *p++;
+    t = p[0];
     /* Reject high-tag-number form (low 5 bits all set): not needed for the
      * structures TLS parses, and it would require multi-byte tag decoding. */
     if ((t & 0x1f) == 0x1f) {
         return -1;
     }
 
-    /* Length octet(s). */
-    if (p >= r->end) {
+    /* First length octet. */
+    if (avail < 2) {
         return -1;
     }
-    lb = *p++;
+    lb = p[1];
+    hdr = 2;
+
     if (lb < 0x80) {
         /* Short form: the length is the octet itself. */
         len = lb;
@@ -60,38 +73,41 @@ int der_read_tlv(der_reader *r, uint8_t *tag, const uint8_t **val, size_t *val_l
         if (nbytes > sizeof(size_t)) {
             return -1;
         }
-        if ((size_t)(r->end - p) < nbytes) {
+        /* Need nbytes length octets after the two header bytes read so far.
+         * avail >= 2 == hdr here, so `avail - hdr` does not underflow. */
+        if (avail - hdr < nbytes) {
             return -1;
         }
         /* DER requires minimal length encoding: no leading zero octet ... */
-        if (p[0] == 0x00) {
+        if (p[hdr] == 0x00) {
             return -1;
         }
         len = 0;
         for (i = 0; i < nbytes; i++) {
-            len = (len << 8) | p[i];
+            len = (len << 8) | p[hdr + i];
         }
-        p += nbytes;
+        hdr += nbytes;
         /* ... and long form must actually be needed (value >= 128). */
         if (len < 0x80) {
             return -1;
         }
     }
 
-    /* The value must lie entirely within the buffer. Compare via subtraction of
-     * the already-validated pointers so nothing overflows. */
-    if (len > (size_t)(r->end - p)) {
+    /* The value must fit in the bytes remaining after the header. `avail >= hdr`
+     * holds on every path above, so the subtraction cannot underflow. */
+    if (len > avail - hdr) {
         return -1;
     }
 
     *tag = t;
-    *val = p;
+    *val = p + hdr;
     *val_len = len;
-    r->pos = p + len;
+    r->pos = p + hdr + len;
+    r->len = avail - hdr - len;
     return 0;
 }
 
-int der_expect(der_reader *r, uint8_t want_tag, const uint8_t **val, size_t *val_len) {
+int der_expect(der_reader_t *r, uint8_t want_tag, const uint8_t **val, size_t *val_len) {
     uint8_t tag;
     if (der_read_tlv(r, &tag, val, val_len) != 0) {
         return -1;
@@ -102,7 +118,7 @@ int der_expect(der_reader *r, uint8_t want_tag, const uint8_t **val, size_t *val
     return 0;
 }
 
-int der_enter(der_reader *r, uint8_t want_tag, der_reader *child) {
+int der_enter(der_reader_t *r, uint8_t want_tag, der_reader_t *child) {
     const uint8_t *val;
     size_t val_len;
     if (der_expect(r, want_tag, &val, &val_len) != 0) {

--- a/src/tls/der.c
+++ b/src/tls/der.c
@@ -1,0 +1,115 @@
+/*
+ * der.c — minimal, bounds-checked DER (ASN.1) reader. EXPERIMENTAL / UNAUDITED.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. See der.h for the contract. The
+ * guiding rule here is that the input is untrusted: no code path may read past
+ * [pos, end), and every length is validated (definite + minimal) before its
+ * value bytes are exposed. Malformed input is always a clean -1, never a crash.
+ */
+#include "der.h"
+
+#ifdef WEBLIB_TLS
+
+void der_init(der_reader *r, const uint8_t *data, size_t len) {
+    r->pos = data;
+    /* Avoid forming data+len when data is NULL (undefined pointer arithmetic);
+     * a NULL/empty range simply has nothing to read. */
+    r->end = (data != NULL) ? data + len : data;
+}
+
+size_t der_remaining(const der_reader *r) {
+    return (size_t)(r->end - r->pos);
+}
+
+int der_at_end(const der_reader *r) {
+    return r->pos == r->end;
+}
+
+int der_read_tlv(der_reader *r, uint8_t *tag, const uint8_t **val, size_t *val_len) {
+    const uint8_t *p = r->pos;
+    uint8_t t, lb;
+    size_t len;
+
+    /* Identifier octet. */
+    if (p >= r->end) {
+        return -1;
+    }
+    t = *p++;
+    /* Reject high-tag-number form (low 5 bits all set): not needed for the
+     * structures TLS parses, and it would require multi-byte tag decoding. */
+    if ((t & 0x1f) == 0x1f) {
+        return -1;
+    }
+
+    /* Length octet(s). */
+    if (p >= r->end) {
+        return -1;
+    }
+    lb = *p++;
+    if (lb < 0x80) {
+        /* Short form: the length is the octet itself. */
+        len = lb;
+    } else if (lb == 0x80) {
+        /* Indefinite length is a BER construct, forbidden in DER. */
+        return -1;
+    } else {
+        size_t nbytes = (size_t)(lb & 0x7f);
+        size_t i;
+        /* A length that needs more octets than a size_t can hold cannot be
+         * represented (and certainly cannot fit the buffer). */
+        if (nbytes > sizeof(size_t)) {
+            return -1;
+        }
+        if ((size_t)(r->end - p) < nbytes) {
+            return -1;
+        }
+        /* DER requires minimal length encoding: no leading zero octet ... */
+        if (p[0] == 0x00) {
+            return -1;
+        }
+        len = 0;
+        for (i = 0; i < nbytes; i++) {
+            len = (len << 8) | p[i];
+        }
+        p += nbytes;
+        /* ... and long form must actually be needed (value >= 128). */
+        if (len < 0x80) {
+            return -1;
+        }
+    }
+
+    /* The value must lie entirely within the buffer. Compare via subtraction of
+     * the already-validated pointers so nothing overflows. */
+    if (len > (size_t)(r->end - p)) {
+        return -1;
+    }
+
+    *tag = t;
+    *val = p;
+    *val_len = len;
+    r->pos = p + len;
+    return 0;
+}
+
+int der_expect(der_reader *r, uint8_t want_tag, const uint8_t **val, size_t *val_len) {
+    uint8_t tag;
+    if (der_read_tlv(r, &tag, val, val_len) != 0) {
+        return -1;
+    }
+    if (tag != want_tag) {
+        return -1;
+    }
+    return 0;
+}
+
+int der_enter(der_reader *r, uint8_t want_tag, der_reader *child) {
+    const uint8_t *val;
+    size_t val_len;
+    if (der_expect(r, want_tag, &val, &val_len) != 0) {
+        return -1;
+    }
+    der_init(child, val, val_len);
+    return 0;
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/der.h
+++ b/src/tls/der.h
@@ -34,38 +34,46 @@
 /* Context-specific constructed tag [n], e.g. [0] EXPLICIT is DER_TAG_CONTEXT(0). */
 #define DER_TAG_CONTEXT(n)    ((uint8_t)(0xA0 | (n)))
 
-/* A read cursor over a DER byte range [pos, end). Treat as opaque. */
+/*
+ * A read cursor over a DER byte range: `pos` is the next unread byte and `len`
+ * is the number of bytes remaining from `pos`. Representing the extent as a
+ * length (rather than an end pointer) keeps every bound a size_t comparison, so
+ * no pointer arithmetic or relational comparison is ever performed on a possibly
+ * NULL/empty buffer. This is an internal struct, exposed only so callers can hold
+ * one by value — do not read or write its fields directly; use the API below.
+ */
 typedef struct {
     const uint8_t *pos;
-    const uint8_t *end;
-} der_reader;
+    size_t len;
+} der_reader_t;
 
-/* Initialize a reader over [data, data+len). Safe with data == NULL when len 0. */
-void der_init(der_reader *r, const uint8_t *data, size_t len);
+/* Initialize a reader over [data, data+len). A NULL `data` is treated as empty
+ * (len forced to 0), so no read ever dereferences or offsets a NULL pointer. */
+void der_init(der_reader_t *r, const uint8_t *data, size_t len);
 
 /* Bytes not yet consumed. */
-size_t der_remaining(const der_reader *r);
+size_t der_remaining(const der_reader_t *r);
 
 /* 1 if the cursor is exactly at the end (no trailing bytes), else 0. */
-int der_at_end(const der_reader *r);
+int der_at_end(const der_reader_t *r);
 
 /*
  * Read one TLV. On success returns 0, writes the identifier octet to *tag, and
  * points [*val, *val + *val_len) at the value; the cursor advances past the
  * value. Returns -1 on any malformation — truncation, indefinite length,
  * non-minimal length, multi-byte tag, or a value that runs past the buffer — and
- * leaves the cursor unspecified (callers must stop reading on error).
+ * leaves the cursor unchanged (callers must stop reading on error).
  */
-int der_read_tlv(der_reader *r, uint8_t *tag, const uint8_t **val, size_t *val_len);
+int der_read_tlv(der_reader_t *r, uint8_t *tag, const uint8_t **val, size_t *val_len);
 
 /* Like der_read_tlv but also requires the tag to equal want_tag. 0 / -1. */
-int der_expect(der_reader *r, uint8_t want_tag, const uint8_t **val, size_t *val_len);
+int der_expect(der_reader_t *r, uint8_t want_tag, const uint8_t **val, size_t *val_len);
 
 /*
  * Read a TLV whose tag equals want_tag (typically a constructed type) and open
  * `child` over its contents so the caller can iterate the members. 0 / -1.
  */
-int der_enter(der_reader *r, uint8_t want_tag, der_reader *child);
+int der_enter(der_reader_t *r, uint8_t want_tag, der_reader_t *child);
 
 #endif /* WEBLIB_TLS */
 #endif /* WEBLIB_TLS_DER_H */

--- a/src/tls/der.h
+++ b/src/tls/der.h
@@ -1,0 +1,71 @@
+/*
+ * der.h — minimal, bounds-checked DER (ASN.1) reader. EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON. Just enough of ITU-T X.690 DER to walk the structures
+ * TLS needs — X.509 certificates and PKCS#8 private keys — with a hard security
+ * requirement: it parses attacker-controlled input, so every read is bounds- and
+ * well-formedness-checked and never reads outside the caller's buffer.
+ *
+ * This is a *reader* (decode only), not an encoder. It enforces DER's canonical
+ * rules that matter for safety and identity: definite, minimal-length encoding
+ * only (indefinite and non-minimal lengths are rejected), and single-byte tags.
+ * Exercised by tests/test_tls_parse.c.
+ */
+#ifndef WEBLIB_TLS_DER_H
+#define WEBLIB_TLS_DER_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Universal ASN.1 tag identifier octets used by X.509 / PKCS#8. The 0x20 bit of
+ * SEQUENCE/SET marks them constructed; matching the exact octet also enforces
+ * the primitive/constructed distinction. */
+#define DER_TAG_BOOLEAN       0x01
+#define DER_TAG_INTEGER       0x02
+#define DER_TAG_BIT_STRING    0x03
+#define DER_TAG_OCTET_STRING  0x04
+#define DER_TAG_NULL          0x05
+#define DER_TAG_OID           0x06
+#define DER_TAG_SEQUENCE      0x30
+#define DER_TAG_SET           0x31
+/* Context-specific constructed tag [n], e.g. [0] EXPLICIT is DER_TAG_CONTEXT(0). */
+#define DER_TAG_CONTEXT(n)    ((uint8_t)(0xA0 | (n)))
+
+/* A read cursor over a DER byte range [pos, end). Treat as opaque. */
+typedef struct {
+    const uint8_t *pos;
+    const uint8_t *end;
+} der_reader;
+
+/* Initialize a reader over [data, data+len). Safe with data == NULL when len 0. */
+void der_init(der_reader *r, const uint8_t *data, size_t len);
+
+/* Bytes not yet consumed. */
+size_t der_remaining(const der_reader *r);
+
+/* 1 if the cursor is exactly at the end (no trailing bytes), else 0. */
+int der_at_end(const der_reader *r);
+
+/*
+ * Read one TLV. On success returns 0, writes the identifier octet to *tag, and
+ * points [*val, *val + *val_len) at the value; the cursor advances past the
+ * value. Returns -1 on any malformation — truncation, indefinite length,
+ * non-minimal length, multi-byte tag, or a value that runs past the buffer — and
+ * leaves the cursor unspecified (callers must stop reading on error).
+ */
+int der_read_tlv(der_reader *r, uint8_t *tag, const uint8_t **val, size_t *val_len);
+
+/* Like der_read_tlv but also requires the tag to equal want_tag. 0 / -1. */
+int der_expect(der_reader *r, uint8_t want_tag, const uint8_t **val, size_t *val_len);
+
+/*
+ * Read a TLV whose tag equals want_tag (typically a constructed type) and open
+ * `child` over its contents so the caller can iterate the members. 0 / -1.
+ */
+int der_enter(der_reader *r, uint8_t want_tag, der_reader *child);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_DER_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,13 @@ if(NOT EMSCRIPTEN)
         target_compile_definitions(test_tls_crypto PRIVATE WEBLIB_TLS)
         target_link_libraries(test_tls_crypto weblib ${PLATFORM_LIBS})
         add_test(NAME TlsCryptoTests COMMAND test_tls_crypto)
+
+        # TLS parsing tests (DER/ASN.1, later PEM/X.509) — malformed-input hardened
+        add_executable(test_tls_parse test_tls_parse.c)
+        target_include_directories(test_tls_parse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls)
+        target_compile_definitions(test_tls_parse PRIVATE WEBLIB_TLS)
+        target_link_libraries(test_tls_parse weblib ${PLATFORM_LIBS})
+        add_test(NAME TlsParseTests COMMAND test_tls_parse)
     endif()
 endif()
 

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -35,7 +35,7 @@ static void test_der_valid_sequence(void) {
         0x02, 0x01, 0x05,       /*   INTEGER 5 */
         0x04, 0x01, 0x41        /*   OCTET STRING "A" */
     };
-    der_reader r, seq;
+    der_reader_t r, seq;
     const uint8_t *val;
     size_t vlen;
 
@@ -55,7 +55,7 @@ static void test_der_valid_sequence(void) {
 /* Valid: long-form length (a 200-byte OCTET STRING: 0x04 0x81 0xC8 <200>). */
 static void test_der_long_form_length(void) {
     uint8_t in[3 + 200];
-    der_reader r;
+    der_reader_t r;
     const uint8_t *val;
     size_t vlen;
     int i;
@@ -79,11 +79,17 @@ static void test_der_rejects_malformed(void) {
     uint8_t tag;
     const uint8_t *val;
     size_t vlen;
-    der_reader r;
+    der_reader_t r;
 
     der_init(&r, NULL, 0);
     check_true("der: rejects empty input",
                der_read_tlv(&r, &tag, &val, &vlen) == -1);
+
+    /* A NULL buffer claiming a non-zero length must be handled as empty (no
+     * pointer arithmetic/comparison on NULL), not crash or over-read. */
+    der_init(&r, NULL, 5);
+    check_true("der: NULL buffer with nonzero len treated as empty",
+               der_read_tlv(&r, &tag, &val, &vlen) == -1 && der_remaining(&r) == 0);
 
     {   /* value runs past the buffer: claims length 5, only 2 value bytes */
         static const uint8_t b[] = { 0x04, 0x05, 0x41, 0x42 };
@@ -132,7 +138,7 @@ static void test_der_rejects_malformed(void) {
 /* der_expect / der_enter must enforce the requested tag. */
 static void test_der_tag_enforcement(void) {
     static const uint8_t in[] = { 0x02, 0x01, 0x05 };   /* INTEGER 5 */
-    der_reader r, child;
+    der_reader_t r, child;
     const uint8_t *val;
     size_t vlen;
 

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -1,0 +1,164 @@
+/*
+ * test_tls_parse.c — tests for the experimental TLS parsing layer (DER/ASN.1;
+ * PEM and X.509 will join here). Built only with -DWEBLIB_ENABLE_TLS=ON.
+ *
+ * The DER reader parses untrusted input, so malformed-input rejection is
+ * weighted as heavily as correct decoding: truncation, indefinite and
+ * non-minimal lengths, multi-byte tags, and out-of-bounds values must each be
+ * rejected cleanly (return -1) — never crash or over-read.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#ifdef WEBLIB_TLS
+#include "der.h"
+#endif
+
+static int g_failures = 0;
+
+static void check_true(const char *label, int cond) {
+    if (cond) {
+        printf("PASS: %s\n", label);
+    } else {
+        printf("FAIL: %s\n", label);
+        g_failures++;
+    }
+}
+
+#ifdef WEBLIB_TLS
+
+/* Valid: SEQUENCE { INTEGER 5, OCTET STRING 'A' } — walk it end to end. */
+static void test_der_valid_sequence(void) {
+    static const uint8_t in[] = {
+        0x30, 0x06,             /* SEQUENCE, length 6 */
+        0x02, 0x01, 0x05,       /*   INTEGER 5 */
+        0x04, 0x01, 0x41        /*   OCTET STRING "A" */
+    };
+    der_reader r, seq;
+    const uint8_t *val;
+    size_t vlen;
+
+    der_init(&r, in, sizeof in);
+    check_true("der: enter SEQUENCE", der_enter(&r, DER_TAG_SEQUENCE, &seq) == 0);
+    check_true("der: outer fully consumed", der_at_end(&r));
+
+    check_true("der: read INTEGER value",
+               der_expect(&seq, DER_TAG_INTEGER, &val, &vlen) == 0
+               && vlen == 1 && val[0] == 0x05);
+    check_true("der: read OCTET STRING value",
+               der_expect(&seq, DER_TAG_OCTET_STRING, &val, &vlen) == 0
+               && vlen == 1 && val[0] == 0x41);
+    check_true("der: inner fully consumed", der_at_end(&seq));
+}
+
+/* Valid: long-form length (a 200-byte OCTET STRING: 0x04 0x81 0xC8 <200>). */
+static void test_der_long_form_length(void) {
+    uint8_t in[3 + 200];
+    der_reader r;
+    const uint8_t *val;
+    size_t vlen;
+    int i;
+
+    in[0] = 0x04;       /* OCTET STRING */
+    in[1] = 0x81;       /* long form, one length octet follows */
+    in[2] = 0xC8;       /* 200 */
+    for (i = 0; i < 200; i++) {
+        in[3 + i] = (uint8_t)i;
+    }
+
+    der_init(&r, in, sizeof in);
+    check_true("der: long-form length decodes",
+               der_expect(&r, DER_TAG_OCTET_STRING, &val, &vlen) == 0
+               && vlen == 200 && val[0] == 0 && val[199] == 199
+               && der_at_end(&r));
+}
+
+/* Each malformed encoding must be rejected by der_read_tlv (-1). */
+static void test_der_rejects_malformed(void) {
+    uint8_t tag;
+    const uint8_t *val;
+    size_t vlen;
+    der_reader r;
+
+    der_init(&r, NULL, 0);
+    check_true("der: rejects empty input",
+               der_read_tlv(&r, &tag, &val, &vlen) == -1);
+
+    {   /* value runs past the buffer: claims length 5, only 2 value bytes */
+        static const uint8_t b[] = { 0x04, 0x05, 0x41, 0x42 };
+        der_init(&r, b, sizeof b);
+        check_true("der: rejects truncated value",
+                   der_read_tlv(&r, &tag, &val, &vlen) == -1);
+    }
+    {   /* long form 0x82 promises two length octets, only one present */
+        static const uint8_t b[] = { 0x04, 0x82, 0x01 };
+        der_init(&r, b, sizeof b);
+        check_true("der: rejects truncated length field",
+                   der_read_tlv(&r, &tag, &val, &vlen) == -1);
+    }
+    {   /* indefinite length (a BER-only construct) */
+        static const uint8_t b[] = { 0x30, 0x80, 0x00, 0x00 };
+        der_init(&r, b, sizeof b);
+        check_true("der: rejects indefinite length",
+                   der_read_tlv(&r, &tag, &val, &vlen) == -1);
+    }
+    {   /* non-minimal: length 5 in long form when short form fits */
+        static const uint8_t b[] = { 0x02, 0x81, 0x05, 0, 0, 0, 0, 0 };
+        der_init(&r, b, sizeof b);
+        check_true("der: rejects non-minimal long-form length",
+                   der_read_tlv(&r, &tag, &val, &vlen) == -1);
+    }
+    {   /* non-minimal: leading zero octet in the length */
+        static const uint8_t b[] = { 0x02, 0x82, 0x00, 0x80, 0 };
+        der_init(&r, b, sizeof b);
+        check_true("der: rejects leading-zero length octet",
+                   der_read_tlv(&r, &tag, &val, &vlen) == -1);
+    }
+    {   /* high-tag-number identifier (low 5 bits all set) */
+        static const uint8_t b[] = { 0x1f, 0x20, 0x01, 0x00 };
+        der_init(&r, b, sizeof b);
+        check_true("der: rejects multi-byte tag",
+                   der_read_tlv(&r, &tag, &val, &vlen) == -1);
+    }
+    {   /* length field wider than a size_t can hold (0x89 => 9 octets) */
+        static const uint8_t b[] = { 0x02, 0x89, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        der_init(&r, b, sizeof b);
+        check_true("der: rejects oversized length field",
+                   der_read_tlv(&r, &tag, &val, &vlen) == -1);
+    }
+}
+
+/* der_expect / der_enter must enforce the requested tag. */
+static void test_der_tag_enforcement(void) {
+    static const uint8_t in[] = { 0x02, 0x01, 0x05 };   /* INTEGER 5 */
+    der_reader r, child;
+    const uint8_t *val;
+    size_t vlen;
+
+    der_init(&r, in, sizeof in);
+    check_true("der: der_expect rejects wrong tag",
+               der_expect(&r, DER_TAG_OCTET_STRING, &val, &vlen) == -1);
+
+    der_init(&r, in, sizeof in);
+    check_true("der: der_enter rejects wrong tag",
+               der_enter(&r, DER_TAG_SEQUENCE, &child) == -1);
+}
+#endif /* WEBLIB_TLS */
+
+int main(void) {
+#ifndef WEBLIB_TLS
+    printf("FAIL: test_tls_parse built without WEBLIB_TLS defined\n");
+    return 1;
+#else
+    test_der_valid_sequence();
+    test_der_long_form_length();
+    test_der_rejects_malformed();
+    test_der_tag_enforcement();
+
+    if (g_failures == 0) {
+        printf("All TLS parse tests passed.\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+#endif
+}


### PR DESCRIPTION
## Summary

Kicks off **TLS Phase 2 (certificate/key loading)** now that the full crypto primitive set is complete. This is the foundation piece: a minimal, **decode-only DER (ITU-T X.690) reader** in `src/tls/der.{c,h}` that the upcoming X.509 certificate and PKCS#8 private-key parsers will build on.

It parses **attacker-controlled input**, so memory safety is the primary requirement — no code path reads outside the caller's `[pos, end)` buffer, and every length is validated before its value bytes are exposed. Malformed input is always a clean `-1`, never a crash or over-read.

## API (TLS-gated, internal — not in `kamran.k`)

| Function | Purpose |
|---|---|
| `der_init` / `der_remaining` / `der_at_end` | cursor over a byte range |
| `der_read_tlv` | read one Tag-Length-Value; `-1` on any malformation |
| `der_expect` | `der_read_tlv` + exact tag match |
| `der_enter` | descend into a constructed value (e.g. `SEQUENCE`) via a child cursor |

## DER canonical rules enforced (each rejected)

Indefinite lengths (BER-only); non-minimal lengths (long form when short fits, or a leading-zero length octet); length fields wider than `size_t`; multi-byte (high-tag-number) tags; truncated tag/length/value; and any value that runs past the buffer. `der_init` also avoids forming `data + len` when `data == NULL` (UB).

## Tests — `TlsParseTests` (new suite)

16 checks in `tests/test_tls_parse.c`: walk a valid `SEQUENCE{INTEGER, OCTET STRING}` end to end, decode a long-form length (200-byte value), enforce tags via `der_expect`/`der_enter`, and reject **all eight** malformed encodings above. Malformed-input rejection is weighted as heavily as correct decoding.

## Verification

| Build | Result |
|---|---|
| Default (TLS **OFF**) | byte-identical; no `der` symbols; **ctest 6/6** |
| TLS (`WEBLIB_ENABLE_TLS=ON`) | 0 warnings; **ctest 9/9** |
| TLS + ASan/UBSan (`halt_on_error=1`) | clean |

**Negative control:** disabling the value-bounds check flips the "rejects truncated value" test to failing (the parser accepts an out-of-bounds value), confirming the test binds to that check.

Native-only, gated behind `WEBLIB_ENABLE_TLS` (default **OFF**).

## Next in Phase 2
(B) PEM decoder (`-----BEGIN/END-----` + base64→DER); (C) PKCS#8 Ed25519 private-key + X.509 SubjectPublicKeyInfo extraction, built on this reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)