### PR TITLE
TLS Phase 3: handshake auth crypto (transcript, Finished, CertificateVerify)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/der.c
     src/tls/wire.c
     src/tls/handshake.c
+    src/tls/handshake_auth.c
     src/tls/pem.c
     src/tls/chacha20.c
     src/tls/poly1305.c

--- a/src/tls/handshake_auth.c
+++ b/src/tls/handshake_auth.c
@@ -1,0 +1,72 @@
+/*
+ * handshake_auth.c — TLS 1.3 handshake authentication crypto (RFC 8446 §4.4).
+ * EXPERIMENTAL / UNAUDITED. See handshake_auth.h.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. Thin composition of verified
+ * primitives: the transcript hash clones a running SHA-256 so the digest of the
+ * messages so far can be taken without ending the stream; the Finished MAC is
+ * HMAC-SHA256; the CertificateVerify signature is Ed25519 over the RFC-defined
+ * content preamble.
+ */
+#include "handshake_auth.h"
+
+#ifdef WEBLIB_TLS
+
+#include "crypto/sha256.h"
+#include "ed25519.h"
+#include <string.h>
+
+/* Server CertificateVerify content preamble (RFC 8446 §4.4.3). */
+#define CV_CONTEXT     "TLS 1.3, server CertificateVerify"
+#define CV_CONTEXT_LEN 33                                   /* strlen(CV_CONTEXT) */
+#define CV_CONTENT_LEN (64 + CV_CONTEXT_LEN + 1 + 32)       /* = 130 */
+
+void tls_transcript_init(tls_transcript_t *t) {
+    sha256_init(&t->sha);
+}
+
+void tls_transcript_update(tls_transcript_t *t, const uint8_t *msg, size_t len) {
+    if (len > 0) {
+        sha256_update(&t->sha, msg, len);
+    }
+}
+
+void tls_transcript_current(const tls_transcript_t *t, uint8_t out[32]) {
+    /* Clone the running context and finalize the copy, so the caller's transcript
+     * keeps accumulating further messages. */
+    sha256_ctx_t snapshot = t->sha;
+    sha256_final(&snapshot, out);
+}
+
+void tls_finished_verify_data(const uint8_t finished_key[32],
+                              const uint8_t transcript_hash[32],
+                              uint8_t out[32]) {
+    hmac_sha256(finished_key, 32, transcript_hash, 32, out);
+}
+
+/* Build the 130-byte content signed/verified in a server CertificateVerify. The
+ * bytes are public (derived from the transcript), so no wiping is needed. */
+static void cert_verify_content(const uint8_t transcript_hash[32],
+                                uint8_t content[CV_CONTENT_LEN]) {
+    memset(content, 0x20, 64);
+    memcpy(content + 64, CV_CONTEXT, CV_CONTEXT_LEN);
+    content[64 + CV_CONTEXT_LEN] = 0x00;
+    memcpy(content + 64 + CV_CONTEXT_LEN + 1, transcript_hash, 32);
+}
+
+void tls_sign_server_cert_verify(const uint8_t seed[32], const uint8_t pubkey[32],
+                                 const uint8_t transcript_hash[32], uint8_t sig[64]) {
+    uint8_t content[CV_CONTENT_LEN];
+    cert_verify_content(transcript_hash, content);
+    ed25519_sign(sig, content, sizeof content, seed, pubkey);
+}
+
+int tls_verify_server_cert_verify(const uint8_t pubkey[32],
+                                  const uint8_t transcript_hash[32],
+                                  const uint8_t sig[64]) {
+    uint8_t content[CV_CONTENT_LEN];
+    cert_verify_content(transcript_hash, content);
+    return ed25519_verify(sig, content, sizeof content, pubkey);
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/handshake_auth.c
+++ b/src/tls/handshake_auth.c
@@ -16,10 +16,13 @@
 #include "ed25519.h"
 #include <string.h>
 
-/* Server CertificateVerify content preamble (RFC 8446 §4.4.3). */
+/* Server CertificateVerify content preamble (RFC 8446 §4.4.3). Lengths are
+ * derived from the label literal and the hash size so the layout can't silently
+ * drift if either changes. */
 #define CV_CONTEXT     "TLS 1.3, server CertificateVerify"
-#define CV_CONTEXT_LEN 33                                   /* strlen(CV_CONTEXT) */
-#define CV_CONTENT_LEN (64 + CV_CONTEXT_LEN + 1 + 32)       /* = 130 */
+#define CV_CONTEXT_LEN (sizeof(CV_CONTEXT) - 1)             /* label length, sans NUL */
+#define CV_PAD_LEN     64                                   /* octet 0x20 * 64 (fixed) */
+#define CV_CONTENT_LEN (CV_PAD_LEN + CV_CONTEXT_LEN + 1 + SHA256_DIGEST_SIZE)  /* = 130 */
 
 void tls_transcript_init(tls_transcript_t *t) {
     sha256_init(&t->sha);
@@ -48,10 +51,10 @@ void tls_finished_verify_data(const uint8_t finished_key[32],
  * bytes are public (derived from the transcript), so no wiping is needed. */
 static void cert_verify_content(const uint8_t transcript_hash[32],
                                 uint8_t content[CV_CONTENT_LEN]) {
-    memset(content, 0x20, 64);
-    memcpy(content + 64, CV_CONTEXT, CV_CONTEXT_LEN);
-    content[64 + CV_CONTEXT_LEN] = 0x00;
-    memcpy(content + 64 + CV_CONTEXT_LEN + 1, transcript_hash, 32);
+    memset(content, 0x20, CV_PAD_LEN);
+    memcpy(content + CV_PAD_LEN, CV_CONTEXT, CV_CONTEXT_LEN);
+    content[CV_PAD_LEN + CV_CONTEXT_LEN] = 0x00;
+    memcpy(content + CV_PAD_LEN + CV_CONTEXT_LEN + 1, transcript_hash, SHA256_DIGEST_SIZE);
 }
 
 void tls_sign_server_cert_verify(const uint8_t seed[32], const uint8_t pubkey[32],

--- a/src/tls/handshake_auth.h
+++ b/src/tls/handshake_auth.h
@@ -1,0 +1,63 @@
+/*
+ * handshake_auth.h — TLS 1.3 handshake authentication crypto (RFC 8446 §4.4).
+ * EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON. The three handshake-specific computations the state
+ * machine performs over the running transcript: the transcript hash itself
+ * (§4.4.1), the Finished MAC (§4.4.4), and the server CertificateVerify signature
+ * (§4.4.3). Built on SHA-256/HMAC (crypto/sha256) and Ed25519 (ed25519).
+ * Verified against an independent reference in tests/test_tls_crypto.c.
+ */
+#ifndef WEBLIB_TLS_HANDSHAKE_AUTH_H
+#define WEBLIB_TLS_HANDSHAKE_AUTH_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+#include "crypto/sha256.h"   /* sha256_ctx_t */
+
+/*
+ * Running handshake transcript hash (RFC 8446 §4.4.1): a SHA-256 over the
+ * concatenation of the handshake messages exchanged so far, each including its
+ * 4-byte header.
+ */
+typedef struct {
+    sha256_ctx_t sha;
+} tls_transcript_t;
+
+void tls_transcript_init(tls_transcript_t *t);
+
+/* Absorb one complete handshake message (header included). */
+void tls_transcript_update(tls_transcript_t *t, const uint8_t *msg, size_t len);
+
+/* Write the transcript hash of the messages absorbed so far to `out` (32 bytes),
+ * without disturbing the running state — more messages may follow. */
+void tls_transcript_current(const tls_transcript_t *t, uint8_t out[32]);
+
+/*
+ * Finished.verify_data (RFC 8446 §4.4.4) = HMAC-SHA256(finished_key,
+ * transcript_hash), where finished_key is derived from a Base traffic secret via
+ * the key schedule. Writes 32 bytes.
+ */
+void tls_finished_verify_data(const uint8_t finished_key[32],
+                              const uint8_t transcript_hash[32],
+                              uint8_t out[32]);
+
+/*
+ * Sign a server CertificateVerify (RFC 8446 §4.4.3): Ed25519 over the content
+ *   0x20 * 64 || "TLS 1.3, server CertificateVerify" || 0x00 || transcript_hash
+ * with the server's Ed25519 key (`seed` + its `pubkey`); writes the 64-byte
+ * signature to `sig`.
+ */
+void tls_sign_server_cert_verify(const uint8_t seed[32], const uint8_t pubkey[32],
+                                 const uint8_t transcript_hash[32], uint8_t sig[64]);
+
+/* Verify a server CertificateVerify signature. Returns 1 if valid, else 0. */
+int tls_verify_server_cert_verify(const uint8_t pubkey[32],
+                                  const uint8_t transcript_hash[32],
+                                  const uint8_t sig[64]);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_HANDSHAKE_AUTH_H */

--- a/tests/test_tls_crypto.c
+++ b/tests/test_tls_crypto.c
@@ -19,6 +19,7 @@
 #include "ed25519.h"
 #include "key_schedule.h"
 #include "record.h"
+#include "handshake_auth.h"
 #include "crypto/sha256.h"
 #endif
 
@@ -760,6 +761,57 @@ static void test_record(void) {
                                    big, sizeof big, 0, bigout, sizeof bigout, &out_len) == 0);
     }
 }
+/* Handshake authentication crypto (RFC 8446 §4.4): transcript hash, Finished
+ * MAC, and server CertificateVerify signature — cross-checked against an
+ * independent reference (SHA-256/HMAC via hashlib, Ed25519 via the ref impl). */
+static void test_hs_auth(void) {
+    tls_transcript_t tr;
+    uint8_t out[32], th[32], sig[64], seed[32], pub[32], fin_key[32], expect[32];
+    int i;
+
+    /* Transcript hash: absorbing "msg1" then "msg2" == SHA-256("msg1msg2"). */
+    tls_transcript_init(&tr);
+    tls_transcript_update(&tr, (const uint8_t *)"msg1", 4);
+    tls_transcript_update(&tr, (const uint8_t *)"msg2", 4);
+    tls_transcript_current(&tr, out);
+    check_hex("hs_auth transcript hash", out, 32,
+              "afd6fb1fc4ec8c2ff174b28911d601be62ad40470c0a436394e3360f90ba1a44");
+
+    /* current() must not disturb the running state: another update continues it. */
+    tls_transcript_update(&tr, (const uint8_t *)"msg3", 4);
+    tls_transcript_current(&tr, out);
+    sha256((const uint8_t *)"msg1msg2msg3", 12, expect);
+    check_true("hs_auth transcript continues after snapshot",
+               memcmp(out, expect, 32) == 0);
+
+    /* Finished verify_data = HMAC-SHA256(finished_key, transcript_hash). */
+    for (i = 0; i < 32; i++) {
+        fin_key[i] = (uint8_t)(0x10 + i);
+    }
+    sha256((const uint8_t *)"transcript", 10, th);
+    check_hex("hs_auth transcript_hash input", th, 32,
+              "54e6289e14c7b0e7ad9acc2dfc4c1e3d027d0eef7f5c4c3fe7c292761d0e06a6");
+    tls_finished_verify_data(fin_key, th, out);
+    check_hex("hs_auth finished verify_data", out, 32,
+              "fff1f2a9f570345a08332d8bfdf117a2bef0783fbdb7ca7d36a3c2e5a4ffaf69");
+
+    /* CertificateVerify: Ed25519 over the RFC 8446 §4.4.3 content preamble. */
+    from_hex("4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb", seed, 32);
+    ed25519_public_key(pub, seed);
+    tls_sign_server_cert_verify(seed, pub, th, sig);
+    check_hex("hs_auth CertificateVerify signature", sig, 64,
+              "6a09cf1bb46ac2a1a956ffea8fdb4eaf230a8be2db43b5e5a07b263a5d01ee14"
+              "3ab3e13dcb35d829613e9db383d331476abedc22c3f1ebdae685749daf889c02");
+    check_true("hs_auth CertificateVerify verifies",
+               tls_verify_server_cert_verify(pub, th, sig) == 1);
+    {   /* a different transcript hash must fail verification */
+        uint8_t bad[32];
+        memcpy(bad, th, 32);
+        bad[0] ^= 0x01;
+        check_true("hs_auth CertificateVerify rejects wrong transcript",
+                   tls_verify_server_cert_verify(pub, bad, sig) == 0);
+    }
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -777,6 +829,7 @@ int main(void) {
     test_ed25519();
     test_key_schedule();
     test_record();
+    test_hs_auth();
 
     if (g_failures == 0) {
         printf("All TLS crypto KATs passed.\n");


### PR DESCRIPTION
src/tls/handshake_auth.{c,h}: transcript hash (SHA-256 with clone-to-snapshot so the stream continues), Finished verify_data (HMAC-SHA256), and server CertificateVerify signing/verifying (Ed25519 over the RFC 8446 §4.4.3 content preamble `0x20*64 || "TLS 1.3, server CertificateVerify" || 0x00 || transcript_hash`).

KAT (+7 -> 86) cross-checked vs an independent SHA-256/HMAC/Ed25519 reference: transcript hash of msg1||msg2, continuation after a snapshot, Finished verify_data, and the CertificateVerify signature (matches an independent Ed25519 sig, verifies, rejects a tampered hash). Default OFF byte-identical (ctest 6/6), TLS 9/9, ASan/UBSan (halt_on_error=1) clean, negative control (wrong separator byte) fails the signature vector. Native-only, gated behind WEBLIB_ENABLE_TLS.

Next: the handshake state machine (parse ClientHello -> X25519 ECDH -> key schedule -> build+encrypt server flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)