### PR TITLE
TLS Phase 3: server handshake state machine (RFC 8446 §4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/wire.c
     src/tls/handshake.c
     src/tls/handshake_auth.c
+    src/tls/server_handshake.c
     src/tls/pem.c
     src/tls/chacha20.c
     src/tls/poly1305.c

--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -1,10 +1,13 @@
 # `src/tls/` — Experimental pure-C TLS 1.3 (EXPERIMENTAL · UNAUDITED)
 
-> **Status: scaffold only.** There is **no** working TLS here yet — no handshake,
-> no record layer, no cryptography. Do **not** rely on this for any security
-> property. This directory is the foundation for an incremental, from-scratch
-> TLS build; every cryptographic primitive will land with a known-answer test
-> against its official RFC vector before anything depends on it.
+> **Status: components built and cross-checked; not yet integrated or audited.**
+> The cryptographic primitives, certificate/key loading, key schedule, record
+> layer, handshake messages, and the **server handshake state machine** now exist,
+> each landed with a known-answer test against an official RFC vector or an
+> independent reference implementation. What does **not** yet exist: the transport
+> integration (`http_server_enable_tls`) and real-client (`curl` / `openssl
+> s_client`) interop — so nothing here terminates a real TLS connection yet. The
+> code is **UNAUDITED**; do **not** rely on it for any security property.
 
 ## Why hand-written TLS
 
@@ -53,9 +56,12 @@ ctest --test-dir build-tls
 - **Phase 1:** primitives from scratch, each with an RFC known-answer test
   (ChaCha20, Poly1305, ChaCha20-Poly1305, HKDF, SHA-384/512, X25519, Ed25519).
 - **Phase 2:** PEM + minimal ASN.1/DER + X.509 loading.
-- **Phase 3:** TLS 1.3 record layer + server handshake state machine + key schedule.
-- **Phase 4:** integration (`http_server_enable_tls`), config, `curl` / `openssl
-  s_client` interop, ClientHello fuzzing, honest security labeling.
+- **Phase 3 (landed):** TLS 1.3 key schedule, record layer, handshake messages
+  (ClientHello parser + server builders + auth crypto), and the server handshake
+  state machine (`server_handshake.c`) — the 1-RTT `TLS_CHACHA20_POLY1305_SHA256`
+  + X25519 + Ed25519 flow, each cross-checked against an independent oracle.
+- **Phase 4 (next):** integration (`http_server_enable_tls`), config, `curl` /
+  `openssl s_client` interop, ClientHello fuzzing, honest security labeling.
 
 Design references in-repo: the "Pure C TLS (not OpenSSL)" ADR in
 [`NEXT_PHASE.md`](../../NEXT_PHASE.md) and the Phase 11 TLS plan in

--- a/src/tls/server_handshake.c
+++ b/src/tls/server_handshake.c
@@ -110,9 +110,11 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
     if (hs->phase != TLS_SERVER_HS_START) {
         return fail(hs, TLS_ALERT_UNEXPECTED_MESSAGE);
     }
-    if (cfg == NULL || ch_msg == NULL || out == NULL ||
+    if (cfg == NULL || ch_msg == NULL || out == NULL || out_len == NULL ||
         cfg->cert_der == NULL || cfg->ed25519_seed == NULL || cfg->ed25519_pub == NULL ||
         cfg->server_eph_sk == NULL || cfg->server_random == NULL) {
+        /* out_len is required: a caller must always learn the response length so it
+         * never sends an unknown/unbounded number of bytes (cf. tls_record_seal). */
         return fail(hs, TLS_ALERT_INTERNAL_ERROR);
     }
 
@@ -255,9 +257,7 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
     }
     out_used += rec_len;
 
-    if (out_len != NULL) {
-        *out_len = out_used;
-    }
+    *out_len = out_used;   /* out_len is guaranteed non-NULL (checked above) */
     hs->phase = TLS_SERVER_HS_WAIT_FINISHED;
     ok = 1;
 

--- a/src/tls/server_handshake.c
+++ b/src/tls/server_handshake.c
@@ -1,0 +1,403 @@
+/*
+ * server_handshake.c — TLS 1.3 server handshake state machine (RFC 8446 §4).
+ * EXPERIMENTAL / UNAUDITED. See server_handshake.h.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. This is the orchestration layer that
+ * sequences the verified primitives into a live 1-RTT handshake. The security
+ * properties it must uphold — none of which the primitives can enforce on their own
+ * — are:
+ *
+ *   1. Sequencing: an explicit phase gates every entry point (a message is accepted
+ *      in exactly one phase, then the phase advances and can never move back).
+ *   2. Authentication: DONE is reached, and application keys released, only after
+ *      the client Finished deprotects and its verify_data matches in constant time.
+ *   3. Fail-closed: every failure latches a terminal FAILED phase, records the alert
+ *      to send, and wipes all secret material before returning.
+ *   4. Contributory behaviour: an all-zero X25519 shared secret is rejected
+ *      (RFC 8446 §7.4.2).
+ *
+ * These are implemented directly below and exercised adversarially in the tests.
+ */
+#include "server_handshake.h"
+
+#ifdef WEBLIB_TLS
+
+#include "handshake.h"
+#include "handshake_auth.h"
+#include "key_schedule.h"
+#include "record.h"
+#include "wire.h"
+#include "x25519.h"
+#include "kamran.k"       /* secure_zero, secure_compare */
+#include <string.h>
+
+/*
+ * Upper bound on the assembled server flight {EncryptedExtensions, Certificate,
+ * CertificateVerify, Finished} in plaintext. The fixed messages total ~114 bytes;
+ * the rest is the certificate. 4 KiB comfortably holds any single Ed25519 or RSA
+ * certificate. A larger certificate is rejected (internal_error) rather than
+ * fragmented across records — see the header's scope notes.
+ */
+#define TLS_SERVER_FLIGHT_CAP 4096
+
+/* Largest client Finished record plaintext (Finished is 36 bytes; the slack
+ * tolerates a reasonably padded record, RFC 8446 §5.4). */
+#define TLS_CLIENT_FIN_PLAINTEXT_CAP 512
+
+/* 1 (constant-time over the buffer) if every byte of `p` is zero. */
+static int all_zero(const uint8_t *p, size_t n) {
+    uint8_t acc = 0;
+    size_t i;
+    for (i = 0; i < n; i++) {
+        acc |= p[i];
+    }
+    return acc == 0;
+}
+
+/* Latch the terminal FAILED phase, record the alert, wipe secrets. Returns 0 so
+ * callers can `return fail(hs, alert);`. */
+static int fail(tls_server_hs_t *hs, uint8_t alert) {
+    tls_server_hs_wipe(hs);      /* wipes key material, sets phase FAILED, alert 0 */
+    hs->alert = alert;
+    return 0;
+}
+
+void tls_server_hs_init(tls_server_hs_t *hs) {
+    if (hs == NULL) {
+        return;
+    }
+    memset(hs, 0, sizeof *hs);
+    hs->phase = TLS_SERVER_HS_START;
+    hs->alert = 0;
+}
+
+int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
+                                     const tls_server_config_t *cfg,
+                                     const uint8_t *ch_msg, size_t ch_len,
+                                     uint8_t *out, size_t out_cap, size_t *out_len) {
+    /* Secret scratch — all wiped at `done` regardless of outcome. */
+    tls_transcript_t transcript;
+    tls_client_hello_t ch;
+    uint8_t ecdhe[32];
+    uint8_t server_pub[32];                       /* public */
+    uint8_t zero32[32];
+    uint8_t empty_hash[32];                        /* public */
+    uint8_t early_secret[32], derived[32], derived2[32];
+    uint8_t handshake_secret[32], master_secret[32];
+    uint8_t c_hs_secret[32], s_hs_secret[32];
+    uint8_t server_hs_key[32], server_hs_iv[12];
+    uint8_t s_finished_key[32], c_finished_key[32];
+    uint8_t c_ap_secret[32], s_ap_secret[32];
+    uint8_t th[32];                                /* public transcript hashes */
+    uint8_t verify_data[32];                       /* server Finished (transmitted) */
+    uint8_t flight[TLS_SERVER_FLIGHT_CAP];
+    uint8_t cv_sig[64];
+
+    tls_writer_t w;
+    size_t sh_len = 0, out_used = 0, flight_len = 0, rec_len = 0, mlen = 0;
+    uint8_t alert = TLS_ALERT_INTERNAL_ERROR;
+    int ok = 0;
+
+    if (out_len != NULL) {
+        *out_len = 0;
+    }
+    if (hs == NULL) {
+        return 0;
+    }
+    /* Phase gate: ClientHello is accepted only in START. Anything else (including a
+     * replay after we have advanced, or a call on a FAILED handshake) is a protocol
+     * violation. */
+    if (hs->phase != TLS_SERVER_HS_START) {
+        return fail(hs, TLS_ALERT_UNEXPECTED_MESSAGE);
+    }
+    if (cfg == NULL || ch_msg == NULL || out == NULL ||
+        cfg->cert_der == NULL || cfg->ed25519_seed == NULL || cfg->ed25519_pub == NULL ||
+        cfg->server_eph_sk == NULL || cfg->server_random == NULL) {
+        return fail(hs, TLS_ALERT_INTERNAL_ERROR);
+    }
+
+    memset(zero32, 0, sizeof zero32);
+
+    /* 1. Parse the (attacker-controlled) ClientHello. */
+    if (!tls_parse_client_hello(ch_msg, ch_len, &ch)) {
+        alert = TLS_ALERT_DECODE_ERROR;
+        goto done;
+    }
+
+    /* 2. Require the one profile we implement. Distinct alerts per RFC 8446 §6. */
+    if (!ch.offers_tls13) {
+        alert = TLS_ALERT_PROTOCOL_VERSION;   /* no TLS 1.3 in supported_versions */
+        goto done;
+    }
+    if (!ch.offers_chacha20_poly1305 || !ch.offers_ed25519 ||
+        !ch.offers_x25519 || ch.x25519_key_share == NULL) {
+        /* No common cipher / signature / group, or (no HRR support) no X25519 share. */
+        alert = TLS_ALERT_HANDSHAKE_FAILURE;
+        goto done;
+    }
+
+    /* 3. X25519 key agreement, then the RFC 8446 §7.4.2 contributory-behaviour
+     * check: reject an all-zero shared secret (a degenerate / small-order peer
+     * key). Constant-time over the secret. */
+    x25519(ecdhe, cfg->server_eph_sk, ch.x25519_key_share);
+    if (all_zero(ecdhe, sizeof ecdhe)) {
+        alert = TLS_ALERT_ILLEGAL_PARAMETER;
+        goto done;
+    }
+    x25519_base(server_pub, cfg->server_eph_sk);
+
+    /* 4. Transcript = ClientHello, then ServerHello. Build the ServerHello directly
+     * into `out` behind a 5-byte record header, then backfill the header. */
+    tls_transcript_init(&transcript);
+    tls_transcript_update(&transcript, ch_msg, ch_len);
+
+    if (out_cap < TLS_RECORD_HEADER_LEN) {
+        goto done;   /* internal_error */
+    }
+    tls_writer_init(&w, out + TLS_RECORD_HEADER_LEN, out_cap - TLS_RECORD_HEADER_LEN);
+    if (!tls_build_server_hello(&w, cfg->server_random, ch.session_id,
+                                ch.session_id_len, server_pub) ||
+        !tls_writer_finish(&w, &sh_len)) {
+        goto done;   /* output buffer too small -> internal_error */
+    }
+    if (sh_len > TLS_RECORD_MAX_PLAINTEXT) {
+        goto done;
+    }
+    out[0] = TLS_CONTENT_HANDSHAKE;             /* 22 */
+    out[1] = 0x03;
+    out[2] = 0x03;                              /* legacy_record_version */
+    out[3] = (uint8_t)(sh_len >> 8);
+    out[4] = (uint8_t)(sh_len & 0xff);
+    tls_transcript_update(&transcript, out + TLS_RECORD_HEADER_LEN, sh_len);
+    out_used = TLS_RECORD_HEADER_LEN + sh_len;
+
+    /* 5. Key schedule through the handshake secret (RFC 8446 §7.1). */
+    tls13_extract(NULL, 0, zero32, sizeof zero32, early_secret);   /* no PSK */
+    tls13_empty_transcript_hash(empty_hash);
+    if (!tls13_derive_secret(early_secret, "derived", empty_hash, derived)) {
+        goto done;
+    }
+    tls13_extract(derived, sizeof derived, ecdhe, sizeof ecdhe, handshake_secret);
+
+    tls_transcript_current(&transcript, th);   /* TH(ClientHello || ServerHello) */
+    if (!tls13_derive_secret(handshake_secret, "s hs traffic", th, s_hs_secret) ||
+        !tls13_derive_secret(handshake_secret, "c hs traffic", th, c_hs_secret) ||
+        !tls13_traffic_keys(s_hs_secret, server_hs_key, sizeof server_hs_key, server_hs_iv) ||
+        !tls13_traffic_keys(c_hs_secret, hs->client_hs_key, sizeof hs->client_hs_key,
+                            hs->client_hs_iv) ||
+        !tls13_finished_key(s_hs_secret, s_finished_key) ||
+        !tls13_finished_key(c_hs_secret, c_finished_key)) {
+        goto done;
+    }
+
+    /* 6. Assemble the server flight, absorbing each message into the transcript in
+     * order. CertificateVerify signs the transcript through Certificate; the server
+     * Finished MACs the transcript through CertificateVerify. Each message is built
+     * with its own writer at a running offset so its exact bytes are known. */
+    /* EncryptedExtensions */
+    tls_writer_init(&w, flight, sizeof flight);
+    if (!tls_build_encrypted_extensions(&w) || !tls_writer_finish(&w, &mlen)) {
+        goto done;
+    }
+    tls_transcript_update(&transcript, flight, mlen);
+    flight_len = mlen;
+    /* Certificate */
+    tls_writer_init(&w, flight + flight_len, sizeof flight - flight_len);
+    if (!tls_build_certificate(&w, cfg->cert_der, cfg->cert_len) ||
+        !tls_writer_finish(&w, &mlen)) {
+        goto done;   /* certificate too large for the flight buffer */
+    }
+    tls_transcript_update(&transcript, flight + flight_len, mlen);
+    flight_len += mlen;
+    /* CertificateVerify — sign TH(ClientHello .. Certificate). */
+    tls_transcript_current(&transcript, th);
+    tls_sign_server_cert_verify(cfg->ed25519_seed, cfg->ed25519_pub, th, cv_sig);
+    tls_writer_init(&w, flight + flight_len, sizeof flight - flight_len);
+    if (!tls_build_certificate_verify(&w, cv_sig) || !tls_writer_finish(&w, &mlen)) {
+        goto done;
+    }
+    tls_transcript_update(&transcript, flight + flight_len, mlen);
+    flight_len += mlen;
+    /* Finished — MAC TH(ClientHello .. CertificateVerify) with the server finished key. */
+    tls_transcript_current(&transcript, th);
+    tls_finished_verify_data(s_finished_key, th, verify_data);
+    tls_writer_init(&w, flight + flight_len, sizeof flight - flight_len);
+    if (!tls_build_finished(&w, verify_data) || !tls_writer_finish(&w, &mlen)) {
+        goto done;
+    }
+    tls_transcript_update(&transcript, flight + flight_len, mlen);
+    flight_len += mlen;
+
+    /* 7. Application traffic keys and the expected client Finished, both over
+     * TH(ClientHello .. server Finished) (RFC 8446 §7.1, §4.4.4). */
+    tls_transcript_current(&transcript, th);
+    if (!tls13_derive_secret(handshake_secret, "derived", empty_hash, derived2)) {
+        goto done;
+    }
+    tls13_extract(derived2, sizeof derived2, zero32, sizeof zero32, master_secret);
+    if (!tls13_derive_secret(master_secret, "s ap traffic", th, s_ap_secret) ||
+        !tls13_derive_secret(master_secret, "c ap traffic", th, c_ap_secret) ||
+        !tls13_traffic_keys(s_ap_secret, hs->server_ap_key, sizeof hs->server_ap_key,
+                            hs->server_ap_iv) ||
+        !tls13_traffic_keys(c_ap_secret, hs->client_ap_key, sizeof hs->client_ap_key,
+                            hs->client_ap_iv)) {
+        goto done;
+    }
+    /* The client will MAC the same transcript with its own finished key. */
+    tls_finished_verify_data(c_finished_key, th, hs->expected_client_finished);
+
+    /* 8. Seal the flight as one protected record (server handshake key, seq 0),
+     * appended after the ServerHello record. */
+    if (!tls_record_seal(server_hs_key, server_hs_iv, 0, TLS_CONTENT_HANDSHAKE,
+                         flight, flight_len, 0, out + out_used, out_cap - out_used,
+                         &rec_len)) {
+        goto done;   /* flight too large or `out` too small -> internal_error */
+    }
+    out_used += rec_len;
+
+    if (out_len != NULL) {
+        *out_len = out_used;
+    }
+    hs->phase = TLS_SERVER_HS_WAIT_FINISHED;
+    ok = 1;
+
+done:
+    secure_zero(ecdhe, sizeof ecdhe);
+    secure_zero(early_secret, sizeof early_secret);
+    secure_zero(derived, sizeof derived);
+    secure_zero(derived2, sizeof derived2);
+    secure_zero(handshake_secret, sizeof handshake_secret);
+    secure_zero(master_secret, sizeof master_secret);
+    secure_zero(c_hs_secret, sizeof c_hs_secret);
+    secure_zero(s_hs_secret, sizeof s_hs_secret);
+    secure_zero(server_hs_key, sizeof server_hs_key);
+    secure_zero(server_hs_iv, sizeof server_hs_iv);
+    secure_zero(s_finished_key, sizeof s_finished_key);
+    secure_zero(c_finished_key, sizeof c_finished_key);
+    secure_zero(c_ap_secret, sizeof c_ap_secret);
+    secure_zero(s_ap_secret, sizeof s_ap_secret);
+    secure_zero(verify_data, sizeof verify_data);
+    secure_zero(flight, sizeof flight);
+    /* transcript, th, cv_sig, server_pub, empty_hash are non-secret (hashes of and
+     * signatures over public handshake messages); left as-is. */
+
+    if (!ok) {
+        return fail(hs, alert);   /* fail-closed: FAILED + alert + wipe hs secrets */
+    }
+    return 1;
+}
+
+int tls_server_hs_read_client_finished(tls_server_hs_t *hs,
+                                        const uint8_t *rec, size_t rec_len) {
+    uint8_t plain[TLS_CLIENT_FIN_PLAINTEXT_CAP];
+    size_t content_len = 0;
+    uint8_t content_type = 0;
+    uint32_t body_len;
+    uint8_t alert = TLS_ALERT_INTERNAL_ERROR;
+    int ok = 0;
+
+    if (hs == NULL) {
+        return 0;
+    }
+    /* Phase gate: the client Finished is accepted only after we have sent our flight. */
+    if (hs->phase != TLS_SERVER_HS_WAIT_FINISHED) {
+        uint8_t a = (hs->phase == TLS_SERVER_HS_FAILED) ? hs->alert
+                                                        : TLS_ALERT_UNEXPECTED_MESSAGE;
+        return fail(hs, a);
+    }
+    if (rec == NULL) {
+        return fail(hs, TLS_ALERT_UNEXPECTED_MESSAGE);
+    }
+
+    /* Deprotect with the client handshake key (its first protected record, seq 0). */
+    if (!tls_record_open(hs->client_hs_key, hs->client_hs_iv, 0, rec, rec_len,
+                         plain, sizeof plain, &content_len, &content_type)) {
+        alert = TLS_ALERT_BAD_RECORD_MAC;      /* AEAD failure / malformed record */
+        goto done;
+    }
+    if (content_type != TLS_CONTENT_HANDSHAKE) {
+        alert = TLS_ALERT_UNEXPECTED_MESSAGE;
+        goto done;
+    }
+    /* Exactly one Finished message: type(1) || uint24 len(==32) || 32-byte verify_data. */
+    if (content_len != 4 + 32) {
+        alert = TLS_ALERT_DECODE_ERROR;
+        goto done;
+    }
+    if (plain[0] != TLS_HS_FINISHED) {
+        alert = TLS_ALERT_UNEXPECTED_MESSAGE;
+        goto done;
+    }
+    body_len = ((uint32_t)plain[1] << 16) | ((uint32_t)plain[2] << 8) | (uint32_t)plain[3];
+    if (body_len != 32) {
+        alert = TLS_ALERT_DECODE_ERROR;
+        goto done;
+    }
+    /* Constant-time verify_data check. A mismatch is an invalid Finished
+     * (RFC 8446 §6.2 decrypt_error), the crux of key confirmation. */
+    if (!secure_compare(plain + 4, hs->expected_client_finished, 32)) {
+        alert = TLS_ALERT_DECRYPT_ERROR;
+        goto done;
+    }
+    ok = 1;
+
+done:
+    secure_zero(plain, sizeof plain);
+    if (!ok) {
+        return fail(hs, alert);
+    }
+    /* Handshake complete. The client handshake key and the expected verify_data are
+     * no longer needed; only the application keys remain (released via app_keys). */
+    secure_zero(hs->client_hs_key, sizeof hs->client_hs_key);
+    secure_zero(hs->client_hs_iv, sizeof hs->client_hs_iv);
+    secure_zero(hs->expected_client_finished, sizeof hs->expected_client_finished);
+    hs->phase = TLS_SERVER_HS_DONE;
+    hs->alert = 0;
+    return 1;
+}
+
+int tls_server_hs_app_keys(const tls_server_hs_t *hs,
+                           uint8_t server_key[32], uint8_t server_iv[12],
+                           uint8_t client_key[32], uint8_t client_iv[12]) {
+    if (hs == NULL || hs->phase != TLS_SERVER_HS_DONE) {
+        return 0;   /* keys unreadable until the client Finished has been verified */
+    }
+    if (server_key != NULL) {
+        memcpy(server_key, hs->server_ap_key, sizeof hs->server_ap_key);
+    }
+    if (server_iv != NULL) {
+        memcpy(server_iv, hs->server_ap_iv, sizeof hs->server_ap_iv);
+    }
+    if (client_key != NULL) {
+        memcpy(client_key, hs->client_ap_key, sizeof hs->client_ap_key);
+    }
+    if (client_iv != NULL) {
+        memcpy(client_iv, hs->client_ap_iv, sizeof hs->client_ap_iv);
+    }
+    return 1;
+}
+
+tls_server_hs_phase_t tls_server_hs_phase(const tls_server_hs_t *hs) {
+    return (hs == NULL) ? TLS_SERVER_HS_FAILED : hs->phase;
+}
+
+uint8_t tls_server_hs_alert(const tls_server_hs_t *hs) {
+    return (hs == NULL) ? 0 : hs->alert;
+}
+
+void tls_server_hs_wipe(tls_server_hs_t *hs) {
+    if (hs == NULL) {
+        return;
+    }
+    secure_zero(hs->client_hs_key, sizeof hs->client_hs_key);
+    secure_zero(hs->client_hs_iv, sizeof hs->client_hs_iv);
+    secure_zero(hs->expected_client_finished, sizeof hs->expected_client_finished);
+    secure_zero(hs->server_ap_key, sizeof hs->server_ap_key);
+    secure_zero(hs->server_ap_iv, sizeof hs->server_ap_iv);
+    secure_zero(hs->client_ap_key, sizeof hs->client_ap_key);
+    secure_zero(hs->client_ap_iv, sizeof hs->client_ap_iv);
+    hs->phase = TLS_SERVER_HS_FAILED;
+    hs->alert = 0;
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/server_handshake.h
+++ b/src/tls/server_handshake.h
@@ -1,0 +1,197 @@
+/*
+ * server_handshake.h — TLS 1.3 server handshake state machine (RFC 8446 §4).
+ * EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON. This is the driver that turns the verified primitives
+ * (X25519, the key schedule, the record layer, the message builders/parsers and
+ * the handshake-auth crypto) into a live 1-RTT TLS 1.3 handshake for the
+ * TLS_CHACHA20_POLY1305_SHA256 + X25519 + Ed25519 profile.
+ *
+ * SECURITY NOTE. The handshake state machine — not the primitives — is where the
+ * serious TLS vulnerabilities have historically lived: state-confusion attacks,
+ * skipped authentication, out-of-order or replayed messages. This module is built
+ * so those *classes* cannot occur rather than merely trying to avoid them:
+ *
+ *   - An explicit phase enum gates every entry point. Each event is accepted in
+ *     exactly one phase; anything else latches a terminal FAILED phase. A message
+ *     can never be processed twice and phases never move backwards.
+ *   - The handshake only reaches DONE after the client's Finished has been
+ *     deprotected and its verify_data matched in constant time. Application keys
+ *     are unreadable until then, so key confirmation can never be skipped.
+ *   - Every error path is fail-closed: it latches FAILED, records the RFC 8446
+ *     alert to send, and wipes all secret material before returning.
+ *   - The computed X25519 shared secret is rejected if all-zero (RFC 8446 §7.4.2),
+ *     defeating small-subgroup / degenerate-key inputs.
+ *
+ * SCOPE / KNOWN LIMITATIONS (this phase — all documented, none silent):
+ *   - Full 1-RTT handshake only. No HelloRetryRequest: a ClientHello that does not
+ *     already carry an X25519 key_share is rejected with handshake_failure rather
+ *     than negotiated down via HRR.
+ *   - No client authentication (no CertificateRequest), no session resumption / PSK,
+ *     no early data, no KeyUpdate.
+ *   - The whole server flight {EncryptedExtensions, Certificate, CertificateVerify,
+ *     Finished} is assembled in a 4 KiB buffer and emitted as a single protected
+ *     record; a certificate too large to fit (comfortably larger than any single
+ *     Ed25519 or RSA certificate) is rejected with internal_error rather than
+ *     fragmented across records.
+ *   - ChangeCipherSpec (RFC 8446 §D.4 middlebox compatibility) is a record-layer /
+ *     transport concern: such records are never delivered to this state machine and
+ *     are excluded from the handshake transcript.
+ *
+ * Determinism. The server's ephemeral X25519 private key and the ServerHello random
+ * are supplied by the caller (tls_server_config_t) so the handshake is fully
+ * reproducible under test. In production the transport wrapper MUST fill both with
+ * fresh CSPRNG output (secure_random_bytes) for every handshake — reusing an
+ * ephemeral key across handshakes destroys forward secrecy.
+ *
+ * Verified in tests/test_tls_parse.c against an independent Python (`cryptography`)
+ * TLS-1.3 client oracle and a self-consistent in-process client simulation.
+ */
+#ifndef WEBLIB_TLS_SERVER_HANDSHAKE_H
+#define WEBLIB_TLS_SERVER_HANDSHAKE_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* ---- alerts we may raise (RFC 8446 §6) --------------------------------- */
+#define TLS_ALERT_UNEXPECTED_MESSAGE 10
+#define TLS_ALERT_BAD_RECORD_MAC     20
+#define TLS_ALERT_HANDSHAKE_FAILURE  40
+#define TLS_ALERT_ILLEGAL_PARAMETER  47
+#define TLS_ALERT_DECODE_ERROR       50
+#define TLS_ALERT_DECRYPT_ERROR      51
+#define TLS_ALERT_PROTOCOL_VERSION   70
+#define TLS_ALERT_INTERNAL_ERROR     80
+
+/* ---- phases ------------------------------------------------------------ */
+/*
+ * The single source of truth for "what will I accept now". Phases only advance
+ * START -> WAIT_FINISHED -> DONE on success; any error jumps to FAILED, which is
+ * terminal (every entry point refuses to do further work once FAILED).
+ */
+typedef enum {
+    TLS_SERVER_HS_START = 0,     /* awaiting ClientHello */
+    TLS_SERVER_HS_WAIT_FINISHED, /* server flight emitted; awaiting client Finished */
+    TLS_SERVER_HS_DONE,          /* client Finished verified; application keys ready */
+    TLS_SERVER_HS_FAILED         /* terminal error; all secrets wiped */
+} tls_server_hs_phase_t;
+
+/* ---- per-handshake configuration (borrowed by read_client_hello) ------- */
+/*
+ * All fields are consumed entirely within tls_server_hs_read_client_hello and are
+ * only borrowed for the duration of that call — none are copied into the handshake
+ * struct, so the long-term signing key never outlives the caller's control. Every
+ * pointer must be non-NULL and name a buffer of the documented length.
+ */
+typedef struct {
+    const uint8_t *cert_der;    /* server certificate, DER (a single X.509 cert) */
+    size_t         cert_len;
+    const uint8_t *ed25519_seed;   /* 32-byte Ed25519 private seed (signs CertificateVerify) */
+    const uint8_t *ed25519_pub;    /* 32-byte Ed25519 public key matching the seed */
+    const uint8_t *server_eph_sk;  /* 32-byte ephemeral X25519 private key (CSPRNG in prod) */
+    const uint8_t *server_random;  /* 32-byte ServerHello random (CSPRNG in prod) */
+} tls_server_config_t;
+
+/* ---- handshake state --------------------------------------------------- */
+/*
+ * Opaque-by-convention: allocate one, drive it with the functions below, do not
+ * read or write the fields directly. It holds only what is needed after the server
+ * flight is sent — the client handshake-read key (to deprotect the client
+ * Finished), the expected client Finished verify_data, and the derived application
+ * traffic keys — so no key-schedule intermediate or long-term secret persists here.
+ */
+typedef struct {
+    tls_server_hs_phase_t phase;
+    uint8_t  alert;   /* RFC 8446 alert to send if phase == FAILED, else 0 */
+
+    uint8_t  client_hs_key[32];   /* client handshake traffic key (opens client Finished) */
+    uint8_t  client_hs_iv[12];
+    uint8_t  expected_client_finished[32];  /* verify_data the client must present */
+
+    uint8_t  server_ap_key[32];   /* application traffic keys, released only in DONE */
+    uint8_t  server_ap_iv[12];
+    uint8_t  client_ap_key[32];
+    uint8_t  client_ap_iv[12];
+} tls_server_hs_t;
+
+/*
+ * Initialize a handshake to phase START. Must be called before any other entry
+ * point. Does not retain any pointer.
+ */
+void tls_server_hs_init(tls_server_hs_t *hs);
+
+/*
+ * Event 1 — process the ClientHello.
+ *
+ * `ch_msg`/`ch_len` is the ClientHello *handshake message* (HandshakeType ||
+ * uint24 length || body), i.e. the record payload with the 5-byte record header
+ * already stripped by the transport. `cfg` supplies the server identity and the
+ * injected ephemeral/random.
+ *
+ * On success (phase START only): validates the offered parameters, performs the
+ * X25519 key agreement (with the §7.4.2 all-zero check), runs the key schedule,
+ * builds and transcript-absorbs the server flight, and writes the response to
+ * `out` (capacity `out_cap`), setting *out_len to its length. The response is:
+ *
+ *     ServerHello record  (TLSPlaintext, ContentType handshake)
+ *   || protected flight   (one TLSCiphertext, ContentType application_data,
+ *                          sealing {EncryptedExtensions, Certificate,
+ *                          CertificateVerify, Finished})
+ *
+ * Advances START -> WAIT_FINISHED and returns 1.
+ *
+ * On any failure returns 0, latches phase FAILED, sets the alert (query with
+ * tls_server_hs_alert), leaves *out_len 0, and wipes every secret. Calling in any
+ * phase other than START is itself a failure (unexpected_message).
+ */
+int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
+                                     const tls_server_config_t *cfg,
+                                     const uint8_t *ch_msg, size_t ch_len,
+                                     uint8_t *out, size_t out_cap, size_t *out_len);
+
+/*
+ * Event 2 — process the client's Finished.
+ *
+ * `rec`/`rec_len` is the single protected record (TLSCiphertext) the client sends
+ * after the server flight. Deprotects it with the client handshake key, requires
+ * it to be exactly one Finished handshake message, and compares its verify_data to
+ * the expected value in constant time.
+ *
+ * On success (phase WAIT_FINISHED only): advances WAIT_FINISHED -> DONE and returns
+ * 1; the application traffic keys become available via tls_server_hs_app_keys.
+ *
+ * On any failure returns 0, latches FAILED, sets the alert, and wipes every secret.
+ * Distinguishes the failure via the alert: bad_record_mac (deprotection failed),
+ * unexpected_message (not a handshake / not a Finished), decode_error (malformed),
+ * decrypt_error (verify_data mismatch). Calling outside WAIT_FINISHED is a failure
+ * (unexpected_message).
+ */
+int tls_server_hs_read_client_finished(tls_server_hs_t *hs,
+                                        const uint8_t *rec, size_t rec_len);
+
+/*
+ * Copy out the derived application traffic keys/IVs. Returns 1 only in phase DONE
+ * (so keys are unreadable until the client Finished has been verified); otherwise
+ * returns 0 and writes nothing. Any out pointer may be NULL to skip it.
+ */
+int tls_server_hs_app_keys(const tls_server_hs_t *hs,
+                           uint8_t server_key[32], uint8_t server_iv[12],
+                           uint8_t client_key[32], uint8_t client_iv[12]);
+
+/* Current phase. */
+tls_server_hs_phase_t tls_server_hs_phase(const tls_server_hs_t *hs);
+
+/* The alert to send after a failure (0 if not FAILED). */
+uint8_t tls_server_hs_alert(const tls_server_hs_t *hs);
+
+/*
+ * Wipe all secret material and latch FAILED. Idempotent; call when discarding a
+ * handshake so no key lingers in the freed struct.
+ */
+void tls_server_hs_wipe(tls_server_hs_t *hs);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_SERVER_HANDSHAKE_H */

--- a/src/tls/server_handshake.h
+++ b/src/tls/server_handshake.h
@@ -134,7 +134,9 @@ void tls_server_hs_init(tls_server_hs_t *hs);
  * On success (phase START only): validates the offered parameters, performs the
  * X25519 key agreement (with the §7.4.2 all-zero check), runs the key schedule,
  * builds and transcript-absorbs the server flight, and writes the response to
- * `out` (capacity `out_cap`), setting *out_len to its length. The response is:
+ * `out` (capacity `out_cap`), setting *out_len to its length. `out` and `out_len`
+ * must be non-NULL — a NULL `out_len` is rejected with internal_error so a caller
+ * always learns the response length. The response is:
  *
  *     ServerHello record  (TLSPlaintext, ContentType handshake)
  *   || protected flight   (one TLSCiphertext, ContentType application_data,

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -18,6 +18,8 @@
 #include "ed25519.h"
 #include "wire.h"
 #include "handshake.h"
+#include "record.h"
+#include "server_handshake.h"
 #endif
 
 static int g_failures = 0;
@@ -666,6 +668,357 @@ static void test_hs_build(void) {
     check_true("hs build: over-long session_id rejected",
                tls_build_server_hello(&w, random, sid, 33, pub) == 0);
 }
+
+/*
+ * Server handshake state machine. The known-answer vectors below (KAT_*) are
+ * produced by an independent Python (`cryptography`) TLS-1.3 client oracle from a
+ * set of fixed inputs — see the commit for scratchpad/server_hs_oracle.py. That
+ * oracle re-derives the whole key schedule (pure-Python HKDF + the RFC labels) and
+ * flight, and separately opens and verifies this C server's actual output. Pinning
+ * its results here means the assertions below are checked against a *different*
+ * implementation, not merely against ourselves.
+ */
+static const uint8_t KAT_CH[144] = {
+    0x01, 0x00, 0x00, 0x8c, 0x03, 0x03, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0x20, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+    0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x00,
+    0x02, 0x13, 0x03, 0x01, 0x00, 0x00, 0x41, 0x00, 0x2b, 0x00, 0x03, 0x02,
+    0x03, 0x04, 0x00, 0x0a, 0x00, 0x04, 0x00, 0x02, 0x00, 0x1d, 0x00, 0x0d,
+    0x00, 0x04, 0x00, 0x02, 0x08, 0x07, 0x00, 0x33, 0x00, 0x26, 0x00, 0x24,
+    0x00, 0x1d, 0x00, 0x20, 0x79, 0xa6, 0x31, 0xee, 0xde, 0x1b, 0xf9, 0xc9,
+    0x8f, 0x12, 0x03, 0x2c, 0xde, 0xad, 0xd0, 0xe7, 0xa0, 0x79, 0x39, 0x8f,
+    0xc7, 0x86, 0xb8, 0x8c, 0xc8, 0x46, 0xec, 0x89, 0xaf, 0x85, 0xa5, 0x1a,
+};
+static const uint8_t KAT_CERT[96] = {
+    0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab,
+    0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7,
+    0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xa0, 0xa1, 0xa2, 0xa3,
+    0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+    0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb,
+    0xbc, 0xbd, 0xbe, 0xbf, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+    0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3,
+    0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf,
+};
+static const uint8_t KAT_ED_SEED[32] = {
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+    0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+};
+static const uint8_t KAT_ED_PUB[32] = {
+    0x79, 0xb5, 0x56, 0x2e, 0x8f, 0xe6, 0x54, 0xf9, 0x40, 0x78, 0xb1, 0x12,
+    0xe8, 0xa9, 0x8b, 0xa7, 0x90, 0x1f, 0x85, 0x3a, 0xe6, 0x95, 0xbe, 0xd7,
+    0xe0, 0xe3, 0x91, 0x0b, 0xad, 0x04, 0x96, 0x64,
+};
+static const uint8_t KAT_SERVER_EPH[32] = {
+    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b,
+    0x6c, 0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77,
+    0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+};
+static const uint8_t KAT_SERVER_RND[32] = {
+    0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e,
+    0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e,
+    0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e,
+};
+static const uint8_t KAT_SERVER_HS_KEY[32] = {
+    0x41, 0xc1, 0xe2, 0xdb, 0x19, 0x3b, 0xc8, 0x84, 0x1e, 0xb5, 0xc6, 0x4a,
+    0xe3, 0x08, 0x09, 0x30, 0x6e, 0x8a, 0xc8, 0x2e, 0x33, 0xc7, 0xd5, 0xfe,
+    0x64, 0xce, 0x20, 0x6f, 0x2f, 0x32, 0xd6, 0xa4,
+};
+static const uint8_t KAT_SERVER_HS_IV[12] = {
+    0x38, 0x9c, 0xa9, 0x76, 0x72, 0x06, 0x7e, 0x0c, 0x73, 0x31, 0xf0, 0x64,
+};
+static const uint8_t KAT_CLIENT_HS_KEY[32] = {
+    0x5d, 0x09, 0xb3, 0x22, 0x93, 0x47, 0xca, 0x9f, 0x67, 0x0f, 0x6b, 0x98,
+    0x8d, 0x30, 0xdc, 0xa3, 0x4f, 0xc4, 0x45, 0x77, 0x05, 0xf4, 0x5d, 0x30,
+    0xd2, 0xb5, 0x19, 0x39, 0x5f, 0x0b, 0x85, 0xd2,
+};
+static const uint8_t KAT_CLIENT_HS_IV[12] = {
+    0xa3, 0x18, 0xa3, 0xeb, 0x91, 0x9e, 0xb2, 0x74, 0x50, 0x5a, 0x6c, 0x9b,
+};
+static const uint8_t KAT_CLIENT_FINISHED_VD[32] = {
+    0xa3, 0xb6, 0x47, 0x2e, 0xd7, 0x60, 0xfd, 0xb0, 0xc3, 0x55, 0x79, 0xf0,
+    0x8e, 0xdb, 0x75, 0xbc, 0x87, 0x59, 0x9e, 0xa8, 0x51, 0xd1, 0x93, 0x22,
+    0x85, 0xce, 0x6f, 0x29, 0x0d, 0x0b, 0xf7, 0x4f,
+};
+static const uint8_t KAT_SERVER_AP_KEY[32] = {
+    0x36, 0xe0, 0x70, 0xfc, 0x68, 0xdd, 0xab, 0x6d, 0xa2, 0x8f, 0xa6, 0x3b,
+    0xe1, 0xac, 0x73, 0x6b, 0x01, 0x63, 0x57, 0xb7, 0xe2, 0x3c, 0x72, 0x8a,
+    0x0e, 0xdd, 0x46, 0x05, 0xe7, 0xc3, 0xf4, 0x1d,
+};
+static const uint8_t KAT_SERVER_AP_IV[12] = {
+    0x39, 0x6b, 0x0d, 0x59, 0xec, 0xb3, 0x89, 0x34, 0x53, 0x87, 0x4a, 0xa4,
+};
+static const uint8_t KAT_CLIENT_AP_KEY[32] = {
+    0x28, 0xc8, 0x92, 0x97, 0x21, 0xfa, 0x74, 0x2e, 0xc8, 0x0a, 0x78, 0x1b,
+    0xed, 0xa8, 0x12, 0x2d, 0x28, 0xad, 0x03, 0xc3, 0x04, 0xdc, 0x8d, 0x8b,
+    0x07, 0xa6, 0xbe, 0x6a, 0x35, 0x76, 0x8e, 0xa4,
+};
+static const uint8_t KAT_CLIENT_AP_IV[12] = {
+    0xa3, 0xd7, 0xd4, 0x06, 0x4c, 0x40, 0x49, 0xc6, 0xab, 0x8a, 0x76, 0xc5,
+};
+static const uint8_t KAT_FLIGHT_PLAIN[223] = {
+    0x08, 0x00, 0x00, 0x02, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x69, 0x00, 0x00,
+    0x00, 0x65, 0x00, 0x00, 0x60, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6,
+    0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2,
+    0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe,
+    0xbf, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa,
+    0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6,
+    0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xa0, 0xa1, 0xa2,
+    0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae,
+    0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba,
+    0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x44, 0x08,
+    0x07, 0x00, 0x40, 0x77, 0x8d, 0xea, 0x16, 0xcf, 0xc9, 0x85, 0x9d, 0x19,
+    0x57, 0x68, 0x5b, 0xd3, 0x1e, 0x13, 0x57, 0xe3, 0xae, 0x8b, 0xc5, 0xdb,
+    0x43, 0xa6, 0xbd, 0x94, 0xd9, 0x7c, 0x49, 0x75, 0xfe, 0xc1, 0xdb, 0x73,
+    0x0e, 0x2b, 0x2a, 0x9f, 0x57, 0x33, 0x83, 0x3d, 0x85, 0xe6, 0xb9, 0x81,
+    0x0b, 0x2e, 0x4f, 0xa8, 0x2d, 0x95, 0xb7, 0xee, 0x28, 0x28, 0x60, 0xdf,
+    0x11, 0x36, 0x16, 0xdd, 0x24, 0xc9, 0x0b, 0x14, 0x00, 0x00, 0x20, 0x20,
+    0x8c, 0x72, 0xcc, 0xea, 0x25, 0xc2, 0x4c, 0x0a, 0xa9, 0x7f, 0x3d, 0x06,
+    0x7f, 0xa3, 0x7b, 0x29, 0xcf, 0xb4, 0x6f, 0xfb, 0xe4, 0x0e, 0xa3, 0x02,
+    0xc0, 0x68, 0xa1, 0x2d, 0xba, 0xb5, 0xe3,
+};
+
+/* Find the first occurrence of `needle` in `hay` (portable; avoids memmem). */
+static long find_bytes(const uint8_t *hay, size_t hn, const uint8_t *needle, size_t nn) {
+    size_t i;
+    if (nn == 0 || hn < nn) {
+        return -1;
+    }
+    for (i = 0; i + nn <= hn; i++) {
+        if (memcmp(hay + i, needle, nn) == 0) {
+            return (long)i;
+        }
+    }
+    return -1;
+}
+
+/* Seal a client Finished { type(20) || u24 len(32) || verify_data } record with
+ * the given client handshake key/IV at sequence 0 (what a real client sends). */
+static int seal_client_finished(const uint8_t *vd, uint8_t *rec, size_t rec_cap,
+                                size_t *rec_len) {
+    uint8_t msg[4 + 32];
+    msg[0] = TLS_HS_FINISHED;
+    msg[1] = 0x00;
+    msg[2] = 0x00;
+    msg[3] = 0x20;
+    memcpy(msg + 4, vd, 32);
+    return tls_record_seal(KAT_CLIENT_HS_KEY, KAT_CLIENT_HS_IV, 0,
+                           TLS_CONTENT_HANDSHAKE, msg, sizeof msg, 0,
+                           rec, rec_cap, rec_len);
+}
+
+/* Copy KAT_CH, overwrite `repl` at the offset of `pat`, feed it, and require the
+ * handshake to reject it with `expect_alert` and latch FAILED. */
+static void check_ch_reject(const char *label, const tls_server_config_t *cfg,
+                            const uint8_t *pat, size_t patn, size_t rel,
+                            const uint8_t *repl, size_t repln, uint8_t expect_alert) {
+    uint8_t ch[sizeof KAT_CH];
+    uint8_t out[2048];
+    size_t out_len = 0;
+    tls_server_hs_t hs;
+    long off;
+
+    memcpy(ch, KAT_CH, sizeof KAT_CH);
+    off = find_bytes(ch, sizeof ch, pat, patn);
+    if (off < 0 || (size_t)off + rel + repln > sizeof ch) {
+        check_true(label, 0);   /* the anchor pattern must exist */
+        return;
+    }
+    memcpy(ch + off + rel, repl, repln);
+    tls_server_hs_init(&hs);
+    check_true(label,
+               tls_server_hs_read_client_hello(&hs, cfg, ch, sizeof ch,
+                                                out, sizeof out, &out_len) == 0
+               && tls_server_hs_alert(&hs) == expect_alert
+               && tls_server_hs_phase(&hs) == TLS_SERVER_HS_FAILED
+               && out_len == 0);
+}
+
+static void test_server_handshake(void) {
+    tls_server_hs_t hs;
+    tls_server_config_t cfg;
+    uint8_t out[2048];
+    size_t out_len = 0;
+    size_t sh_len, rec_off;
+    uint8_t flight[512];
+    size_t flen = 0;
+    uint8_t ctype = 0;
+    uint8_t rec[128];
+    size_t rec_len = 0;
+    uint8_t sk[32], siv[12], ck[32], civ[12];
+
+    memset(&cfg, 0, sizeof cfg);
+    cfg.cert_der = KAT_CERT;
+    cfg.cert_len = sizeof KAT_CERT;
+    cfg.ed25519_seed = KAT_ED_SEED;
+    cfg.ed25519_pub = KAT_ED_PUB;
+    cfg.server_eph_sk = KAT_SERVER_EPH;
+    cfg.server_random = KAT_SERVER_RND;
+
+    /* ===== Part A: a full handshake, checked against the independent oracle ===== */
+    tls_server_hs_init(&hs);
+    check_true("srv hs: initial phase START",
+               tls_server_hs_phase(&hs) == TLS_SERVER_HS_START);
+
+    check_true("srv hs: ClientHello accepted",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH, sizeof KAT_CH,
+                                               out, sizeof out, &out_len) == 1);
+    check_true("srv hs: phase -> WAIT_FINISHED",
+               tls_server_hs_phase(&hs) == TLS_SERVER_HS_WAIT_FINISHED);
+    /* Authentication cannot be skipped: app keys are withheld until the client
+     * Finished has been verified. */
+    check_true("srv hs: app keys withheld before DONE",
+               tls_server_hs_app_keys(&hs, sk, siv, ck, civ) == 0);
+
+    check_true("srv hs: ServerHello record framed (type 22)",
+               out_len > 5 && out[0] == 0x16 && out[1] == 0x03 && out[2] == 0x03);
+    sh_len = ((size_t)out[3] << 8) | out[4];
+    rec_off = 5 + sh_len;
+    check_true("srv hs: protected flight record follows (type 23)",
+               rec_off < out_len && out[rec_off] == 0x17);
+
+    /* Open the flight with the INDEPENDENTLY-derived server handshake key. Success
+     * proves our ECDH + key schedule + record sealing agree with a separate
+     * implementation, and the plaintext must match byte-for-byte. */
+    check_true("srv hs: flight opens under independent key schedule",
+               tls_record_open(KAT_SERVER_HS_KEY, KAT_SERVER_HS_IV, 0,
+                               out + rec_off, out_len - rec_off,
+                               flight, sizeof flight, &flen, &ctype) == 1);
+    check_true("srv hs: flight inner type handshake", ctype == TLS_CONTENT_HANDSHAKE);
+    check_true("srv hs: flight bytes match independent prediction",
+               flen == sizeof KAT_FLIGHT_PLAIN
+               && memcmp(flight, KAT_FLIGHT_PLAIN, flen) == 0);
+
+    /* Complete: the client returns its Finished (sealed with the independent client
+     * handshake key). */
+    check_true("srv hs: (harness) seal client Finished",
+               seal_client_finished(KAT_CLIENT_FINISHED_VD, rec, sizeof rec, &rec_len) == 1);
+    check_true("srv hs: client Finished verified -> handshake complete",
+               tls_server_hs_read_client_finished(&hs, rec, rec_len) == 1);
+    check_true("srv hs: phase -> DONE", tls_server_hs_phase(&hs) == TLS_SERVER_HS_DONE);
+
+    check_true("srv hs: app keys released after DONE",
+               tls_server_hs_app_keys(&hs, sk, siv, ck, civ) == 1);
+    check_true("srv hs: server app key matches oracle", memcmp(sk, KAT_SERVER_AP_KEY, 32) == 0);
+    check_true("srv hs: server app iv matches oracle", memcmp(siv, KAT_SERVER_AP_IV, 12) == 0);
+    check_true("srv hs: client app key matches oracle", memcmp(ck, KAT_CLIENT_AP_KEY, 32) == 0);
+    check_true("srv hs: client app iv matches oracle", memcmp(civ, KAT_CLIENT_AP_IV, 12) == 0);
+
+    /* A second Finished after DONE is a protocol violation: fail-closed. */
+    check_true("srv hs: second Finished after DONE rejected",
+               tls_server_hs_read_client_finished(&hs, rec, rec_len) == 0
+               && tls_server_hs_phase(&hs) == TLS_SERVER_HS_FAILED);
+    check_true("srv hs: app keys withheld once FAILED",
+               tls_server_hs_app_keys(&hs, sk, siv, ck, civ) == 0);
+
+    /* ===== Part B: sequencing / state-machine defences ===== */
+    /* B1: ClientHello replayed after we advanced -> unexpected_message + terminal. */
+    tls_server_hs_init(&hs);
+    tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH, sizeof KAT_CH, out, sizeof out, &out_len);
+    check_true("srv hs: replayed ClientHello rejected",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH, sizeof KAT_CH,
+                                               out, sizeof out, &out_len) == 0
+               && tls_server_hs_alert(&hs) == TLS_ALERT_UNEXPECTED_MESSAGE
+               && tls_server_hs_phase(&hs) == TLS_SERVER_HS_FAILED);
+    check_true("srv hs: FAILED is terminal",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH, sizeof KAT_CH,
+                                               out, sizeof out, &out_len) == 0
+               && tls_server_hs_phase(&hs) == TLS_SERVER_HS_FAILED);
+
+    /* B2: client Finished before any ClientHello -> unexpected_message. */
+    tls_server_hs_init(&hs);
+    seal_client_finished(KAT_CLIENT_FINISHED_VD, rec, sizeof rec, &rec_len);
+    check_true("srv hs: Finished before ClientHello rejected",
+               tls_server_hs_read_client_finished(&hs, rec, rec_len) == 0
+               && tls_server_hs_alert(&hs) == TLS_ALERT_UNEXPECTED_MESSAGE);
+
+    /* B3: truncated ClientHello -> decode_error. */
+    tls_server_hs_init(&hs);
+    check_true("srv hs: truncated ClientHello -> decode_error",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH, 20,
+                                               out, sizeof out, &out_len) == 0
+               && tls_server_hs_alert(&hs) == TLS_ALERT_DECODE_ERROR);
+
+    /* B4: undersized output buffer -> internal_error (fail-closed, not a crash). */
+    tls_server_hs_init(&hs);
+    check_true("srv hs: tiny out buffer -> internal_error",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH, sizeof KAT_CH,
+                                               out, 10, &out_len) == 0
+               && tls_server_hs_alert(&hs) == TLS_ALERT_INTERNAL_ERROR);
+
+    /* ===== Part C: parameter negotiation (correct alerts) ===== */
+    {
+        static const uint8_t p_ver[]  = {0x00,0x2b,0x00,0x03,0x02,0x03,0x04};
+        static const uint8_t r_ver[]  = {0x03,0x03};   /* TLS 1.2, not 1.3 */
+        static const uint8_t p_suite[]= {0x00,0x02,0x13,0x03,0x01,0x00};
+        static const uint8_t r_suite[]= {0x13,0x01};   /* AES-128-GCM, not ChaCha20 */
+        static const uint8_t p_sig[]  = {0x00,0x0d,0x00,0x04,0x00,0x02,0x08,0x07};
+        static const uint8_t r_sig[]  = {0x08,0x08};   /* ed448, not ed25519 */
+        static const uint8_t p_ks[]   = {0x00,0x33,0x00,0x26,0x00,0x24,0x00,0x1d,0x00,0x20};
+        static const uint8_t r_ks[]   = {0x00,0x1e};   /* wrong key_share group -> no X25519 share */
+        check_ch_reject("srv hs: no TLS 1.3 -> protocol_version", &cfg,
+                        p_ver, sizeof p_ver, 5, r_ver, sizeof r_ver,
+                        TLS_ALERT_PROTOCOL_VERSION);
+        check_ch_reject("srv hs: no ChaCha20 suite -> handshake_failure", &cfg,
+                        p_suite, sizeof p_suite, 2, r_suite, sizeof r_suite,
+                        TLS_ALERT_HANDSHAKE_FAILURE);
+        check_ch_reject("srv hs: no ed25519 -> handshake_failure", &cfg,
+                        p_sig, sizeof p_sig, 6, r_sig, sizeof r_sig,
+                        TLS_ALERT_HANDSHAKE_FAILURE);
+        check_ch_reject("srv hs: no X25519 key_share -> handshake_failure", &cfg,
+                        p_ks, sizeof p_ks, 6, r_ks, sizeof r_ks,
+                        TLS_ALERT_HANDSHAKE_FAILURE);
+    }
+
+    /* ===== Part D: cryptographic defences ===== */
+    /* D1: an all-zero (small-order) X25519 share yields an all-zero shared secret,
+     * which RFC 8446 §7.4.2 requires we reject. */
+    {
+        static const uint8_t p_share[] = {0x00,0x1d,0x00,0x20};   /* group + key_exchange len */
+        uint8_t ch[sizeof KAT_CH];
+        long off;
+        memcpy(ch, KAT_CH, sizeof KAT_CH);
+        off = find_bytes(ch, sizeof ch, p_share, sizeof p_share);
+        if (off >= 0 && (size_t)off + 4 + 32 <= sizeof ch) {
+            memset(ch + off + 4, 0x00, 32);   /* all-zero key_exchange */
+        }
+        tls_server_hs_init(&hs);
+        check_true("srv hs: all-zero ECDH share -> illegal_parameter",
+                   tls_server_hs_read_client_hello(&hs, &cfg, ch, sizeof ch,
+                                                   out, sizeof out, &out_len) == 0
+                   && tls_server_hs_alert(&hs) == TLS_ALERT_ILLEGAL_PARAMETER);
+    }
+
+    /* D2: a Finished with the wrong verify_data (but valid AEAD) -> decrypt_error.
+     * This is the key-confirmation check; it must actually compare. */
+    {
+        uint8_t bad[32];
+        memcpy(bad, KAT_CLIENT_FINISHED_VD, 32);
+        bad[0] ^= 0x01;
+        tls_server_hs_init(&hs);
+        tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH, sizeof KAT_CH, out, sizeof out, &out_len);
+        seal_client_finished(bad, rec, sizeof rec, &rec_len);
+        check_true("srv hs: wrong verify_data -> decrypt_error",
+                   tls_server_hs_read_client_finished(&hs, rec, rec_len) == 0
+                   && tls_server_hs_alert(&hs) == TLS_ALERT_DECRYPT_ERROR
+                   && tls_server_hs_phase(&hs) == TLS_SERVER_HS_FAILED);
+    }
+
+    /* D3: a corrupted Finished record (AEAD tag fails) -> bad_record_mac, no
+     * plaintext released. */
+    {
+        tls_server_hs_init(&hs);
+        tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH, sizeof KAT_CH, out, sizeof out, &out_len);
+        seal_client_finished(KAT_CLIENT_FINISHED_VD, rec, sizeof rec, &rec_len);
+        rec[6] ^= 0x80;   /* flip a ciphertext byte (past the 5-byte header) */
+        check_true("srv hs: corrupted Finished record -> bad_record_mac",
+                   tls_server_hs_read_client_finished(&hs, rec, rec_len) == 0
+                   && tls_server_hs_alert(&hs) == TLS_ALERT_BAD_RECORD_MAC);
+    }
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -682,6 +1035,7 @@ int main(void) {
     test_wire();
     test_client_hello();
     test_hs_build();
+    test_server_handshake();
 
     if (g_failures == 0) {
         printf("All TLS parse tests passed.\n");

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -949,6 +949,14 @@ static void test_server_handshake(void) {
                                                out, 10, &out_len) == 0
                && tls_server_hs_alert(&hs) == TLS_ALERT_INTERNAL_ERROR);
 
+    /* B4b: a NULL out_len is a usage error (the caller must always learn the
+     * response length) -> internal_error, never a "successful" unknown-length send. */
+    tls_server_hs_init(&hs);
+    check_true("srv hs: NULL out_len -> internal_error",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH, sizeof KAT_CH,
+                                               out, sizeof out, NULL) == 0
+               && tls_server_hs_alert(&hs) == TLS_ALERT_INTERNAL_ERROR);
+
     /* ===== Part C: parameter negotiation (correct alerts) ===== */
     {
         static const uint8_t p_ver[]  = {0x00,0x2b,0x00,0x03,0x02,0x03,0x04};
@@ -982,14 +990,19 @@ static void test_server_handshake(void) {
         long off;
         memcpy(ch, KAT_CH, sizeof KAT_CH);
         off = find_bytes(ch, sizeof ch, p_share, sizeof p_share);
-        if (off >= 0 && (size_t)off + 4 + 32 <= sizeof ch) {
+        if (off < 0 || (size_t)off + 4 + 32 > sizeof ch) {
+            /* The anchor must exist. Without this guard, a ClientHello-layout change
+             * would leave the share unmodified and the test would fail with a
+             * misleading alert mismatch instead of a clear "anchor missing". */
+            check_true("srv hs: all-zero ECDH share test anchor located", 0);
+        } else {
             memset(ch + off + 4, 0x00, 32);   /* all-zero key_exchange */
+            tls_server_hs_init(&hs);
+            check_true("srv hs: all-zero ECDH share -> illegal_parameter",
+                       tls_server_hs_read_client_hello(&hs, &cfg, ch, sizeof ch,
+                                                       out, sizeof out, &out_len) == 0
+                       && tls_server_hs_alert(&hs) == TLS_ALERT_ILLEGAL_PARAMETER);
         }
-        tls_server_hs_init(&hs);
-        check_true("srv hs: all-zero ECDH share -> illegal_parameter",
-                   tls_server_hs_read_client_hello(&hs, &cfg, ch, sizeof ch,
-                                                   out, sizeof out, &out_len) == 0
-                   && tls_server_hs_alert(&hs) == TLS_ALERT_ILLEGAL_PARAMETER);
     }
 
     /* D2: a Finished with the wrong verify_data (but valid AEAD) -> decrypt_error.


### PR DESCRIPTION
## Summary

The **server handshake state machine** — the driver that sequences the already-merged, RFC-verified TLS 1.3 primitives into a live **1-RTT handshake** for `TLS_CHACHA20_POLY1305_SHA256` + X25519 + Ed25519. This is the culmination of Phase 3.

Flow (`read_client_hello` → `read_client_finished`):
ClientHello validation → X25519 ECDH (+ §7.4.2 all-zero check) → key schedule → build / Ed25519-sign / AEAD-seal the server flight (`EncryptedExtensions`, `Certificate`, `CertificateVerify`, `Finished`) → derive application keys → verify the client Finished (key confirmation).

## Why this is the highest-risk component

The state machine — not the primitives — is where the serious TLS CVEs have historically lived: state-confusion attacks (SMACK/FREAK, CCS injection), skipped authentication, out-of-order/replayed messages. It is designed so those **classes are structurally impossible**, not merely avoided:

- **Sequencing** — an explicit phase enum (`START → WAIT_FINISHED → DONE`, or terminal `FAILED`) gates every entry point. Each message is accepted in exactly one phase; the phase only advances. Replay / out-of-order / post-DONE messages latch `FAILED`.
- **Authentication cannot be skipped** — `DONE`, and the application keys, are released only after the client Finished deprotects and its `verify_data` matches in **constant time** (`secure_compare`).
- **Fail-closed** — every error path latches `FAILED`, records the RFC 8446 alert, and wipes all secret material.
- **Contributory behaviour** — an all-zero X25519 shared secret is rejected (RFC 8446 §7.4.2).
- **Minimal secret lifetime** — the Ed25519 seed and ephemeral key live only in the caller's config and only during `read_client_hello`; the persistent struct holds only what's needed to verify the client Finished and hand out app keys.

## Independent verification

The entire handshake is cross-checked against an **independent Python (`cryptography`) TLS-1.3 client oracle** that re-derives the whole key schedule (pure-Python HKDF + the RFC labels) and separately **opens and verifies this C server's actual output** — the ServerHello, the AEAD-sealed flight, the Ed25519 CertificateVerify, and the server Finished. The pinned known-answer keys in the test therefore certify agreement with a *separate* implementation, not just self-consistency. (Oracle: `scratchpad/server_hs_oracle.py`, kept out of the tree.)

**31 new assertions** (109 total in `TlsParseTests`), covering:
- Full happy-path round trip to `DONE`; flight opens under the independently-derived key and matches byte-for-byte; app keys match the oracle.
- **Adversarial / state-machine:** replayed ClientHello, Finished-before-ClientHello, terminal-`FAILED` latch, second-Finished-after-`DONE`, truncated ClientHello, undersized output buffer.
- **Negotiation alerts:** no TLS 1.3 → `protocol_version`; no ChaCha20 / no Ed25519 / no X25519 key_share → `handshake_failure`.
- **Crypto defences:** all-zero ECDH share → `illegal_parameter`; wrong `verify_data` → `decrypt_error`; corrupted record → `bad_record_mac`.

## Scope / limitations (documented, none silent)

Full 1-RTT only — **no HelloRetryRequest** (a ClientHello without an X25519 key_share gets `handshake_failure`), no client auth, no resumption/PSK/0-RTT/KeyUpdate. The server flight is one protected record (certificate must fit a 4 KiB assembly buffer). ChangeCipherSpec (§D.4) is a transport-layer concern and is excluded from the transcript. The code is **EXPERIMENTAL / UNAUDITED**.

## Verification matrix

- **OFF build (default):** 6/6, no `server_hs` symbols, `server_handshake.c.o` absent — default build unaffected.
- **TLS build:** 9/9.
- **ASan + UBSan** (`halt_on_error=1`): clean.
- **Negative control:** disabling the key-confirmation check makes exactly the `wrong verify_data` test fail; restored.
- Zero warnings (`-Wall -Wextra -pedantic`) on the new/changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)