### PR TITLE
TLS Phase 3: key schedule (RFC 8446 §7.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/poly1305.c
     src/tls/chacha20poly1305.c
     src/tls/hkdf.c
+    src/tls/key_schedule.c
     src/tls/field25519.c
     src/tls/x25519.c
     src/tls/sha512.c

--- a/src/tls/key_schedule.c
+++ b/src/tls/key_schedule.c
@@ -14,6 +14,7 @@
 
 #include "hkdf.h"
 #include "crypto/sha256.h"
+#include "kamran.k"       /* secure_zero */
 #include <string.h>
 
 void tls13_extract(const uint8_t *salt, size_t salt_len,
@@ -29,18 +30,24 @@ void tls13_empty_transcript_hash(uint8_t out[TLS13_SECRET_LEN]) {
 int tls13_derive_secret(const uint8_t secret[TLS13_SECRET_LEN], const char *label,
                         const uint8_t transcript_hash[TLS13_SECRET_LEN],
                         uint8_t out[TLS13_SECRET_LEN]) {
-    return hkdf_expand_label(secret, label, strlen(label),
-                             transcript_hash, TLS13_SECRET_LEN,
-                             out, TLS13_SECRET_LEN);
+    if (!hkdf_expand_label(secret, label, strlen(label),
+                           transcript_hash, TLS13_SECRET_LEN,
+                           out, TLS13_SECRET_LEN)) {
+        secure_zero(out, TLS13_SECRET_LEN);   /* no partial secret on failure */
+        return 0;
+    }
+    return 1;
 }
 
 int tls13_traffic_keys(const uint8_t secret[TLS13_SECRET_LEN],
                        uint8_t *key, size_t key_len,
                        uint8_t iv[TLS13_IV_LEN]) {
-    if (!hkdf_expand_label(secret, "key", 3, NULL, 0, key, key_len)) {
-        return 0;
-    }
-    if (!hkdf_expand_label(secret, "iv", 2, NULL, 0, iv, TLS13_IV_LEN)) {
+    if (!hkdf_expand_label(secret, "key", 3, NULL, 0, key, key_len) ||
+        !hkdf_expand_label(secret, "iv", 2, NULL, 0, iv, TLS13_IV_LEN)) {
+        /* Never leave a partially-derived key/IV in the caller's buffers: if the
+         * IV step fails after the key was written, both are zeroed. */
+        secure_zero(key, key_len);
+        secure_zero(iv, TLS13_IV_LEN);
         return 0;
     }
     return 1;
@@ -48,7 +55,11 @@ int tls13_traffic_keys(const uint8_t secret[TLS13_SECRET_LEN],
 
 int tls13_finished_key(const uint8_t base_key[TLS13_SECRET_LEN],
                        uint8_t out[TLS13_SECRET_LEN]) {
-    return hkdf_expand_label(base_key, "finished", 8, NULL, 0, out, TLS13_SECRET_LEN);
+    if (!hkdf_expand_label(base_key, "finished", 8, NULL, 0, out, TLS13_SECRET_LEN)) {
+        secure_zero(out, TLS13_SECRET_LEN);
+        return 0;
+    }
+    return 1;
 }
 
 #endif /* WEBLIB_TLS */

--- a/src/tls/key_schedule.c
+++ b/src/tls/key_schedule.c
@@ -1,0 +1,54 @@
+/*
+ * key_schedule.c — TLS 1.3 key schedule (RFC 8446 §7.1). EXPERIMENTAL / UNAUDITED.
+ * See key_schedule.h.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. Thin, stateless composition of the
+ * already-verified HKDF-SHA256 primitives (hkdf.c, whose HKDF-Expand-Label
+ * encoding is pinned to the RFC 8448 trace) into the specific extract /
+ * derive-secret / traffic-key operations RFC 8446 defines. Verified against the
+ * RFC 8448 key-schedule trace in tests/test_tls_crypto.c.
+ */
+#include "key_schedule.h"
+
+#ifdef WEBLIB_TLS
+
+#include "hkdf.h"
+#include "crypto/sha256.h"
+#include <string.h>
+
+void tls13_extract(const uint8_t *salt, size_t salt_len,
+                   const uint8_t *ikm, size_t ikm_len,
+                   uint8_t prk[TLS13_SECRET_LEN]) {
+    hkdf_extract(salt, salt_len, ikm, ikm_len, prk);
+}
+
+void tls13_empty_transcript_hash(uint8_t out[TLS13_SECRET_LEN]) {
+    sha256((const uint8_t *)"", 0, out);
+}
+
+int tls13_derive_secret(const uint8_t secret[TLS13_SECRET_LEN], const char *label,
+                        const uint8_t transcript_hash[TLS13_SECRET_LEN],
+                        uint8_t out[TLS13_SECRET_LEN]) {
+    return hkdf_expand_label(secret, label, strlen(label),
+                             transcript_hash, TLS13_SECRET_LEN,
+                             out, TLS13_SECRET_LEN);
+}
+
+int tls13_traffic_keys(const uint8_t secret[TLS13_SECRET_LEN],
+                       uint8_t *key, size_t key_len,
+                       uint8_t iv[TLS13_IV_LEN]) {
+    if (!hkdf_expand_label(secret, "key", 3, NULL, 0, key, key_len)) {
+        return 0;
+    }
+    if (!hkdf_expand_label(secret, "iv", 2, NULL, 0, iv, TLS13_IV_LEN)) {
+        return 0;
+    }
+    return 1;
+}
+
+int tls13_finished_key(const uint8_t base_key[TLS13_SECRET_LEN],
+                       uint8_t out[TLS13_SECRET_LEN]) {
+    return hkdf_expand_label(base_key, "finished", 8, NULL, 0, out, TLS13_SECRET_LEN);
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/key_schedule.h
+++ b/src/tls/key_schedule.h
@@ -1,0 +1,65 @@
+/*
+ * key_schedule.h — TLS 1.3 key schedule (RFC 8446 §7.1). EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON. The primitives the handshake composes to derive every
+ * secret and traffic key from the (EC)DHE shared secret and the running
+ * transcript hash: HKDF-Extract, Derive-Secret, and the "key"/"iv"/"finished"
+ * expansions — all over HKDF-SHA256 (hkdf.h) and SHA-256 (crypto/sha256.h).
+ *
+ * The transcript management and the ordering of the derivation chain belong to
+ * the handshake state machine; this module is the stateless key-schedule math,
+ * verified against the RFC 8448 trace in tests/test_tls_crypto.c.
+ */
+#ifndef WEBLIB_TLS_KEY_SCHEDULE_H
+#define WEBLIB_TLS_KEY_SCHEDULE_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define TLS13_SECRET_LEN 32   /* SHA-256 output = the key schedule's secret size */
+#define TLS13_IV_LEN     12   /* AEAD record nonce length (RFC 8446 §5.3) */
+
+/*
+ * HKDF-Extract (RFC 5869 §2.2) as used at each level of the schedule:
+ * PRK = HMAC-SHA256(salt, ikm). Pass salt NULL / salt_len 0 for the all-zero
+ * salt (the "no PSK" Early Secret uses a zero salt and a zero IKM).
+ */
+void tls13_extract(const uint8_t *salt, size_t salt_len,
+                   const uint8_t *ikm, size_t ikm_len,
+                   uint8_t prk[TLS13_SECRET_LEN]);
+
+/* SHA-256 of the empty transcript — the context for Derive-Secret(., ., ""). */
+void tls13_empty_transcript_hash(uint8_t out[TLS13_SECRET_LEN]);
+
+/*
+ * Derive-Secret(secret, label, transcript_hash) (RFC 8446 §7.1) =
+ * HKDF-Expand-Label(secret, label, transcript_hash, 32). `transcript_hash` is the
+ * 32-byte hash of the handshake messages named by the label (or the empty-string
+ * hash for the "derived" steps). Returns 1 on success, 0 on failure.
+ */
+int tls13_derive_secret(const uint8_t secret[TLS13_SECRET_LEN], const char *label,
+                        const uint8_t transcript_hash[TLS13_SECRET_LEN],
+                        uint8_t out[TLS13_SECRET_LEN]);
+
+/*
+ * Per-connection traffic key and IV from a *_traffic_secret (RFC 8446 §7.3):
+ *   key = HKDF-Expand-Label(secret, "key", "", key_len)   (32 for ChaCha20)
+ *   iv  = HKDF-Expand-Label(secret, "iv",  "", 12)
+ * Returns 1 on success, 0 on failure.
+ */
+int tls13_traffic_keys(const uint8_t secret[TLS13_SECRET_LEN],
+                       uint8_t *key, size_t key_len,
+                       uint8_t iv[TLS13_IV_LEN]);
+
+/*
+ * Finished-message MAC key = HKDF-Expand-Label(base_key, "finished", "", 32),
+ * where base_key is a handshake traffic secret (RFC 8446 §4.4.4). Returns 1/0.
+ */
+int tls13_finished_key(const uint8_t base_key[TLS13_SECRET_LEN],
+                       uint8_t out[TLS13_SECRET_LEN]);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_KEY_SCHEDULE_H */

--- a/src/tls/key_schedule.h
+++ b/src/tls/key_schedule.h
@@ -48,7 +48,8 @@ int tls13_derive_secret(const uint8_t secret[TLS13_SECRET_LEN], const char *labe
  * Per-connection traffic key and IV from a *_traffic_secret (RFC 8446 §7.3):
  *   key = HKDF-Expand-Label(secret, "key", "", key_len)   (32 for ChaCha20)
  *   iv  = HKDF-Expand-Label(secret, "iv",  "", 12)
- * Returns 1 on success, 0 on failure.
+ * Returns 1 on success, 0 on failure. On failure both `key` and `iv` are zeroed,
+ * so a partially-derived key is never left in the caller's buffers.
  */
 int tls13_traffic_keys(const uint8_t secret[TLS13_SECRET_LEN],
                        uint8_t *key, size_t key_len,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,9 @@ if(NOT EMSCRIPTEN)
 
         # TLS crypto primitive known-answer tests (ChaCha20, ... each vs its RFC vector)
         add_executable(test_tls_crypto test_tls_crypto.c)
-        target_include_directories(test_tls_crypto PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls)
+        target_include_directories(test_tls_crypto PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src)
         target_compile_definitions(test_tls_crypto PRIVATE WEBLIB_TLS)
         target_link_libraries(test_tls_crypto weblib ${PLATFORM_LIBS})
         add_test(NAME TlsCryptoTests COMMAND test_tls_crypto)

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -17,6 +17,8 @@
 #include "x25519.h"
 #include "sha512.h"
 #include "ed25519.h"
+#include "key_schedule.h"
+#include "crypto/sha256.h"
 #endif
 
 static int g_failures = 0;
@@ -596,6 +598,73 @@ static void test_ed25519(void) {
                    ed25519_verify(got_sig, NULL, 5, pk) == 0);
     }
 }
+
+/* RFC 8446 §7.1 key schedule. early_secret and derived are the authoritative
+ * RFC 8448 trace anchors; the rest of the chain is exercised with a fixed ECDHE
+ * (the RFC 7748 §6.1 shared secret) and synthetic transcript hashes (SHA-256 of
+ * marker strings — the key-schedule math is independent of the transcript's
+ * content), all cross-checked against an independent HKDF-SHA256 reference. */
+static void test_key_schedule(void) {
+    uint8_t zero[32] = {0};
+    uint8_t early[32], empty_hash[32], derived[32], ecdhe[32], hs[32];
+    uint8_t th_ch_sh[32], c_hs[32], s_hs[32], derived_hs[32], master[32];
+    uint8_t th_ch_sf[32], s_ap[32];
+    uint8_t key[32], iv[12], fin[32];
+    const char *m_ch_sh = "ClientHello||ServerHello";
+    const char *m_ch_sf = "ClientHello..server Finished";
+
+    /* Early Secret = HKDF-Extract(0, 0). */
+    tls13_extract(zero, 32, zero, 32, early);
+    check_hex("ks early_secret (RFC 8448)", early, 32,
+              "33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a");
+
+    /* derived = Derive-Secret(Early, "derived", ""). */
+    tls13_empty_transcript_hash(empty_hash);
+    check_hex("ks empty transcript hash", empty_hash, 32,
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    check_true("ks derive_secret(derived) ok",
+               tls13_derive_secret(early, "derived", empty_hash, derived) == 1);
+    check_hex("ks derived (RFC 8448)", derived, 32,
+              "6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba");
+
+    /* Handshake Secret = HKDF-Extract(derived, ECDHE). */
+    from_hex("4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742", ecdhe, 32);
+    tls13_extract(derived, 32, ecdhe, 32, hs);
+    check_hex("ks handshake_secret", hs, 32,
+              "e4e520f8ca639e6562121a8d006bbce3e012f049744806f283e99c54cab713f3");
+
+    /* Handshake traffic secrets over the ClientHello..ServerHello transcript. */
+    sha256((const uint8_t *)m_ch_sh, strlen(m_ch_sh), th_ch_sh);
+    tls13_derive_secret(hs, "c hs traffic", th_ch_sh, c_hs);
+    check_hex("ks c_hs_traffic", c_hs, 32,
+              "cb24193a3801afad533babae440f2c5ea5d4a0a667c7811d45ec9b89441facaf");
+    tls13_derive_secret(hs, "s hs traffic", th_ch_sh, s_hs);
+    check_hex("ks s_hs_traffic", s_hs, 32,
+              "6186d5e4a6913a51e3d93c674e957c47ab3a8e06ae6f1568f9a53ab0072430ba");
+
+    /* Master Secret = HKDF-Extract(Derive-Secret(HS, "derived", ""), 0). */
+    tls13_derive_secret(hs, "derived", empty_hash, derived_hs);
+    check_hex("ks derived_hs", derived_hs, 32,
+              "b47c8bd24c77a2a9fbf501b9b592afa8fe7c248b16b6db86f209f47aa2de64d4");
+    tls13_extract(derived_hs, 32, zero, 32, master);
+    check_hex("ks master_secret", master, 32,
+              "34f6eb660fafe5471a480c287f29ec6f688153423a8c35ad4c15e072c576875a");
+
+    /* Application traffic secret over the ClientHello..server Finished transcript. */
+    sha256((const uint8_t *)m_ch_sf, strlen(m_ch_sf), th_ch_sf);
+    tls13_derive_secret(master, "s ap traffic", th_ch_sf, s_ap);
+    check_hex("ks s_ap_traffic", s_ap, 32,
+              "345773668b61ec576ebf34546f30121824a5c01da76ca6277bbaefd28a3ab9b1");
+
+    /* Traffic key/IV (ChaCha20: 32/12) + Finished key from s_hs_traffic. */
+    check_true("ks traffic_keys ok", tls13_traffic_keys(s_hs, key, 32, iv) == 1);
+    check_hex("ks s_hs write_key", key, 32,
+              "65b1acab64981f4a389f7cbb61960e188cba36c394347b6f2dec27815679627e");
+    check_hex("ks s_hs write_iv", iv, 12, "49a58cdfb9fb269bfc6d10a7");
+    check_true("ks finished_key ok", tls13_finished_key(s_hs, fin) == 1);
+    check_hex("ks s_hs finished_key", fin, 32,
+              "3517ba1c0647b82fe6db82add2ed8314b1ea4acb2c821f1dbcc1ffd557a975f6");
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -611,6 +680,7 @@ int main(void) {
     test_sha512();
     test_x25519();
     test_ed25519();
+    test_key_schedule();
 
     if (g_failures == 0) {
         printf("All TLS crypto KATs passed.\n");

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -599,6 +599,19 @@ static void test_ed25519(void) {
     }
 }
 
+/* Derive-Secret then compare, failing clearly if the derivation itself returns 0
+ * (rather than comparing an uninitialized buffer). */
+static void check_derive(const char *name, const uint8_t secret[32], const char *label,
+                         const uint8_t transcript_hash[32], uint8_t out[32],
+                         const char *expected_hex) {
+    if (tls13_derive_secret(secret, label, transcript_hash, out) != 1) {
+        printf("FAIL: %s (tls13_derive_secret returned 0)\n", name);
+        g_failures++;
+        return;
+    }
+    check_hex(name, out, 32, expected_hex);
+}
+
 /* RFC 8446 §7.1 key schedule. early_secret and derived are the authoritative
  * RFC 8448 trace anchors; the rest of the chain is exercised with a fixed ECDHE
  * (the RFC 7748 §6.1 shared secret) and synthetic transcript hashes (SHA-256 of
@@ -622,10 +635,8 @@ static void test_key_schedule(void) {
     tls13_empty_transcript_hash(empty_hash);
     check_hex("ks empty transcript hash", empty_hash, 32,
               "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-    check_true("ks derive_secret(derived) ok",
-               tls13_derive_secret(early, "derived", empty_hash, derived) == 1);
-    check_hex("ks derived (RFC 8448)", derived, 32,
-              "6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba");
+    check_derive("ks derived (RFC 8448)", early, "derived", empty_hash, derived,
+                 "6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba");
 
     /* Handshake Secret = HKDF-Extract(derived, ECDHE). */
     from_hex("4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742", ecdhe, 32);
@@ -635,26 +646,22 @@ static void test_key_schedule(void) {
 
     /* Handshake traffic secrets over the ClientHello..ServerHello transcript. */
     sha256((const uint8_t *)m_ch_sh, strlen(m_ch_sh), th_ch_sh);
-    tls13_derive_secret(hs, "c hs traffic", th_ch_sh, c_hs);
-    check_hex("ks c_hs_traffic", c_hs, 32,
-              "cb24193a3801afad533babae440f2c5ea5d4a0a667c7811d45ec9b89441facaf");
-    tls13_derive_secret(hs, "s hs traffic", th_ch_sh, s_hs);
-    check_hex("ks s_hs_traffic", s_hs, 32,
-              "6186d5e4a6913a51e3d93c674e957c47ab3a8e06ae6f1568f9a53ab0072430ba");
+    check_derive("ks c_hs_traffic", hs, "c hs traffic", th_ch_sh, c_hs,
+                 "cb24193a3801afad533babae440f2c5ea5d4a0a667c7811d45ec9b89441facaf");
+    check_derive("ks s_hs_traffic", hs, "s hs traffic", th_ch_sh, s_hs,
+                 "6186d5e4a6913a51e3d93c674e957c47ab3a8e06ae6f1568f9a53ab0072430ba");
 
     /* Master Secret = HKDF-Extract(Derive-Secret(HS, "derived", ""), 0). */
-    tls13_derive_secret(hs, "derived", empty_hash, derived_hs);
-    check_hex("ks derived_hs", derived_hs, 32,
-              "b47c8bd24c77a2a9fbf501b9b592afa8fe7c248b16b6db86f209f47aa2de64d4");
+    check_derive("ks derived_hs", hs, "derived", empty_hash, derived_hs,
+                 "b47c8bd24c77a2a9fbf501b9b592afa8fe7c248b16b6db86f209f47aa2de64d4");
     tls13_extract(derived_hs, 32, zero, 32, master);
     check_hex("ks master_secret", master, 32,
               "34f6eb660fafe5471a480c287f29ec6f688153423a8c35ad4c15e072c576875a");
 
     /* Application traffic secret over the ClientHello..server Finished transcript. */
     sha256((const uint8_t *)m_ch_sf, strlen(m_ch_sf), th_ch_sf);
-    tls13_derive_secret(master, "s ap traffic", th_ch_sf, s_ap);
-    check_hex("ks s_ap_traffic", s_ap, 32,
-              "345773668b61ec576ebf34546f30121824a5c01da76ca6277bbaefd28a3ab9b1");
+    check_derive("ks s_ap_traffic", master, "s ap traffic", th_ch_sf, s_ap,
+                 "345773668b61ec576ebf34546f30121824a5c01da76ca6277bbaefd28a3ab9b1");
 
     /* Traffic key/IV (ChaCha20: 32/12) + Finished key from s_hs_traffic. */
     check_true("ks traffic_keys ok", tls13_traffic_keys(s_hs, key, 32, iv) == 1);


### PR DESCRIPTION
## Summary

**First module of Phase 3** — assembling the finished crypto into a live TLS 1.3 connection begins with the **key schedule**, which derives every secret and traffic key. `src/tls/key_schedule.{c,h}` is the stateless key-schedule math, composing the already-verified HKDF-SHA256 primitives (whose `HKDF-Expand-Label` encoding was pinned to the RFC 8448 trace back in #101):

| Function | RFC 8446 role |
|---|---|
| `tls13_extract()` | HKDF-Extract at each level (zero salt supported) |
| `tls13_empty_transcript_hash()` | `SHA-256("")` — the Derive-Secret `""` context |
| `tls13_derive_secret()` | `Derive-Secret = HKDF-Expand-Label(., ., hash, 32)` |
| `tls13_traffic_keys()` | `write_key` (`"key"`) + `write_iv` (`"iv"`) — 32/12 for ChaCha20 |
| `tls13_finished_key()` | Finished MAC key (`"finished"`) |

Transcript management and the ordering of the derivation chain belong to the (later) handshake state machine; this PR is the reusable math.

## KAT — anchored to RFC 8448

`test_tls_crypto.c` (+15 → **65** crypto checks): `early_secret` and `derived` are the **authoritative RFC 8448** values (`early = 33ad0a1c…`, `derived = 6f2615a1…`). The rest of the chain — `handshake_secret`, client/server handshake-traffic secrets, `derived_hs`, `master_secret`, server application-traffic secret, plus `write_key`/`write_iv` and `finished_key` — is exercised with a fixed ECDHE (RFC 7748 §6.1 shared secret) and synthetic transcript hashes, **cross-checked against an independent HKDF-SHA256 reference that itself reproduces the RFC 8448 early/derived anchors**.

## Verification

| Build | Result |
|---|---|
| Default (TLS **OFF**) | byte-identical; no `tls13_` symbols; **ctest 6/6** |
| TLS (`WEBLIB_ENABLE_TLS=ON`) | 0 warnings; **ctest 9/9** |
| TLS + ASan/UBSan (`halt_on_error=1`) | clean |

**Negative control:** truncating the `"key"` label fails *exactly* the `write_key` KAT (while `write_iv` still passes), confirming the derivation binds to the label.

Native-only, gated behind `WEBLIB_ENABLE_TLS` (default **OFF**).

## Next in Phase 3
The record layer (AEAD-protect TLS records), then handshake message parsing/building, then the state machine that wires transcript → key schedule → record keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)