### PR TITLE
TLS Phase 2: Ed25519 key extraction (PKCS#8 + X.509 SPKI)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/x25519.c
     src/tls/sha512.c
     src/tls/ed25519.c
+    src/tls/ed25519_key.c
 )
 
 if(EMSCRIPTEN)

--- a/src/tls/ed25519_key.c
+++ b/src/tls/ed25519_key.c
@@ -34,6 +34,11 @@ static int expect_ed25519_alg(der_reader_t *seq) {
     if (oid_len != sizeof ED25519_OID || memcmp(oid, ED25519_OID, oid_len) != 0) {
         return -1;
     }
+    /* RFC 8410 §3: the Ed25519 AlgorithmIdentifier parameters MUST be absent, so
+     * the SEQUENCE must hold nothing after the OID. */
+    if (!der_at_end(&alg)) {
+        return -1;
+    }
     return 0;
 }
 
@@ -75,6 +80,12 @@ int ed25519_parse_pkcs8(const uint8_t *der, size_t der_len, uint8_t seed[32]) {
     if (vlen != 32) {
         return -1;
     }
+    /* The CurvePrivateKey wrapper holds only the 32-byte seed, and nothing may
+     * follow the OneAsymmetricKey SEQUENCE. (The outer SEQUENCE itself may carry
+     * v2's optional attributes/publicKey, so it is not required to be empty.) */
+    if (!der_at_end(&priv) || !der_at_end(&top)) {
+        return -1;
+    }
 
     memcpy(seed, v, 32);
     return 0;
@@ -106,6 +117,11 @@ int ed25519_parse_spki(const uint8_t *der, size_t der_len, uint8_t pub[32]) {
         return -1;
     }
     if (vlen != 33 || v[0] != 0x00) {
+        return -1;
+    }
+    /* SubjectPublicKeyInfo is exactly { algorithm, subjectPublicKey }, and
+     * nothing may follow it. */
+    if (!der_at_end(&seq) || !der_at_end(&top)) {
         return -1;
     }
 

--- a/src/tls/ed25519_key.c
+++ b/src/tls/ed25519_key.c
@@ -1,0 +1,116 @@
+/*
+ * ed25519_key.c — parse Ed25519 keys from DER. EXPERIMENTAL / UNAUDITED.
+ * See ed25519_key.h.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. Walks the PKCS#8 and
+ * SubjectPublicKeyInfo structures with the bounds-checked DER reader, checking
+ * the Ed25519 algorithm OID and the exact key sizes before copying any bytes.
+ * The DER templates were cross-checked against OpenSSL (it parses the same bytes
+ * as valid Ed25519 keys and derives the matching public key).
+ */
+#include "ed25519_key.h"
+
+#ifdef WEBLIB_TLS
+
+#include "der.h"
+#include <string.h>
+
+/* id-Ed25519 (RFC 8410 §3) = 1.3.101.112, DER OID value bytes. */
+static const uint8_t ED25519_OID[3] = { 0x2B, 0x65, 0x70 };
+
+/* Match an AlgorithmIdentifier SEQUENCE carrying exactly the Ed25519 OID.
+ * RFC 8410 §3 requires the parameters field to be absent; a lone OID satisfies
+ * that. Returns 0 on match, -1 otherwise. Advances `seq` past the algorithm. */
+static int expect_ed25519_alg(der_reader_t *seq) {
+    der_reader_t alg;
+    const uint8_t *oid;
+    size_t oid_len;
+    if (der_enter(seq, DER_TAG_SEQUENCE, &alg) != 0) {
+        return -1;
+    }
+    if (der_expect(&alg, DER_TAG_OID, &oid, &oid_len) != 0) {
+        return -1;
+    }
+    if (oid_len != sizeof ED25519_OID || memcmp(oid, ED25519_OID, oid_len) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int ed25519_parse_pkcs8(const uint8_t *der, size_t der_len, uint8_t seed[32]) {
+    der_reader_t top, seq, priv;
+    const uint8_t *v;
+    size_t vlen;
+
+    if (der == NULL || seed == NULL) {
+        return -1;
+    }
+
+    der_init(&top, der, der_len);
+
+    /* OneAsymmetricKey ::= SEQUENCE { version, privateKeyAlgorithm, privateKey } */
+    if (der_enter(&top, DER_TAG_SEQUENCE, &seq) != 0) {
+        return -1;
+    }
+
+    /* version INTEGER: 0 (v1) or 1 (v2, which may carry an optional public key). */
+    if (der_expect(&seq, DER_TAG_INTEGER, &v, &vlen) != 0) {
+        return -1;
+    }
+    if (vlen != 1 || (v[0] != 0x00 && v[0] != 0x01)) {
+        return -1;
+    }
+
+    if (expect_ed25519_alg(&seq) != 0) {
+        return -1;
+    }
+
+    /* privateKey ::= OCTET STRING wrapping CurvePrivateKey ::= OCTET STRING(32). */
+    if (der_enter(&seq, DER_TAG_OCTET_STRING, &priv) != 0) {
+        return -1;
+    }
+    if (der_expect(&priv, DER_TAG_OCTET_STRING, &v, &vlen) != 0) {
+        return -1;
+    }
+    if (vlen != 32) {
+        return -1;
+    }
+
+    memcpy(seed, v, 32);
+    return 0;
+}
+
+int ed25519_parse_spki(const uint8_t *der, size_t der_len, uint8_t pub[32]) {
+    der_reader_t top, seq;
+    const uint8_t *v;
+    size_t vlen;
+
+    if (der == NULL || pub == NULL) {
+        return -1;
+    }
+
+    der_init(&top, der, der_len);
+
+    /* SubjectPublicKeyInfo ::= SEQUENCE { algorithm, subjectPublicKey } */
+    if (der_enter(&top, DER_TAG_SEQUENCE, &seq) != 0) {
+        return -1;
+    }
+
+    if (expect_ed25519_alg(&seq) != 0) {
+        return -1;
+    }
+
+    /* subjectPublicKey ::= BIT STRING. For a key the value is one leading
+     * "unused bits" octet (0x00) followed by the 32 raw public-key bytes. */
+    if (der_expect(&seq, DER_TAG_BIT_STRING, &v, &vlen) != 0) {
+        return -1;
+    }
+    if (vlen != 33 || v[0] != 0x00) {
+        return -1;
+    }
+
+    memcpy(pub, v + 1, 32);
+    return 0;
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/ed25519_key.h
+++ b/src/tls/ed25519_key.h
@@ -1,0 +1,37 @@
+/*
+ * ed25519_key.h — parse Ed25519 keys from their DER encodings. EXPERIMENTAL /
+ * UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON. Extracts the raw 32-byte Ed25519 seed / public key
+ * from the two DER structures a TLS server loads:
+ *   - a PKCS#8 OneAsymmetricKey (RFC 5958 / RFC 8410 §7) private key, and
+ *   - a SubjectPublicKeyInfo (RFC 8410 §4) public key.
+ * Built on the bounds-checked DER reader (der.h); every field is validated
+ * (Ed25519 OID 1.3.101.112, exact key lengths) before any bytes are returned.
+ * Exercised by tests/test_tls_parse.c.
+ */
+#ifndef WEBLIB_TLS_ED25519_KEY_H
+#define WEBLIB_TLS_ED25519_KEY_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Parse a PKCS#8 Ed25519 private key (DER) and copy its 32-byte seed to `seed`.
+ * Returns 0 on success, -1 if the structure is not a well-formed Ed25519 PKCS#8
+ * key (wrong OID, wrong lengths, malformed DER). `seed` is written only on
+ * success.
+ */
+int ed25519_parse_pkcs8(const uint8_t *der, size_t der_len, uint8_t seed[32]);
+
+/*
+ * Parse an Ed25519 SubjectPublicKeyInfo (DER) and copy its 32-byte public key to
+ * `pub`. Returns 0 on success, -1 otherwise. `pub` is written only on success.
+ */
+int ed25519_parse_spki(const uint8_t *der, size_t der_len, uint8_t pub[32]);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_ED25519_KEY_H */

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -275,23 +275,35 @@ static void test_ed25519_key(void) {
         0xc0, 0xcd, 0x55, 0xf1, 0x2a, 0xf4, 0x66, 0x0c
     };
     static const uint8_t garbage[] = { 0x30, 0x03, 0x99, 0x88, 0x77 };
+    static const uint8_t spki_alg_params[] = {   /* AlgId carries a NULL param */
+        0x30, 0x2c, 0x30, 0x07, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x05, 0x00, 0x03,
+        0x21, 0x00, 0x3d, 0x40, 0x17, 0xc3, 0xe8, 0x43, 0x89, 0x5a, 0x92, 0xb7,
+        0x0a, 0xa7, 0x4d, 0x1b, 0x7e, 0xbc, 0x9c, 0x98, 0x2c, 0xcf, 0x2e, 0xc4,
+        0x96, 0x8c, 0xc0, 0xcd, 0x55, 0xf1, 0x2a, 0xf4, 0x66, 0x0c
+    };
     uint8_t got_seed[32], got_pub[32], derived[32];
+    int pk_ok, sp_ok;
+
+    /* Parse both keys once, then gate the cross-derivation checks on success so
+     * a parse failure surfaces as one clear failure, not cascading ones. */
+    pk_ok = (ed25519_parse_pkcs8(pkcs8, sizeof pkcs8, got_seed) == 0);
+    sp_ok = (ed25519_parse_spki(spki, sizeof spki, got_pub) == 0);
 
     check_true("ed25519_key: PKCS#8 -> seed",
-               ed25519_parse_pkcs8(pkcs8, sizeof pkcs8, got_seed) == 0
-               && memcmp(got_seed, seed, 32) == 0);
-
-    /* End to end: the extracted seed must derive the expected public key. */
-    ed25519_public_key(derived, got_seed);
-    check_true("ed25519_key: PKCS#8 seed derives the expected public key",
-               memcmp(derived, pub, 32) == 0);
-
+               pk_ok && memcmp(got_seed, seed, 32) == 0);
     check_true("ed25519_key: SPKI -> public key",
-               ed25519_parse_spki(spki, sizeof spki, got_pub) == 0
-               && memcmp(got_pub, pub, 32) == 0);
+               sp_ok && memcmp(got_pub, pub, 32) == 0);
 
-    check_true("ed25519_key: PKCS#8-derived key matches SPKI key",
-               memcmp(derived, got_pub, 32) == 0);
+    if (pk_ok) {
+        /* End to end: the extracted seed must derive the expected public key. */
+        ed25519_public_key(derived, got_seed);
+        check_true("ed25519_key: PKCS#8 seed derives the expected public key",
+                   memcmp(derived, pub, 32) == 0);
+        if (sp_ok) {
+            check_true("ed25519_key: PKCS#8-derived key matches SPKI key",
+                       memcmp(derived, got_pub, 32) == 0);
+        }
+    }
 
     /* Rejections. */
     check_true("ed25519_key: SPKI wrong OID rejected",
@@ -305,6 +317,25 @@ static void test_ed25519_key(void) {
     check_true("ed25519_key: NULL arguments rejected",
                ed25519_parse_pkcs8(NULL, 10, got_seed) == -1
                && ed25519_parse_spki(spki, sizeof spki, NULL) == -1);
+
+    /* Strict structure: reject an AlgorithmIdentifier with parameters (RFC 8410
+     * requires them absent) and any trailing data after the key structure. */
+    check_true("ed25519_key: SPKI with AlgId parameters rejected",
+               ed25519_parse_spki(spki_alg_params, sizeof spki_alg_params, got_pub) == -1);
+    {
+        uint8_t buf[sizeof spki + 1];
+        memcpy(buf, spki, sizeof spki);
+        buf[sizeof spki] = 0x2a;
+        check_true("ed25519_key: SPKI with trailing data rejected",
+                   ed25519_parse_spki(buf, sizeof buf, got_pub) == -1);
+    }
+    {
+        uint8_t buf[sizeof pkcs8 + 1];
+        memcpy(buf, pkcs8, sizeof pkcs8);
+        buf[sizeof pkcs8] = 0x2a;
+        check_true("ed25519_key: PKCS#8 with trailing data rejected",
+                   ed25519_parse_pkcs8(buf, sizeof buf, got_seed) == -1);
+    }
 
     /* End-to-end server key-loading flow: a PEM "PRIVATE KEY" file decodes to
      * DER (pem_decode) which parses to the same seed (ed25519_parse_pkcs8). The

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -14,6 +14,8 @@
 #ifdef WEBLIB_TLS
 #include "der.h"
 #include "pem.h"
+#include "ed25519_key.h"
+#include "ed25519.h"
 #endif
 
 static int g_failures = 0;
@@ -238,6 +240,88 @@ static void test_pem_decode(void) {
                pem_decode(NULL, lf_pem, strlen(lf_pem), out, sizeof out, &out_len) == -1
                && pem_decode("CERTIFICATE", NULL, 10, out, sizeof out, &out_len) == -1);
 }
+
+/* Ed25519 key parsing: PKCS#8 private key + SubjectPublicKeyInfo public key.
+ * The vectors are the RFC 8032 TEST2 keypair wrapped in the standard DER
+ * templates, cross-checked with OpenSSL (which parses them as valid Ed25519 keys
+ * and derives the same public key from the private seed). */
+static void test_ed25519_key(void) {
+    static const uint8_t pkcs8[] = {
+        0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,
+        0x04, 0x22, 0x04, 0x20, 0x4c, 0xcd, 0x08, 0x9b, 0x28, 0xff, 0x96, 0xda,
+        0x9d, 0xb6, 0xc3, 0x46, 0xec, 0x11, 0x4e, 0x0f, 0x5b, 0x8a, 0x31, 0x9f,
+        0x35, 0xab, 0xa6, 0x24, 0xda, 0x8c, 0xf6, 0xed, 0x4f, 0xb8, 0xa6, 0xfb
+    };
+    static const uint8_t spki[] = {
+        0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+        0x3d, 0x40, 0x17, 0xc3, 0xe8, 0x43, 0x89, 0x5a, 0x92, 0xb7, 0x0a, 0xa7,
+        0x4d, 0x1b, 0x7e, 0xbc, 0x9c, 0x98, 0x2c, 0xcf, 0x2e, 0xc4, 0x96, 0x8c,
+        0xc0, 0xcd, 0x55, 0xf1, 0x2a, 0xf4, 0x66, 0x0c
+    };
+    static const uint8_t seed[32] = {
+        0x4c, 0xcd, 0x08, 0x9b, 0x28, 0xff, 0x96, 0xda, 0x9d, 0xb6, 0xc3, 0x46,
+        0xec, 0x11, 0x4e, 0x0f, 0x5b, 0x8a, 0x31, 0x9f, 0x35, 0xab, 0xa6, 0x24,
+        0xda, 0x8c, 0xf6, 0xed, 0x4f, 0xb8, 0xa6, 0xfb
+    };
+    static const uint8_t pub[32] = {
+        0x3d, 0x40, 0x17, 0xc3, 0xe8, 0x43, 0x89, 0x5a, 0x92, 0xb7, 0x0a, 0xa7,
+        0x4d, 0x1b, 0x7e, 0xbc, 0x9c, 0x98, 0x2c, 0xcf, 0x2e, 0xc4, 0x96, 0x8c,
+        0xc0, 0xcd, 0x55, 0xf1, 0x2a, 0xf4, 0x66, 0x0c
+    };
+    static const uint8_t spki_bad_oid[] = {   /* OID last byte 0x70 -> 0x71 */
+        0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x71, 0x03, 0x21, 0x00,
+        0x3d, 0x40, 0x17, 0xc3, 0xe8, 0x43, 0x89, 0x5a, 0x92, 0xb7, 0x0a, 0xa7,
+        0x4d, 0x1b, 0x7e, 0xbc, 0x9c, 0x98, 0x2c, 0xcf, 0x2e, 0xc4, 0x96, 0x8c,
+        0xc0, 0xcd, 0x55, 0xf1, 0x2a, 0xf4, 0x66, 0x0c
+    };
+    static const uint8_t garbage[] = { 0x30, 0x03, 0x99, 0x88, 0x77 };
+    uint8_t got_seed[32], got_pub[32], derived[32];
+
+    check_true("ed25519_key: PKCS#8 -> seed",
+               ed25519_parse_pkcs8(pkcs8, sizeof pkcs8, got_seed) == 0
+               && memcmp(got_seed, seed, 32) == 0);
+
+    /* End to end: the extracted seed must derive the expected public key. */
+    ed25519_public_key(derived, got_seed);
+    check_true("ed25519_key: PKCS#8 seed derives the expected public key",
+               memcmp(derived, pub, 32) == 0);
+
+    check_true("ed25519_key: SPKI -> public key",
+               ed25519_parse_spki(spki, sizeof spki, got_pub) == 0
+               && memcmp(got_pub, pub, 32) == 0);
+
+    check_true("ed25519_key: PKCS#8-derived key matches SPKI key",
+               memcmp(derived, got_pub, 32) == 0);
+
+    /* Rejections. */
+    check_true("ed25519_key: SPKI wrong OID rejected",
+               ed25519_parse_spki(spki_bad_oid, sizeof spki_bad_oid, got_pub) == -1);
+    check_true("ed25519_key: truncated PKCS#8 rejected",
+               ed25519_parse_pkcs8(pkcs8, sizeof pkcs8 - 5, got_seed) == -1);
+    check_true("ed25519_key: truncated SPKI rejected",
+               ed25519_parse_spki(spki, sizeof spki - 3, got_pub) == -1);
+    check_true("ed25519_key: garbage PKCS#8 rejected",
+               ed25519_parse_pkcs8(garbage, sizeof garbage, got_seed) == -1);
+    check_true("ed25519_key: NULL arguments rejected",
+               ed25519_parse_pkcs8(NULL, 10, got_seed) == -1
+               && ed25519_parse_spki(spki, sizeof spki, NULL) == -1);
+
+    /* End-to-end server key-loading flow: a PEM "PRIVATE KEY" file decodes to
+     * DER (pem_decode) which parses to the same seed (ed25519_parse_pkcs8). The
+     * PEM was verified with OpenSSL. */
+    {
+        static const char key_pem[] =
+            "-----BEGIN PRIVATE KEY-----\n"
+            "MC4CAQAwBQYDK2VwBCIEIEzNCJso/5banbbDRuwRTg9bijGfNaumJNqM9u1PuKb7\n"
+            "-----END PRIVATE KEY-----\n";
+        unsigned char der[128];
+        size_t der_len = 0;
+        check_true("ed25519_key: PEM PRIVATE KEY -> DER -> seed (end to end)",
+                   pem_decode("PRIVATE KEY", key_pem, strlen(key_pem), der, sizeof der, &der_len) == 0
+                   && ed25519_parse_pkcs8(der, der_len, got_seed) == 0
+                   && memcmp(got_seed, seed, 32) == 0);
+    }
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -250,6 +334,7 @@ int main(void) {
     test_der_rejects_malformed();
     test_der_tag_enforcement();
     test_pem_decode();
+    test_ed25519_key();
 
     if (g_failures == 0) {
         printf("All TLS parse tests passed.\n");


### PR DESCRIPTION
## Summary

**The final piece of TLS Phase 2 (certificate/key loading).** `src/tls/ed25519_key.{c,h}` extracts the raw 32-byte Ed25519 seed / public key from the two DER structures a server loads, using the bounds-checked DER reader (#106):

- **`ed25519_parse_pkcs8()`** — PKCS#8 `OneAsymmetricKey` (RFC 5958 / RFC 8410 §7): `SEQUENCE{ INTEGER version(0|1), AlgId{ OID 1.3.101.112 }, OCTET STRING{ OCTET STRING(32) } }` → seed.
- **`ed25519_parse_spki()`** — `SubjectPublicKeyInfo` (RFC 8410 §4): `SEQUENCE{ AlgId{ OID 1.3.101.112 }, BIT STRING(0x00 ‖ 32) }` → public key.

Both validate the Ed25519 OID (`1.3.101.112` = `2B 65 70`) and the exact key lengths before copying any bytes; malformed input is a clean `-1`.

## Test vectors — cross-checked with OpenSSL

The vectors are the RFC 8032 **TEST2 keypair** (seed `4ccd…`, pub `3d40…`) wrapped in the standard DER templates. **OpenSSL 3.6 parses the same bytes as valid Ed25519 keys and derives the identical public key from the seed** — so the DER layout and the seed→pubkey relationship are both independently confirmed.

Tests (`TlsParseTests`, +10 → **39**):
- `PKCS#8 → seed`; `SPKI → pubkey`.
- The extracted seed derives the expected pubkey (ties in `ed25519_public_key`), and the PKCS#8-derived key equals the SPKI key.
- **End-to-end server flow:** a PEM `PRIVATE KEY` → `pem_decode` → `ed25519_parse_pkcs8` → seed.
- Rejections: wrong OID, truncated PKCS#8, truncated SPKI, garbage, NULL args.

## Verification

| Build | Result |
|---|---|
| Default (TLS **OFF**) | byte-identical; no key-parse symbols; **ctest 6/6** |
| TLS (`WEBLIB_ENABLE_TLS=ON`) | 0 warnings; **ctest 9/9** |
| TLS + ASan/UBSan (`halt_on_error=1`) | clean |

**Negative control:** disabling the Ed25519 OID match fails the wrong-OID rejection test, confirming it binds.

## Phase 2 complete 🎉
With DER (#106) + base64 (#107) + PEM (#108) + this, a server can load an Ed25519 **private key and certificate end to end**. Next: **Phase 3** — the transport seam (`conn_read`/`conn_write`), the TLS 1.3 record layer, and the handshake state machine (where the crypto + key schedule + X25519 low-order check all come together).

**Note (scope):** this extracts a *bare* SPKI's key; navigating a full X.509 certificate to its SPKI (for a key/cert consistency check) is deferred to the handshake work, where the server otherwise transmits the certificate DER as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)