### PR TITLE
TLS Phase 3: bounded wire codec (RFC 8446 §3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ option(WEBLIB_ENABLE_TLS "Build the experimental pure-C TLS 1.3 layer (native-on
 set(WEBLIB_SOURCES_TLS
     src/tls/tls.c
     src/tls/der.c
+    src/tls/wire.c
     src/tls/pem.c
     src/tls/chacha20.c
     src/tls/poly1305.c

--- a/src/tls/wire.c
+++ b/src/tls/wire.c
@@ -16,7 +16,7 @@
 
 /* ---- reader ------------------------------------------------------------ */
 
-void tls_reader_init(tls_reader *r, const uint8_t *data, size_t len) {
+void tls_reader_init(tls_reader_t *r, const uint8_t *data, size_t len) {
     if (data == NULL) {
         len = 0;
     }
@@ -24,15 +24,15 @@ void tls_reader_init(tls_reader *r, const uint8_t *data, size_t len) {
     r->len = len;
 }
 
-size_t tls_reader_remaining(const tls_reader *r) {
+size_t tls_reader_remaining(const tls_reader_t *r) {
     return r->len;
 }
 
-int tls_reader_eof(const tls_reader *r) {
+int tls_reader_eof(const tls_reader_t *r) {
     return r->len == 0;
 }
 
-int tls_read_u8(tls_reader *r, uint8_t *out) {
+int tls_read_u8(tls_reader_t *r, uint8_t *out) {
     if (r->len < 1) {
         return 0;
     }
@@ -42,7 +42,7 @@ int tls_read_u8(tls_reader *r, uint8_t *out) {
     return 1;
 }
 
-int tls_read_u16(tls_reader *r, uint16_t *out) {
+int tls_read_u16(tls_reader_t *r, uint16_t *out) {
     if (r->len < 2) {
         return 0;
     }
@@ -52,7 +52,7 @@ int tls_read_u16(tls_reader *r, uint16_t *out) {
     return 1;
 }
 
-int tls_read_u24(tls_reader *r, uint32_t *out) {
+int tls_read_u24(tls_reader_t *r, uint32_t *out) {
     if (r->len < 3) {
         return 0;
     }
@@ -62,7 +62,7 @@ int tls_read_u24(tls_reader *r, uint32_t *out) {
     return 1;
 }
 
-int tls_read_bytes(tls_reader *r, const uint8_t **out, size_t n) {
+int tls_read_bytes(tls_reader_t *r, const uint8_t **out, size_t n) {
     if (r->len < n) {
         return 0;
     }
@@ -72,8 +72,9 @@ int tls_read_bytes(tls_reader *r, const uint8_t **out, size_t n) {
     return 1;
 }
 
-int tls_read_vector(tls_reader *r, int len_bytes, tls_reader *body) {
-    uint32_t vlen;
+int tls_read_vector(tls_reader_t *r, int len_bytes, tls_reader_t *body) {
+    uint32_t vlen32;
+    size_t vlen;
     const uint8_t *p;
 
     if (len_bytes == 1) {
@@ -81,21 +82,29 @@ int tls_read_vector(tls_reader *r, int len_bytes, tls_reader *body) {
         if (!tls_read_u8(r, &v)) {
             return 0;
         }
-        vlen = v;
+        vlen32 = v;
     } else if (len_bytes == 2) {
         uint16_t v;
         if (!tls_read_u16(r, &v)) {
             return 0;
         }
-        vlen = v;
+        vlen32 = v;
     } else if (len_bytes == 3) {
-        if (!tls_read_u24(r, &vlen)) {
+        if (!tls_read_u24(r, &vlen32)) {
             return 0;
         }
     } else {
         return 0;
     }
 
+#if SIZE_MAX < UINT32_MAX
+    /* A u24 length can exceed size_t only where size_t is narrower than 32 bits;
+     * reject rather than silently truncate. (Compiled out where size_t >= 32b.) */
+    if (vlen32 > (uint32_t)SIZE_MAX) {
+        return 0;
+    }
+#endif
+    vlen = (size_t)vlen32;
     if (!tls_read_bytes(r, &p, vlen)) {
         return 0;
     }
@@ -105,7 +114,7 @@ int tls_read_vector(tls_reader *r, int len_bytes, tls_reader *body) {
 
 /* ---- writer ------------------------------------------------------------ */
 
-void tls_writer_init(tls_writer *w, uint8_t *buf, size_t cap) {
+void tls_writer_init(tls_writer_t *w, uint8_t *buf, size_t cap) {
     w->buf = buf;
     w->cap = cap;
     w->len = 0;
@@ -114,7 +123,7 @@ void tls_writer_init(tls_writer *w, uint8_t *buf, size_t cap) {
 
 /* Reserve room for `n` more bytes; clear `ok` and return 0 if it doesn't fit.
  * The invariant w->len <= w->cap makes `cap - len` safe. */
-static int writer_room(tls_writer *w, size_t n) {
+static int writer_room(tls_writer_t *w, size_t n) {
     if (!w->ok) {
         return 0;
     }
@@ -125,7 +134,7 @@ static int writer_room(tls_writer *w, size_t n) {
     return 1;
 }
 
-int tls_write_u8(tls_writer *w, uint8_t v) {
+int tls_write_u8(tls_writer_t *w, uint8_t v) {
     if (!writer_room(w, 1)) {
         return 0;
     }
@@ -133,7 +142,7 @@ int tls_write_u8(tls_writer *w, uint8_t v) {
     return 1;
 }
 
-int tls_write_u16(tls_writer *w, uint16_t v) {
+int tls_write_u16(tls_writer_t *w, uint16_t v) {
     if (!writer_room(w, 2)) {
         return 0;
     }
@@ -142,7 +151,7 @@ int tls_write_u16(tls_writer *w, uint16_t v) {
     return 1;
 }
 
-int tls_write_u24(tls_writer *w, uint32_t v) {
+int tls_write_u24(tls_writer_t *w, uint32_t v) {
     if (v > 0xFFFFFFu) {   /* not representable in 24 bits */
         w->ok = 0;
         return 0;
@@ -156,7 +165,7 @@ int tls_write_u24(tls_writer *w, uint32_t v) {
     return 1;
 }
 
-int tls_write_bytes(tls_writer *w, const uint8_t *data, size_t n) {
+int tls_write_bytes(tls_writer_t *w, const uint8_t *data, size_t n) {
     if (n == 0) {
         return w->ok;
     }
@@ -172,30 +181,42 @@ int tls_write_bytes(tls_writer *w, const uint8_t *data, size_t n) {
     return 1;
 }
 
-size_t tls_writer_open_vector(tls_writer *w, int len_bytes) {
+size_t tls_writer_open_vector(tls_writer_t *w, int len_bytes) {
     size_t marker = w->len;
     int i;
+    if (len_bytes < 1 || len_bytes > 3) {
+        w->ok = 0;   /* fail fast: an invalid width would reserve no valid prefix */
+        return marker;
+    }
     for (i = 0; i < len_bytes; i++) {
         tls_write_u8(w, 0x00);   /* placeholder; overflow handled via w->ok */
     }
     return marker;
 }
 
-void tls_writer_close_vector(tls_writer *w, size_t marker, int len_bytes) {
+void tls_writer_close_vector(tls_writer_t *w, size_t marker, int len_bytes) {
     size_t body_len, max_len;
     int i;
 
     if (!w->ok) {
         return;
     }
-    /* The body is everything written after the reserved length prefix. */
-    body_len = w->len - marker - (size_t)len_bytes;
-
+    /* Validate the prefix width and that `marker` names a reserved prefix within
+     * the bytes already written, BEFORE any arithmetic or backfill. */
     if (len_bytes < 1 || len_bytes > 3) {
         w->ok = 0;
         return;
     }
-    max_len = ((size_t)1 << (8 * len_bytes)) - 1;   /* 0xFF, 0xFFFF, or 0xFFFFFF */
+    if (marker > w->len || (w->len - marker) < (size_t)len_bytes) {
+        w->ok = 0;
+        return;
+    }
+    /* The body is everything written after the reserved length prefix. */
+    body_len = (w->len - marker) - (size_t)len_bytes;
+
+    /* Largest body representable in the prefix, chosen explicitly to avoid a shift
+     * whose result would depend on the width of size_t. */
+    max_len = (len_bytes == 1) ? 0xFFu : (len_bytes == 2) ? 0xFFFFu : 0xFFFFFFu;
     if (body_len > max_len) {
         w->ok = 0;
         return;
@@ -205,7 +226,7 @@ void tls_writer_close_vector(tls_writer *w, size_t marker, int len_bytes) {
     }
 }
 
-int tls_writer_finish(const tls_writer *w, size_t *out_len) {
+int tls_writer_finish(const tls_writer_t *w, size_t *out_len) {
     if (!w->ok) {
         return 0;
     }

--- a/src/tls/wire.c
+++ b/src/tls/wire.c
@@ -1,0 +1,218 @@
+/*
+ * wire.c — bounded TLS wire codec (RFC 8446 §3). EXPERIMENTAL / UNAUDITED.
+ * See wire.h.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. The reader carries a remaining-byte
+ * count (not an end pointer), so all bounds are size_t comparisons and no pointer
+ * arithmetic is ever performed on an unproven range. The writer never writes past
+ * its capacity: the first would-be overflow clears a sticky `ok` flag and all
+ * subsequent writes become no-ops.
+ */
+#include "wire.h"
+
+#ifdef WEBLIB_TLS
+
+#include <string.h>
+
+/* ---- reader ------------------------------------------------------------ */
+
+void tls_reader_init(tls_reader *r, const uint8_t *data, size_t len) {
+    if (data == NULL) {
+        len = 0;
+    }
+    r->pos = data;
+    r->len = len;
+}
+
+size_t tls_reader_remaining(const tls_reader *r) {
+    return r->len;
+}
+
+int tls_reader_eof(const tls_reader *r) {
+    return r->len == 0;
+}
+
+int tls_read_u8(tls_reader *r, uint8_t *out) {
+    if (r->len < 1) {
+        return 0;
+    }
+    *out = r->pos[0];
+    r->pos += 1;
+    r->len -= 1;
+    return 1;
+}
+
+int tls_read_u16(tls_reader *r, uint16_t *out) {
+    if (r->len < 2) {
+        return 0;
+    }
+    *out = (uint16_t)(((uint16_t)r->pos[0] << 8) | r->pos[1]);
+    r->pos += 2;
+    r->len -= 2;
+    return 1;
+}
+
+int tls_read_u24(tls_reader *r, uint32_t *out) {
+    if (r->len < 3) {
+        return 0;
+    }
+    *out = ((uint32_t)r->pos[0] << 16) | ((uint32_t)r->pos[1] << 8) | (uint32_t)r->pos[2];
+    r->pos += 3;
+    r->len -= 3;
+    return 1;
+}
+
+int tls_read_bytes(tls_reader *r, const uint8_t **out, size_t n) {
+    if (r->len < n) {
+        return 0;
+    }
+    *out = r->pos;
+    r->pos += n;
+    r->len -= n;
+    return 1;
+}
+
+int tls_read_vector(tls_reader *r, int len_bytes, tls_reader *body) {
+    uint32_t vlen;
+    const uint8_t *p;
+
+    if (len_bytes == 1) {
+        uint8_t v;
+        if (!tls_read_u8(r, &v)) {
+            return 0;
+        }
+        vlen = v;
+    } else if (len_bytes == 2) {
+        uint16_t v;
+        if (!tls_read_u16(r, &v)) {
+            return 0;
+        }
+        vlen = v;
+    } else if (len_bytes == 3) {
+        if (!tls_read_u24(r, &vlen)) {
+            return 0;
+        }
+    } else {
+        return 0;
+    }
+
+    if (!tls_read_bytes(r, &p, vlen)) {
+        return 0;
+    }
+    tls_reader_init(body, p, vlen);
+    return 1;
+}
+
+/* ---- writer ------------------------------------------------------------ */
+
+void tls_writer_init(tls_writer *w, uint8_t *buf, size_t cap) {
+    w->buf = buf;
+    w->cap = cap;
+    w->len = 0;
+    w->ok = (buf != NULL);
+}
+
+/* Reserve room for `n` more bytes; clear `ok` and return 0 if it doesn't fit.
+ * The invariant w->len <= w->cap makes `cap - len` safe. */
+static int writer_room(tls_writer *w, size_t n) {
+    if (!w->ok) {
+        return 0;
+    }
+    if (n > w->cap - w->len) {
+        w->ok = 0;
+        return 0;
+    }
+    return 1;
+}
+
+int tls_write_u8(tls_writer *w, uint8_t v) {
+    if (!writer_room(w, 1)) {
+        return 0;
+    }
+    w->buf[w->len++] = v;
+    return 1;
+}
+
+int tls_write_u16(tls_writer *w, uint16_t v) {
+    if (!writer_room(w, 2)) {
+        return 0;
+    }
+    w->buf[w->len++] = (uint8_t)(v >> 8);
+    w->buf[w->len++] = (uint8_t)(v & 0xff);
+    return 1;
+}
+
+int tls_write_u24(tls_writer *w, uint32_t v) {
+    if (v > 0xFFFFFFu) {   /* not representable in 24 bits */
+        w->ok = 0;
+        return 0;
+    }
+    if (!writer_room(w, 3)) {
+        return 0;
+    }
+    w->buf[w->len++] = (uint8_t)(v >> 16);
+    w->buf[w->len++] = (uint8_t)(v >> 8);
+    w->buf[w->len++] = (uint8_t)(v & 0xff);
+    return 1;
+}
+
+int tls_write_bytes(tls_writer *w, const uint8_t *data, size_t n) {
+    if (n == 0) {
+        return w->ok;
+    }
+    if (data == NULL) {
+        w->ok = 0;
+        return 0;
+    }
+    if (!writer_room(w, n)) {
+        return 0;
+    }
+    memcpy(w->buf + w->len, data, n);
+    w->len += n;
+    return 1;
+}
+
+size_t tls_writer_open_vector(tls_writer *w, int len_bytes) {
+    size_t marker = w->len;
+    int i;
+    for (i = 0; i < len_bytes; i++) {
+        tls_write_u8(w, 0x00);   /* placeholder; overflow handled via w->ok */
+    }
+    return marker;
+}
+
+void tls_writer_close_vector(tls_writer *w, size_t marker, int len_bytes) {
+    size_t body_len, max_len;
+    int i;
+
+    if (!w->ok) {
+        return;
+    }
+    /* The body is everything written after the reserved length prefix. */
+    body_len = w->len - marker - (size_t)len_bytes;
+
+    if (len_bytes < 1 || len_bytes > 3) {
+        w->ok = 0;
+        return;
+    }
+    max_len = ((size_t)1 << (8 * len_bytes)) - 1;   /* 0xFF, 0xFFFF, or 0xFFFFFF */
+    if (body_len > max_len) {
+        w->ok = 0;
+        return;
+    }
+    for (i = 0; i < len_bytes; i++) {
+        w->buf[marker + (size_t)i] = (uint8_t)(body_len >> (8 * (len_bytes - 1 - i)));
+    }
+}
+
+int tls_writer_finish(const tls_writer *w, size_t *out_len) {
+    if (!w->ok) {
+        return 0;
+    }
+    if (out_len != NULL) {
+        *out_len = w->len;
+    }
+    return 1;
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/wire.h
+++ b/src/tls/wire.h
@@ -1,0 +1,90 @@
+/*
+ * wire.h — bounded TLS wire codec (RFC 8446 §3). EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON. The reader/writer the handshake layer parses and builds
+ * every message on: big-endian u8/u16/u24 integers and length-prefixed vectors
+ * (RFC 8446 §3.4). The reader is the security-critical half — it parses an
+ * untrusted ClientHello — so every read is bounds-checked and never touches
+ * memory outside the caller's buffer. The writer tracks a sticky overflow flag so
+ * a whole message can be built without checking each field, with one final
+ * success test. Exercised by tests/test_tls_parse.c.
+ */
+#ifndef WEBLIB_TLS_WIRE_H
+#define WEBLIB_TLS_WIRE_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* ---- reader ------------------------------------------------------------ */
+
+/* A read cursor: `pos` is the next unread byte, `len` the bytes remaining.
+ * Internal struct — use the functions below; do not touch the fields. */
+typedef struct {
+    const uint8_t *pos;
+    size_t len;
+} tls_reader;
+
+/* Initialize over [data, data+len). A NULL `data` is treated as empty. */
+void tls_reader_init(tls_reader *r, const uint8_t *data, size_t len);
+
+/* Bytes not yet consumed. */
+size_t tls_reader_remaining(const tls_reader *r);
+
+/* 1 if the cursor is fully consumed (no trailing bytes), else 0. */
+int tls_reader_eof(const tls_reader *r);
+
+/* Read a big-endian integer, advancing the cursor. Returns 1 on success, 0 if
+ * fewer than the needed bytes remain (the cursor is then left unchanged). */
+int tls_read_u8(tls_reader *r, uint8_t *out);
+int tls_read_u16(tls_reader *r, uint16_t *out);
+int tls_read_u24(tls_reader *r, uint32_t *out);
+
+/* Borrow exactly `n` bytes: point *out at them and advance. 0 if fewer remain. */
+int tls_read_bytes(tls_reader *r, const uint8_t **out, size_t n);
+
+/* Read a length-prefixed vector (RFC 8446 §3.4): a `len_bytes` (1, 2, or 3)
+ * big-endian length L followed by L bytes; opens `body` over those L bytes and
+ * advances `r` past them. Returns 0 on a bad `len_bytes`, a truncated length, or
+ * a body that runs past the buffer. */
+int tls_read_vector(tls_reader *r, int len_bytes, tls_reader *body);
+
+/* ---- writer ------------------------------------------------------------ */
+
+/* An append cursor over a fixed buffer. `ok` is sticky: it clears the first time
+ * a write (or a vector length) would not fit, and every later write is a no-op,
+ * so a whole message can be assembled and validated once at the end. */
+typedef struct {
+    uint8_t *buf;
+    size_t cap;
+    size_t len;
+    int ok;
+} tls_writer;
+
+/* Initialize over the output buffer [buf, buf+cap). */
+void tls_writer_init(tls_writer *w, uint8_t *buf, size_t cap);
+
+/* Append a big-endian integer / raw bytes. Return the writer's `ok` state after
+ * the write (0 once overflowed). u24 also fails if v > 0xFFFFFF. */
+int tls_write_u8(tls_writer *w, uint8_t v);
+int tls_write_u16(tls_writer *w, uint16_t v);
+int tls_write_u24(tls_writer *w, uint32_t v);
+int tls_write_bytes(tls_writer *w, const uint8_t *data, size_t n);
+
+/*
+ * Length-prefixed vector: reserve a `len_bytes` (1, 2, or 3) length placeholder
+ * and return a marker; write the body with the normal tls_write_* calls; then
+ * pass the marker to tls_writer_close_vector, which backfills the length. Closing
+ * fails (clears `ok`) if the body does not fit the prefix width.
+ */
+size_t tls_writer_open_vector(tls_writer *w, int len_bytes);
+void tls_writer_close_vector(tls_writer *w, size_t marker, int len_bytes);
+
+/* On success sets *out_len (if non-NULL) to the bytes written and returns 1;
+ * returns 0 if any write overflowed or a vector length did not fit. */
+int tls_writer_finish(const tls_writer *w, size_t *out_len);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_WIRE_H */

--- a/src/tls/wire.h
+++ b/src/tls/wire.h
@@ -25,31 +25,31 @@
 typedef struct {
     const uint8_t *pos;
     size_t len;
-} tls_reader;
+} tls_reader_t;
 
 /* Initialize over [data, data+len). A NULL `data` is treated as empty. */
-void tls_reader_init(tls_reader *r, const uint8_t *data, size_t len);
+void tls_reader_init(tls_reader_t *r, const uint8_t *data, size_t len);
 
 /* Bytes not yet consumed. */
-size_t tls_reader_remaining(const tls_reader *r);
+size_t tls_reader_remaining(const tls_reader_t *r);
 
 /* 1 if the cursor is fully consumed (no trailing bytes), else 0. */
-int tls_reader_eof(const tls_reader *r);
+int tls_reader_eof(const tls_reader_t *r);
 
 /* Read a big-endian integer, advancing the cursor. Returns 1 on success, 0 if
  * fewer than the needed bytes remain (the cursor is then left unchanged). */
-int tls_read_u8(tls_reader *r, uint8_t *out);
-int tls_read_u16(tls_reader *r, uint16_t *out);
-int tls_read_u24(tls_reader *r, uint32_t *out);
+int tls_read_u8(tls_reader_t *r, uint8_t *out);
+int tls_read_u16(tls_reader_t *r, uint16_t *out);
+int tls_read_u24(tls_reader_t *r, uint32_t *out);
 
 /* Borrow exactly `n` bytes: point *out at them and advance. 0 if fewer remain. */
-int tls_read_bytes(tls_reader *r, const uint8_t **out, size_t n);
+int tls_read_bytes(tls_reader_t *r, const uint8_t **out, size_t n);
 
 /* Read a length-prefixed vector (RFC 8446 §3.4): a `len_bytes` (1, 2, or 3)
  * big-endian length L followed by L bytes; opens `body` over those L bytes and
  * advances `r` past them. Returns 0 on a bad `len_bytes`, a truncated length, or
  * a body that runs past the buffer. */
-int tls_read_vector(tls_reader *r, int len_bytes, tls_reader *body);
+int tls_read_vector(tls_reader_t *r, int len_bytes, tls_reader_t *body);
 
 /* ---- writer ------------------------------------------------------------ */
 
@@ -61,17 +61,17 @@ typedef struct {
     size_t cap;
     size_t len;
     int ok;
-} tls_writer;
+} tls_writer_t;
 
 /* Initialize over the output buffer [buf, buf+cap). */
-void tls_writer_init(tls_writer *w, uint8_t *buf, size_t cap);
+void tls_writer_init(tls_writer_t *w, uint8_t *buf, size_t cap);
 
 /* Append a big-endian integer / raw bytes. Return the writer's `ok` state after
  * the write (0 once overflowed). u24 also fails if v > 0xFFFFFF. */
-int tls_write_u8(tls_writer *w, uint8_t v);
-int tls_write_u16(tls_writer *w, uint16_t v);
-int tls_write_u24(tls_writer *w, uint32_t v);
-int tls_write_bytes(tls_writer *w, const uint8_t *data, size_t n);
+int tls_write_u8(tls_writer_t *w, uint8_t v);
+int tls_write_u16(tls_writer_t *w, uint16_t v);
+int tls_write_u24(tls_writer_t *w, uint32_t v);
+int tls_write_bytes(tls_writer_t *w, const uint8_t *data, size_t n);
 
 /*
  * Length-prefixed vector: reserve a `len_bytes` (1, 2, or 3) length placeholder
@@ -79,12 +79,12 @@ int tls_write_bytes(tls_writer *w, const uint8_t *data, size_t n);
  * pass the marker to tls_writer_close_vector, which backfills the length. Closing
  * fails (clears `ok`) if the body does not fit the prefix width.
  */
-size_t tls_writer_open_vector(tls_writer *w, int len_bytes);
-void tls_writer_close_vector(tls_writer *w, size_t marker, int len_bytes);
+size_t tls_writer_open_vector(tls_writer_t *w, int len_bytes);
+void tls_writer_close_vector(tls_writer_t *w, size_t marker, int len_bytes);
 
 /* On success sets *out_len (if non-NULL) to the bytes written and returns 1;
  * returns 0 if any write overflowed or a vector length did not fit. */
-int tls_writer_finish(const tls_writer *w, size_t *out_len);
+int tls_writer_finish(const tls_writer_t *w, size_t *out_len);
 
 #endif /* WEBLIB_TLS */
 #endif /* WEBLIB_TLS_WIRE_H */

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -368,7 +368,7 @@ static void test_wire(void) {
 
     /* --- reader: read every field back --- */
     {
-        tls_reader r, body;
+        tls_reader_t r, body;
         uint8_t u8 = 0;
         uint16_t u16 = 0;
         uint32_t u24 = 0;
@@ -389,7 +389,7 @@ static void test_wire(void) {
     /* --- reader rejections --- */
     {
         static const uint8_t trunc[] = { 0x01 };            /* u16 needs 2 bytes */
-        tls_reader r, body;
+        tls_reader_t r, body;
         uint16_t u16 = 0;
         tls_reader_init(&r, trunc, sizeof trunc);
         check_true("wire read u16 truncated fails", tls_read_u16(&r, &u16) == 0);
@@ -397,7 +397,7 @@ static void test_wire(void) {
     }
     {
         static const uint8_t badvec[] = { 0x00, 0x05, 0xaa };  /* vec len 5, 1 byte body */
-        tls_reader r, body;
+        tls_reader_t r, body;
         tls_reader_init(&r, badvec, sizeof badvec);
         check_true("wire vector overrun fails", tls_read_vector(&r, 2, &body) == 0);
         tls_reader_init(&r, badvec, sizeof badvec);
@@ -407,7 +407,7 @@ static void test_wire(void) {
     /* --- writer: build the same framing and compare to `framed` --- */
     {
         uint8_t buf[64];
-        tls_writer w;
+        tls_writer_t w;
         size_t out_len = 0, marker;
         static const uint8_t vbody[] = { 0xaa, 0xbb, 0xcc };
         tls_writer_init(&w, buf, sizeof buf);
@@ -427,7 +427,7 @@ static void test_wire(void) {
     /* --- writer overflow + u24 range --- */
     {
         uint8_t buf[3];
-        tls_writer w;
+        tls_writer_t w;
         tls_writer_init(&w, buf, sizeof buf);
         tls_write_u16(&w, 0x1234);      /* 2 of 3 bytes */
         tls_write_u16(&w, 0x5678);      /* needs 2 more, only 1 left -> overflow */
@@ -435,6 +435,24 @@ static void test_wire(void) {
 
         tls_writer_init(&w, buf, sizeof buf);
         check_true("wire write u24 over 0xFFFFFF fails", tls_write_u24(&w, 0x1000000u) == 0);
+    }
+
+    /* --- invalid vector widths fail fast --- */
+    {
+        uint8_t buf[16];
+        tls_writer_t w;
+        size_t m;
+        tls_writer_init(&w, buf, sizeof buf);
+        (void)tls_writer_open_vector(&w, 0);            /* width must be 1..3 */
+        check_true("wire open_vector invalid width clears ok",
+                   tls_writer_finish(&w, NULL) == 0);
+
+        tls_writer_init(&w, buf, sizeof buf);
+        m = tls_writer_open_vector(&w, 2);
+        tls_write_u8(&w, 0xaa);
+        tls_writer_close_vector(&w, m, 4);              /* invalid close width */
+        check_true("wire close_vector invalid width clears ok",
+                   tls_writer_finish(&w, NULL) == 0);
     }
 }
 #endif /* WEBLIB_TLS */

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -16,6 +16,7 @@
 #include "pem.h"
 #include "ed25519_key.h"
 #include "ed25519.h"
+#include "wire.h"
 #endif
 
 static int g_failures = 0;
@@ -353,6 +354,89 @@ static void test_ed25519_key(void) {
                    && memcmp(got_seed, seed, 32) == 0);
     }
 }
+
+/* Bounded TLS wire codec: big-endian integers + length-prefixed vectors. The
+ * writer's output is constructed to equal the reader's input, so the two are
+ * cross-checked against each other, and malformed reads / writer overflow are
+ * rejected. */
+static void test_wire(void) {
+    /* This byte string is both the reader's input and the writer's expected
+     * output: u8 0x2a | u16 0x0103 | u24 0x000200 | u16-vector{aa,bb,cc} | u8 0xff. */
+    static const uint8_t framed[] = {
+        0x2a, 0x01, 0x03, 0x00, 0x02, 0x00, 0x00, 0x03, 0xaa, 0xbb, 0xcc, 0xff
+    };
+
+    /* --- reader: read every field back --- */
+    {
+        tls_reader r, body;
+        uint8_t u8 = 0;
+        uint16_t u16 = 0;
+        uint32_t u24 = 0;
+        const uint8_t *p = NULL;
+        tls_reader_init(&r, framed, sizeof framed);
+        check_true("wire read u8", tls_read_u8(&r, &u8) && u8 == 0x2a);
+        check_true("wire read u16", tls_read_u16(&r, &u16) && u16 == 0x0103);
+        check_true("wire read u24", tls_read_u24(&r, &u24) && u24 == 0x000200u);
+        check_true("wire read u16 vector",
+                   tls_read_vector(&r, 2, &body) && tls_reader_remaining(&body) == 3
+                   && tls_read_bytes(&body, &p, 3) && p[0] == 0xaa && p[2] == 0xcc
+                   && tls_reader_eof(&body));
+        check_true("wire read trailing u8", tls_read_u8(&r, &u8) && u8 == 0xff);
+        check_true("wire reader reaches eof", tls_reader_eof(&r));
+        check_true("wire read past eof fails", tls_read_u8(&r, &u8) == 0);
+    }
+
+    /* --- reader rejections --- */
+    {
+        static const uint8_t trunc[] = { 0x01 };            /* u16 needs 2 bytes */
+        tls_reader r, body;
+        uint16_t u16 = 0;
+        tls_reader_init(&r, trunc, sizeof trunc);
+        check_true("wire read u16 truncated fails", tls_read_u16(&r, &u16) == 0);
+        (void)body;
+    }
+    {
+        static const uint8_t badvec[] = { 0x00, 0x05, 0xaa };  /* vec len 5, 1 byte body */
+        tls_reader r, body;
+        tls_reader_init(&r, badvec, sizeof badvec);
+        check_true("wire vector overrun fails", tls_read_vector(&r, 2, &body) == 0);
+        tls_reader_init(&r, badvec, sizeof badvec);
+        check_true("wire vector bad len_bytes fails", tls_read_vector(&r, 4, &body) == 0);
+    }
+
+    /* --- writer: build the same framing and compare to `framed` --- */
+    {
+        uint8_t buf[64];
+        tls_writer w;
+        size_t out_len = 0, marker;
+        static const uint8_t vbody[] = { 0xaa, 0xbb, 0xcc };
+        tls_writer_init(&w, buf, sizeof buf);
+        tls_write_u8(&w, 0x2a);
+        tls_write_u16(&w, 0x0103);
+        tls_write_u24(&w, 0x000200u);
+        marker = tls_writer_open_vector(&w, 2);
+        tls_write_bytes(&w, vbody, sizeof vbody);
+        tls_writer_close_vector(&w, marker, 2);
+        tls_write_u8(&w, 0xff);
+        check_true("wire writer output matches reader input",
+                   tls_writer_finish(&w, &out_len) == 1
+                   && out_len == sizeof framed
+                   && memcmp(buf, framed, sizeof framed) == 0);
+    }
+
+    /* --- writer overflow + u24 range --- */
+    {
+        uint8_t buf[3];
+        tls_writer w;
+        tls_writer_init(&w, buf, sizeof buf);
+        tls_write_u16(&w, 0x1234);      /* 2 of 3 bytes */
+        tls_write_u16(&w, 0x5678);      /* needs 2 more, only 1 left -> overflow */
+        check_true("wire writer overflow clears ok", tls_writer_finish(&w, NULL) == 0);
+
+        tls_writer_init(&w, buf, sizeof buf);
+        check_true("wire write u24 over 0xFFFFFF fails", tls_write_u24(&w, 0x1000000u) == 0);
+    }
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -366,6 +450,7 @@ int main(void) {
     test_der_tag_enforcement();
     test_pem_decode();
     test_ed25519_key();
+    test_wire();
 
     if (g_failures == 0) {
         printf("All TLS parse tests passed.\n");


### PR DESCRIPTION
## Summary

The foundation of the handshake layer: `src/tls/wire.{c,h}` — the reader/writer that every handshake message will parse and build on. Big-endian `u8`/`u16`/`u24` integers and length-prefixed vectors (RFC 8446 §3.4).

**Reader** (the security-critical half — it will parse an untrusted ClientHello): `tls_reader` carries a **remaining-byte count**, not an end pointer, so all bounds are `size_t` comparisons and no pointer arithmetic is done on an unproven range (same discipline as the DER reader). `tls_read_u8/u16/u24`, `tls_read_bytes` (borrow N), and `tls_read_vector` (a 1/2/3-byte length prefix + body opened as a sub-reader). Every read is bounds-checked; truncation, an over-long vector, or a bad prefix width returns 0.

**Writer**: `tls_writer` with a **sticky `ok` flag** — the first would-be overflow clears it and every later write is a no-op, so a whole message is assembled and checked once at the end. `tls_write_u8/u16/u24` (u24 range-checked), `tls_write_bytes`, and `open`/`close_vector` which reserves a length placeholder and backfills it (failing if the body doesn't fit the prefix width).

## Tests — `TlsParseTests` (+13 → 55)

One byte string is used as **both** the reader's input and the writer's expected output, so the reader and writer are cross-checked against each other (write → bytes → read back). Plus rejection of: truncated reads, vector overrun, a bad prefix width, writer overflow, and an out-of-range u24.

## Verification

| Build | Result |
|---|---|
| Default (TLS **OFF**) | byte-identical; no `wire` symbols; **ctest 6/6** |
| TLS (`WEBLIB_ENABLE_TLS=ON`) | 0 warnings; **ctest 9/9** |
| TLS + ASan/UBSan (`halt_on_error=1`) | clean |

**Negative control:** disabling the `tls_read_bytes` bounds check fails *exactly* the vector-overrun rejection (the u16-truncated case still passes via its own check), confirming that guard is load-bearing.

Native-only, gated behind `WEBLIB_ENABLE_TLS` (default **OFF**).

## Next in Phase 3
ClientHello parser (on this reader), then ServerHello / EncryptedExtensions / Certificate / CertificateVerify / Finished builders (on this writer), then the handshake state machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)