### PR TITLE
TLS Phase 3: record layer (RFC 8446 §5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/chacha20.c
     src/tls/poly1305.c
     src/tls/chacha20poly1305.c
+    src/tls/record.c
     src/tls/hkdf.c
     src/tls/key_schedule.c
     src/tls/field25519.c

--- a/src/tls/record.c
+++ b/src/tls/record.c
@@ -1,0 +1,162 @@
+/*
+ * record.c — TLS 1.3 record protection (RFC 8446 §5). EXPERIMENTAL / UNAUDITED.
+ * See record.h.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. Thin framing over the verified
+ * ChaCha20-Poly1305 AEAD: the novel logic here is the per-record nonce (§5.3),
+ * the additional-data header (§5.2), the TLSInnerPlaintext construction and its
+ * constant-time de-padding (§5.4). The AEAD itself never releases plaintext on an
+ * authentication failure. Verified against an independent record reference.
+ */
+#include "record.h"
+
+#ifdef WEBLIB_TLS
+
+#include "chacha20poly1305.h"
+#include "kamran.k"       /* secure_zero */
+#include <string.h>
+
+/* Per-record nonce (RFC 8446 §5.3): the 64-bit sequence number, left-padded with
+ * four zero bytes to the IV length, XORed with the static write_iv. */
+static void record_nonce(const uint8_t iv[TLS_RECORD_IV_LEN], uint64_t seq,
+                         uint8_t nonce[TLS_RECORD_IV_LEN]) {
+    uint8_t seq_be[TLS_RECORD_IV_LEN];
+    int i;
+    memset(seq_be, 0, 4);
+    for (i = 0; i < 8; i++) {
+        seq_be[4 + i] = (uint8_t)(seq >> (56 - 8 * i));
+    }
+    for (i = 0; i < TLS_RECORD_IV_LEN; i++) {
+        nonce[i] = iv[i] ^ seq_be[i];
+    }
+}
+
+int tls_record_seal(const uint8_t key[TLS_RECORD_KEY_LEN],
+                    const uint8_t iv[TLS_RECORD_IV_LEN], uint64_t seq,
+                    uint8_t content_type, const uint8_t *content, size_t content_len,
+                    size_t padding_len, uint8_t *out, size_t out_cap, size_t *out_len) {
+    uint8_t nonce[TLS_RECORD_IV_LEN];
+    size_t inner_len, enc_len, total;
+
+    if (key == NULL || iv == NULL || out == NULL || out_len == NULL) {
+        return 0;
+    }
+    if (content == NULL && content_len != 0) {
+        return 0;
+    }
+    /* Bound each length so the additions below cannot overflow, then enforce the
+     * RFC 8446 §5.2 ciphertext-size limit. */
+    if (content_len > TLS_RECORD_MAX_CIPHERTEXT || padding_len > TLS_RECORD_MAX_CIPHERTEXT) {
+        return 0;
+    }
+    inner_len = content_len + 1 + padding_len;         /* content || type || zeros */
+    enc_len = inner_len + TLS_RECORD_TAG_LEN;
+    if (enc_len > TLS_RECORD_MAX_CIPHERTEXT) {
+        return 0;
+    }
+    total = TLS_RECORD_HEADER_LEN + enc_len;
+    if (total > out_cap) {
+        return 0;
+    }
+
+    /* Record header, which is also the AEAD additional data:
+     * opaque_type(23) || legacy_record_version(0x0303) || length. */
+    out[0] = 0x17;
+    out[1] = 0x03;
+    out[2] = 0x03;
+    out[3] = (uint8_t)(enc_len >> 8);
+    out[4] = (uint8_t)(enc_len & 0xff);
+
+    /* Build TLSInnerPlaintext in place where the ciphertext will go, then seal it
+     * in place (the AEAD's ChaCha20 layer supports pt == ct). */
+    if (content_len) {
+        memcpy(out + TLS_RECORD_HEADER_LEN, content, content_len);
+    }
+    out[TLS_RECORD_HEADER_LEN + content_len] = content_type;
+    if (padding_len) {
+        memset(out + TLS_RECORD_HEADER_LEN + content_len + 1, 0, padding_len);
+    }
+
+    record_nonce(iv, seq, nonce);
+    if (!chacha20poly1305_seal(key, nonce, out, TLS_RECORD_HEADER_LEN,
+                               out + TLS_RECORD_HEADER_LEN, inner_len,
+                               out + TLS_RECORD_HEADER_LEN,
+                               out + TLS_RECORD_HEADER_LEN + inner_len)) {
+        secure_zero(out, total);           /* leave no partial plaintext/ciphertext */
+        secure_zero(nonce, sizeof nonce);
+        return 0;
+    }
+    secure_zero(nonce, sizeof nonce);
+    *out_len = total;
+    return 1;
+}
+
+int tls_record_open(const uint8_t key[TLS_RECORD_KEY_LEN],
+                    const uint8_t iv[TLS_RECORD_IV_LEN], uint64_t seq,
+                    const uint8_t *record, size_t record_len,
+                    uint8_t *out, size_t out_cap,
+                    size_t *content_len, uint8_t *content_type) {
+    uint8_t nonce[TLS_RECORD_IV_LEN];
+    size_t enc_len, inner_len, i, type_pos;
+
+    if (key == NULL || iv == NULL || record == NULL || out == NULL ||
+        content_len == NULL || content_type == NULL) {
+        return 0;
+    }
+    /* A record is a 5-byte header plus an encrypted_record that holds at least the
+     * 16-byte tag. */
+    if (record_len < TLS_RECORD_HEADER_LEN + TLS_RECORD_TAG_LEN) {
+        return 0;
+    }
+    enc_len = record_len - TLS_RECORD_HEADER_LEN;
+    /* Header: opaque_type(23), legacy_record_version(0x0303), and a length that
+     * matches the actual encrypted_record. */
+    if (record[0] != 0x17 || record[1] != 0x03 || record[2] != 0x03) {
+        return 0;
+    }
+    if ((((size_t)record[3] << 8) | record[4]) != enc_len) {
+        return 0;
+    }
+    if (enc_len > TLS_RECORD_MAX_CIPHERTEXT) {
+        return 0;
+    }
+
+    inner_len = enc_len - TLS_RECORD_TAG_LEN;
+    if (inner_len > out_cap) {
+        return 0;                          /* need room for the whole inner plaintext */
+    }
+
+    record_nonce(iv, seq, nonce);
+    /* Authenticate over header || ciphertext and, only if authentic, decrypt into
+     * `out`. The AEAD releases no plaintext when the tag does not verify. */
+    if (!chacha20poly1305_open(key, nonce, record, TLS_RECORD_HEADER_LEN,
+                               record + TLS_RECORD_HEADER_LEN, inner_len,
+                               record + TLS_RECORD_HEADER_LEN + inner_len, out)) {
+        secure_zero(nonce, sizeof nonce);
+        return 0;
+    }
+    secure_zero(nonce, sizeof nonce);
+
+    /* De-pad (RFC 8446 §5.4): the ContentType is the last non-zero octet. Scan all
+     * bytes without an early exit so the timing does not reveal the padding
+     * length. type_pos ends as the 1-based index of the last non-zero byte, 0 if
+     * the inner plaintext is entirely zero. */
+    type_pos = 0;
+    for (i = 0; i < inner_len; i++) {
+        uint8_t b = out[i];
+        /* nz = 1 if b != 0, else 0 (branchless). */
+        size_t nz = (size_t)((b | (uint8_t)(0u - b)) >> 7);
+        size_t mask = (size_t)0 - nz;      /* all ones if nz, else 0 */
+        type_pos = (type_pos & ~mask) | ((i + 1) & mask);
+    }
+    if (type_pos == 0) {
+        secure_zero(out, inner_len);       /* all-zero inner: no ContentType */
+        return 0;
+    }
+
+    *content_type = out[type_pos - 1];
+    *content_len = type_pos - 1;           /* content precedes the type byte, in place */
+    return 1;
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/record.c
+++ b/src/tls/record.c
@@ -31,6 +31,15 @@ static void record_nonce(const uint8_t iv[TLS_RECORD_IV_LEN], uint64_t seq,
     }
 }
 
+/* The inner ContentType of a TLS 1.3 protected record is alert, handshake, or
+ * application_data. change_cipher_spec is only ever an unprotected record, and
+ * other values are invalid — reject them either way. */
+static int is_valid_inner_type(uint8_t t) {
+    return t == TLS_CONTENT_ALERT ||
+           t == TLS_CONTENT_HANDSHAKE ||
+           t == TLS_CONTENT_APPLICATION_DATA;
+}
+
 int tls_record_seal(const uint8_t key[TLS_RECORD_KEY_LEN],
                     const uint8_t iv[TLS_RECORD_IV_LEN], uint64_t seq,
                     uint8_t content_type, const uint8_t *content, size_t content_len,
@@ -44,9 +53,12 @@ int tls_record_seal(const uint8_t key[TLS_RECORD_KEY_LEN],
     if (content == NULL && content_len != 0) {
         return 0;
     }
-    /* Bound each length so the additions below cannot overflow, then enforce the
-     * RFC 8446 §5.2 ciphertext-size limit. */
-    if (content_len > TLS_RECORD_MAX_CIPHERTEXT || padding_len > TLS_RECORD_MAX_CIPHERTEXT) {
+    if (!is_valid_inner_type(content_type)) {
+        return 0;
+    }
+    /* RFC 8446 §5.1 caps the plaintext content at 2^14; bound padding too so the
+     * additions below cannot overflow, then enforce the §5.2 ciphertext limit. */
+    if (content_len > TLS_RECORD_MAX_PLAINTEXT || padding_len > TLS_RECORD_MAX_CIPHERTEXT) {
         return 0;
     }
     inner_len = content_len + 1 + padding_len;         /* content || type || zeros */
@@ -154,8 +166,18 @@ int tls_record_open(const uint8_t key[TLS_RECORD_KEY_LEN],
         return 0;
     }
 
-    *content_type = out[type_pos - 1];
-    *content_len = type_pos - 1;           /* content precedes the type byte, in place */
+    {
+        uint8_t type = out[type_pos - 1];
+        size_t len = type_pos - 1;         /* content precedes the type byte */
+        /* Reject a malformed inner plaintext: an illegal ContentType or content
+         * exceeding the 2^14 plaintext limit. Outputs are set only on success. */
+        if (!is_valid_inner_type(type) || len > TLS_RECORD_MAX_PLAINTEXT) {
+            secure_zero(out, inner_len);
+            return 0;
+        }
+        *content_type = type;
+        *content_len = len;                /* content is in place at out[0..len) */
+    }
     return 1;
 }
 

--- a/src/tls/record.h
+++ b/src/tls/record.h
@@ -28,6 +28,9 @@
 /* RFC 8446 §5.2: TLSCiphertext.length (the encrypted_record) MUST NOT exceed
  * 2^14 + 256 bytes. */
 #define TLS_RECORD_MAX_CIPHERTEXT (16384 + 256)
+/* RFC 8446 §5.1: TLSPlaintext.content (the inner content, excluding the
+ * ContentType byte and any padding) MUST NOT exceed 2^14 bytes. */
+#define TLS_RECORD_MAX_PLAINTEXT 16384
 
 /* TLS 1.3 inner ContentType values (RFC 8446 §5.1). */
 #define TLS_CONTENT_CHANGE_CIPHER_SPEC 20
@@ -36,12 +39,13 @@
 #define TLS_CONTENT_APPLICATION_DATA   23
 
 /*
- * Seal one record: encrypt `content` (length `content_len`) of inner type
- * `content_type` with `padding_len` trailing zero-padding bytes, writing the full
- * TLSCiphertext (5-byte header + encrypted_record) to `out`. On success returns 1
- * and sets *out_len to the total record size. Returns 0 on a NULL/oversized
- * argument, a record that would exceed the 2^14+256 limit, `out` too small, or an
- * AEAD failure (in which case `out` is zeroed).
+ * Seal one record: encrypt `content` (length `content_len`, at most 2^14) of
+ * inner type `content_type` (alert, handshake, or application_data) with
+ * `padding_len` trailing zero-padding bytes, writing the full TLSCiphertext
+ * (5-byte header + encrypted_record) to `out`. On success returns 1 and sets
+ * *out_len to the total record size. Returns 0 on a NULL argument, an illegal
+ * `content_type`, a content/record that would exceed the 2^14 / 2^14+256 limits,
+ * `out` too small, or an AEAD failure (in which case `out` is zeroed).
  */
 int tls_record_seal(const uint8_t key[TLS_RECORD_KEY_LEN],
                     const uint8_t iv[TLS_RECORD_IV_LEN], uint64_t seq,
@@ -53,8 +57,10 @@ int tls_record_seal(const uint8_t key[TLS_RECORD_KEY_LEN],
  * writing the recovered content to `out`, the inner ContentType to *content_type,
  * and the content length to *content_len. Returns 1 on success, 0 on a malformed
  * header, an AEAD authentication failure (no plaintext is released), an all-zero
- * inner plaintext (no ContentType), or `out` too small. The trailing zero padding
- * is removed in constant time with respect to the padding length (§5.4).
+ * inner plaintext (no ContentType), an illegal recovered ContentType or content
+ * exceeding 2^14, or `out` too small. The trailing zero padding is removed in
+ * constant time with respect to the padding length (§5.4). Outputs are written
+ * only on success.
  */
 int tls_record_open(const uint8_t key[TLS_RECORD_KEY_LEN],
                     const uint8_t iv[TLS_RECORD_IV_LEN], uint64_t seq,

--- a/src/tls/record.h
+++ b/src/tls/record.h
@@ -1,0 +1,66 @@
+/*
+ * record.h — TLS 1.3 record protection (RFC 8446 §5). EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON. Seals and opens a single TLSCiphertext record with the
+ * TLS_CHACHA20_POLY1305_SHA256 AEAD: it constructs the TLSInnerPlaintext
+ * (content || ContentType || zero-padding), the per-record nonce (write_iv XOR
+ * the 64-bit sequence number, §5.3), and the additional data (the 5-byte record
+ * header, §5.2), then calls the verified ChaCha20-Poly1305 AEAD.
+ *
+ * The key schedule (key_schedule.h) provides the write_key/write_iv; the
+ * handshake state machine drives the sequence numbers and content types. Verified
+ * against an independent ChaCha20-Poly1305 record reference in
+ * tests/test_tls_crypto.c.
+ */
+#ifndef WEBLIB_TLS_RECORD_H
+#define WEBLIB_TLS_RECORD_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define TLS_RECORD_HEADER_LEN 5
+#define TLS_RECORD_TAG_LEN    16
+#define TLS_RECORD_IV_LEN     12
+#define TLS_RECORD_KEY_LEN    32   /* ChaCha20-Poly1305 */
+/* RFC 8446 §5.2: TLSCiphertext.length (the encrypted_record) MUST NOT exceed
+ * 2^14 + 256 bytes. */
+#define TLS_RECORD_MAX_CIPHERTEXT (16384 + 256)
+
+/* TLS 1.3 inner ContentType values (RFC 8446 §5.1). */
+#define TLS_CONTENT_CHANGE_CIPHER_SPEC 20
+#define TLS_CONTENT_ALERT              21
+#define TLS_CONTENT_HANDSHAKE          22
+#define TLS_CONTENT_APPLICATION_DATA   23
+
+/*
+ * Seal one record: encrypt `content` (length `content_len`) of inner type
+ * `content_type` with `padding_len` trailing zero-padding bytes, writing the full
+ * TLSCiphertext (5-byte header + encrypted_record) to `out`. On success returns 1
+ * and sets *out_len to the total record size. Returns 0 on a NULL/oversized
+ * argument, a record that would exceed the 2^14+256 limit, `out` too small, or an
+ * AEAD failure (in which case `out` is zeroed).
+ */
+int tls_record_seal(const uint8_t key[TLS_RECORD_KEY_LEN],
+                    const uint8_t iv[TLS_RECORD_IV_LEN], uint64_t seq,
+                    uint8_t content_type, const uint8_t *content, size_t content_len,
+                    size_t padding_len, uint8_t *out, size_t out_cap, size_t *out_len);
+
+/*
+ * Open one record: authenticate and decrypt the full TLSCiphertext in `record`,
+ * writing the recovered content to `out`, the inner ContentType to *content_type,
+ * and the content length to *content_len. Returns 1 on success, 0 on a malformed
+ * header, an AEAD authentication failure (no plaintext is released), an all-zero
+ * inner plaintext (no ContentType), or `out` too small. The trailing zero padding
+ * is removed in constant time with respect to the padding length (§5.4).
+ */
+int tls_record_open(const uint8_t key[TLS_RECORD_KEY_LEN],
+                    const uint8_t iv[TLS_RECORD_IV_LEN], uint64_t seq,
+                    const uint8_t *record, size_t record_len,
+                    uint8_t *out, size_t out_cap,
+                    size_t *content_len, uint8_t *content_type);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_RECORD_H */

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -18,6 +18,7 @@
 #include "sha512.h"
 #include "ed25519.h"
 #include "key_schedule.h"
+#include "record.h"
 #include "crypto/sha256.h"
 #endif
 
@@ -672,6 +673,75 @@ static void test_key_schedule(void) {
     check_hex("ks s_hs finished_key", fin, 32,
               "3517ba1c0647b82fe6db82add2ed8314b1ea4acb2c821f1dbcc1ffd557a975f6");
 }
+
+/* TLS 1.3 record protection (RFC 8446 §5). The sealed wire bytes are compared to
+ * an independent ChaCha20-Poly1305 record reference (itself validated against the
+ * RFC 8439 AEAD vector); the key/iv are a real key-schedule write_key/write_iv. */
+static void test_record(void) {
+    uint8_t key[32], iv[12];
+    uint8_t out[128], dec[128];
+    size_t out_len = 0, clen = 0;
+    uint8_t ctype = 0;
+    const char *c0 = "hello TLS 1.3 record";   /* 20 bytes */
+    const char *c1 = "application data";       /* 16 bytes */
+
+    from_hex("65b1acab64981f4a389f7cbb61960e188cba36c394347b6f2dec27815679627e", key, 32);
+    from_hex("49a58cdfb9fb269bfc6d10a7", iv, 12);
+
+    /* Seal seq 0, handshake, no padding — compare the whole record to the ref. */
+    check_true("record seal(seq0) ok",
+               tls_record_seal(key, iv, 0, TLS_CONTENT_HANDSHAKE,
+                               (const uint8_t *)c0, strlen(c0), 0,
+                               out, sizeof out, &out_len) == 1);
+    check_hex("record seal(seq0) wire (independent ref)", out, out_len,
+              "170303002522aa5fdade138fde8c5edbb5cb002c78c8ed69591ec672af40fc4d2087461f32eaa73adabb");
+    check_true("record open(seq0) round-trips",
+               tls_record_open(key, iv, 0, out, out_len, dec, sizeof dec, &clen, &ctype) == 1
+               && clen == strlen(c0) && ctype == TLS_CONTENT_HANDSHAKE
+               && memcmp(dec, c0, clen) == 0);
+
+    /* Seal seq 1, application_data, 4 padding bytes. */
+    check_true("record seal(seq1, pad4) ok",
+               tls_record_seal(key, iv, 1, TLS_CONTENT_APPLICATION_DATA,
+                               (const uint8_t *)c1, strlen(c1), 4,
+                               out, sizeof out, &out_len) == 1);
+    check_hex("record seal(seq1, pad4) wire (independent ref)", out, out_len,
+              "1703030025c8e36769115bdc08ec7dddf99e500cd6d4d189a16fb15c9a373e7d8ef0f9d7013f9b871449");
+    check_true("record open(seq1) strips padding, recovers type",
+               tls_record_open(key, iv, 1, out, out_len, dec, sizeof dec, &clen, &ctype) == 1
+               && clen == strlen(c1) && ctype == TLS_CONTENT_APPLICATION_DATA
+               && memcmp(dec, c1, clen) == 0);
+
+    /* Tamper a ciphertext byte -> AEAD auth failure, no plaintext released. */
+    out[10] ^= 0x01;
+    check_true("record open rejects tampered ciphertext",
+               tls_record_open(key, iv, 1, out, out_len, dec, sizeof dec, &clen, &ctype) == 0);
+    out[10] ^= 0x01;
+
+    /* Wrong sequence number -> wrong nonce -> auth failure. */
+    check_true("record open rejects wrong sequence number",
+               tls_record_open(key, iv, 2, out, out_len, dec, sizeof dec, &clen, &ctype) == 0);
+
+    /* Malformed records. */
+    check_true("record open rejects too-short record",
+               tls_record_open(key, iv, 1, out, 20, dec, sizeof dec, &clen, &ctype) == 0);
+    {
+        uint8_t bad[128];
+        memcpy(bad, out, out_len);
+        bad[0] = 0x16;   /* opaque_type must be 23 */
+        check_true("record open rejects wrong opaque_type",
+                   tls_record_open(key, iv, 1, bad, out_len, dec, sizeof dec, &clen, &ctype) == 0);
+        memcpy(bad, out, out_len);
+        bad[4] ^= 0x01;  /* header length no longer matches the record */
+        check_true("record open rejects length mismatch",
+                   tls_record_open(key, iv, 1, bad, out_len, dec, sizeof dec, &clen, &ctype) == 0);
+    }
+
+    /* Seal into an undersized buffer is rejected. */
+    check_true("record seal rejects too-small output",
+               tls_record_seal(key, iv, 0, TLS_CONTENT_HANDSHAKE,
+                               (const uint8_t *)c0, strlen(c0), 0, out, 10, &out_len) == 0);
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -688,6 +758,7 @@ int main(void) {
     test_x25519();
     test_ed25519();
     test_key_schedule();
+    test_record();
 
     if (g_failures == 0) {
         printf("All TLS crypto KATs passed.\n");

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -741,6 +741,24 @@ static void test_record(void) {
     check_true("record seal rejects too-small output",
                tls_record_seal(key, iv, 0, TLS_CONTENT_HANDSHAKE,
                                (const uint8_t *)c0, strlen(c0), 0, out, 10, &out_len) == 0);
+
+    /* Illegal inner content types are rejected (only alert/handshake/appdata). */
+    check_true("record seal rejects invalid content type",
+               tls_record_seal(key, iv, 0, 99, (const uint8_t *)c0, strlen(c0), 0,
+                               out, sizeof out, &out_len) == 0);
+    check_true("record seal rejects change_cipher_spec inner type",
+               tls_record_seal(key, iv, 0, TLS_CONTENT_CHANGE_CIPHER_SPEC,
+                               (const uint8_t *)c0, strlen(c0), 0, out, sizeof out, &out_len) == 0);
+
+    /* Content past the 2^14 plaintext limit is rejected. */
+    {
+        static uint8_t big[TLS_RECORD_MAX_PLAINTEXT + 1];
+        static uint8_t bigout[TLS_RECORD_MAX_PLAINTEXT + 64];
+        memset(big, 0x41, sizeof big);
+        check_true("record seal rejects content over 2^14",
+                   tls_record_seal(key, iv, 0, TLS_CONTENT_APPLICATION_DATA,
+                                   big, sizeof big, 0, bigout, sizeof bigout, &out_len) == 0);
+    }
 }
 #endif /* WEBLIB_TLS */
 


### PR DESCRIPTION
## Summary

The Phase 3 **record layer**: `src/tls/record.{c,h}` seals and opens a single TLSCiphertext with `TLS_CHACHA20_POLY1305_SHA256`, on top of the verified AEAD (#100) and driven by the key schedule's write_key/write_iv (#110).

Framing (RFC 8446 §5):
- **per-record nonce** = `write_iv XOR (seq as a 96-bit big-endian int)` (§5.3)
- **additional data** = the 5-byte record header (`opaque_type 23 ‖ 0x0303 ‖ length`) (§5.2)
- **TLSInnerPlaintext** = `content ‖ ContentType ‖ zero-padding` (§5.4)
- built **in place** in the output buffer and sealed in place (the AEAD's ChaCha20 layer supports `pt == ct`), so **no per-record allocation**

`open()` authenticates over `header ‖ ciphertext` and decrypts only if authentic (the AEAD releases no plaintext on tag failure), then strips the trailing zero padding **in constant time** with respect to the padding length (§5.4) to recover the ContentType. It enforces the §5.2 `2^14+256` ciphertext limit, exact header/length agreement, and `size_t`-overflow-safe length math; the nonce (and, on a seal failure, the output) is wiped.

## KAT — cross-checked against an independent reference

`test_tls_crypto.c` (+12 → **76** checks): the sealed **wire bytes** for two records (handshake, seq 0, no padding; application_data, seq 1, 4 padding bytes) match an **independent ChaCha20-Poly1305 record reference** — itself validated against the RFC 8439 §2.8.2 AEAD vector — using a real key-schedule `write_key`/`write_iv`. Plus round-trip (padding stripped, type recovered) and rejection of: tampered ciphertext, wrong sequence number, too-short record, wrong `opaque_type`, header length mismatch, and undersized output.

## Verification

| Build | Result |
|---|---|
| Default (TLS **OFF**) | byte-identical; no `record` symbols; **ctest 6/6** |
| TLS (`WEBLIB_ENABLE_TLS=ON`) | 0 warnings; **ctest 9/9** |
| TLS + ASan/UBSan (`halt_on_error=1`) | clean |

**Negative control:** dropping the sequence number from the nonce fails *exactly* the seq-dependent KATs (the seq-1 wire vector and the wrong-sequence rejection), while seq-0 is unaffected (its nonce equals the IV) — confirming the seq→nonce binding.

Native-only, gated behind `WEBLIB_ENABLE_TLS` (default **OFF**).

## Next in Phase 3
Handshake message parsing/building (ClientHello/ServerHello/…/Finished + extensions), then the state machine that wires transcript → key schedule → record keys into a live handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)