### PR TITLE
TLS Phase 3: blocking-socket adapter (tls_transport)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(WEBLIB_SOURCES_TLS
     src/tls/handshake_auth.c
     src/tls/server_handshake.c
     src/tls/tls_khannection.c
+    src/tls/tls_transport.c
     src/tls/pem.c
     src/tls/chacha20.c
     src/tls/poly1305.c

--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -58,13 +58,15 @@ ctest --test-dir build-tls
 - **Phase 2:** PEM + minimal ASN.1/DER + X.509 loading.
 - **Phase 3 (landed):** TLS 1.3 key schedule, record layer, handshake messages
   (ClientHello parser + server builders + auth crypto), the server handshake
-  state machine (`server_handshake.c`), and the sans-IO connection engine
+  state machine (`server_handshake.c`), the sans-IO connection engine
   (`tls_khannection.c`) — record framing, handshake driving, and application-data
-  encrypt/decrypt — for the 1-RTT `TLS_CHACHA20_POLY1305_SHA256` + X25519 + Ed25519
-  flow, each cross-checked against an independent Python oracle.
-- **Phase 4 — integration (next):** wire `tls_khannection` into the transport seam
-  (`conn_read`/`conn_write`) and add `http_server_enable_tls`; internal TLS
-  termination validated with a local self-signed cert.
+  encrypt/decrypt — and the blocking-socket adapter (`tls_transport.c`) that drives
+  the engine over a real fd; for the 1-RTT `TLS_CHACHA20_POLY1305_SHA256` + X25519 +
+  Ed25519 flow, each cross-checked against an independent Python oracle (the adapter
+  over an actual socketpair).
+- **Phase 4 — integration (next):** wire `tls_transport` into the threaded server
+  path and add `http_server_enable_tls`; internal TLS termination validated with a
+  local self-signed cert.
 - **Interoperability (separate milestone):** real `curl` / `openssl s_client` /
   browser interop, negotiation edge cases, ClientHello fuzzing, honest security
   labeling — tracked as its own milestone, not folded into integration.

--- a/src/tls/tls_transport.c
+++ b/src/tls/tls_transport.c
@@ -9,6 +9,7 @@
 
 #ifdef WEBLIB_TLS
 
+#include "kamran.k"   /* secure_zero */
 #include <errno.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -20,6 +21,17 @@
 #else
 #define TLS_SEND_FLAGS 0
 #endif
+
+/* Tear down: wipe the engine's key material AND the decrypted application
+ * plaintext buffered here (the strictly-more-sensitive secret — cookies, auth
+ * headers, request bodies), so neither lingers in the freed struct / a core dump.
+ * Idempotent. */
+static void transport_wipe(tls_transport_t *t) {
+    tls_khannection_wipe(&t->conn);
+    secure_zero(t->app, sizeof t->app);
+    t->app_off = 0;
+    t->app_len = 0;
+}
 
 /* Write every byte of `buf` to `fd`, retrying short writes and EINTR. 0 / -1. */
 static int send_all_fd(int fd, const uint8_t *buf, size_t len) {
@@ -57,7 +69,7 @@ static int transport_pump(tls_transport_t *t) {
         n = recv(t->fd, raw, sizeof raw, 0);
     } while (n < 0 && errno == EINTR);
     if (n < 0) {
-        tls_khannection_wipe(&t->conn);   /* fail closed: don't leave keys behind */
+        transport_wipe(t);   /* fail closed */
         return -1;
     }
     if (n == 0) {
@@ -69,12 +81,12 @@ static int transport_pump(tls_transport_t *t) {
                               t->app, sizeof t->app, &app_len);
     if (out_len > 0) {
         if (send_all_fd(t->fd, out, out_len) < 0) {
-            tls_khannection_wipe(&t->conn);
+            transport_wipe(t);
             return -1;
         }
     }
     if (rc == TLS_KHANNECTION_RC_ERROR) {
-        tls_khannection_wipe(&t->conn);   /* idempotent: the engine already wiped */
+        transport_wipe(t);   /* idempotent: the engine already wiped its own state */
         return -1;
     }
     t->app_off = 0;
@@ -106,15 +118,27 @@ int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *
 
     while (tls_khannection_state(&t->conn) == TLS_KHANNECTION_HANDSHAKE) {
         if (transport_pump(t) <= 0) {
-            tls_khannection_wipe(&t->conn);   /* error or EOF mid-handshake: fail closed */
+            transport_wipe(t);   /* error or EOF mid-handshake: fail closed */
             return -1;
         }
     }
-    if (tls_khannection_state(&t->conn) != TLS_KHANNECTION_ESTABLISHED) {
-        tls_khannection_wipe(&t->conn);
-        return -1;
+    /* Success is normally state ESTABLISHED. It is ALSO success if the peer
+     * coalesced its close_notify with (or right after) its Finished in one recv:
+     * the engine then runs HANDSHAKE -> ESTABLISHED -> CLOSED inside a single pump,
+     * so the terminal state is CLOSED. Application bytes can only be produced once
+     * the handshake has established, so a non-empty app buffer proves it completed
+     * and a request was received — keep it rather than discarding the request and
+     * misreporting a completed handshake as a failure. (The peer has closed its
+     * write side; responding to such a half-closed request is not yet supported —
+     * see the header's limitations.) */
+    if (tls_khannection_state(&t->conn) == TLS_KHANNECTION_ESTABLISHED) {
+        return 0;
     }
-    return 0;
+    if (tls_khannection_state(&t->conn) == TLS_KHANNECTION_CLOSED && t->app_len > 0) {
+        return 0;
+    }
+    transport_wipe(t);
+    return -1;
 }
 
 ssize_t tls_transport_read(tls_transport_t *t, void *buf, size_t len) {
@@ -166,11 +190,11 @@ int tls_transport_write(tls_transport_t *t, const void *buf, size_t len) {
         }
         if (tls_khannection_send(&t->conn, p + off, chunk, out, sizeof out, &out_len)
             != TLS_KHANNECTION_RC_OK) {
-            tls_khannection_wipe(&t->conn);   /* fail closed */
+            transport_wipe(t);   /* fail closed */
             return -1;
         }
         if (send_all_fd(t->fd, out, out_len) < 0) {
-            tls_khannection_wipe(&t->conn);
+            transport_wipe(t);
             return -1;
         }
         off += chunk;
@@ -190,9 +214,7 @@ void tls_transport_close(tls_transport_t *t) {
             (void)send_all_fd(t->fd, out, out_len);   /* best effort */
         }
     }
-    tls_khannection_wipe(&t->conn);
-    t->app_off = 0;
-    t->app_len = 0;
+    transport_wipe(t);   /* wipe keys AND any buffered decrypted plaintext */
 }
 
 #endif /* WEBLIB_TLS */

--- a/src/tls/tls_transport.c
+++ b/src/tls/tls_transport.c
@@ -32,6 +32,9 @@ static int send_all_fd(int fd, const uint8_t *buf, size_t len) {
             }
             return -1;
         }
+        if (s == 0) {
+            return -1;   /* a 0-byte send makes no progress: treat as an error, not a spin */
+        }
         off += (size_t)s;
     }
     return 0;
@@ -54,6 +57,7 @@ static int transport_pump(tls_transport_t *t) {
         n = recv(t->fd, raw, sizeof raw, 0);
     } while (n < 0 && errno == EINTR);
     if (n < 0) {
+        tls_khannection_wipe(&t->conn);   /* fail closed: don't leave keys behind */
         return -1;
     }
     if (n == 0) {
@@ -65,10 +69,12 @@ static int transport_pump(tls_transport_t *t) {
                               t->app, sizeof t->app, &app_len);
     if (out_len > 0) {
         if (send_all_fd(t->fd, out, out_len) < 0) {
+            tls_khannection_wipe(&t->conn);
             return -1;
         }
     }
     if (rc == TLS_KHANNECTION_RC_ERROR) {
+        tls_khannection_wipe(&t->conn);   /* idempotent: the engine already wiped */
         return -1;
     }
     t->app_off = 0;
@@ -83,6 +89,15 @@ int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *
     if (t == NULL) {
         return -1;
     }
+#ifdef SO_NOSIGPIPE
+    /* On platforms without MSG_NOSIGNAL (macOS/BSD), a send() to a peer that has
+     * closed would otherwise raise SIGPIPE and kill the process. Suppress it on the
+     * socket itself so the adapter is self-contained (best effort). */
+    {
+        int on = 1;
+        (void)setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof on);
+    }
+#endif
     tls_khannection_init(&t->conn, cfg);
     t->fd = fd;
     t->app_off = 0;
@@ -90,12 +105,16 @@ int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *
     t->eof = 0;
 
     while (tls_khannection_state(&t->conn) == TLS_KHANNECTION_HANDSHAKE) {
-        int r = transport_pump(t);
-        if (r <= 0) {
-            return -1;   /* error, or EOF before the handshake completed */
+        if (transport_pump(t) <= 0) {
+            tls_khannection_wipe(&t->conn);   /* error or EOF mid-handshake: fail closed */
+            return -1;
         }
     }
-    return (tls_khannection_state(&t->conn) == TLS_KHANNECTION_ESTABLISHED) ? 0 : -1;
+    if (tls_khannection_state(&t->conn) != TLS_KHANNECTION_ESTABLISHED) {
+        tls_khannection_wipe(&t->conn);
+        return -1;
+    }
+    return 0;
 }
 
 ssize_t tls_transport_read(tls_transport_t *t, void *buf, size_t len) {
@@ -147,9 +166,11 @@ int tls_transport_write(tls_transport_t *t, const void *buf, size_t len) {
         }
         if (tls_khannection_send(&t->conn, p + off, chunk, out, sizeof out, &out_len)
             != TLS_KHANNECTION_RC_OK) {
+            tls_khannection_wipe(&t->conn);   /* fail closed */
             return -1;
         }
         if (send_all_fd(t->fd, out, out_len) < 0) {
+            tls_khannection_wipe(&t->conn);
             return -1;
         }
         off += chunk;

--- a/src/tls/tls_transport.c
+++ b/src/tls/tls_transport.c
@@ -1,0 +1,177 @@
+/*
+ * tls_transport.c — blocking-socket adapter over the TLS 1.3 connection engine.
+ * EXPERIMENTAL / UNAUDITED. See tls_transport.h.
+ *
+ * Compiled only under -DWEBLIB_ENABLE_TLS=ON. Owns the recv()/send() loop and
+ * drives the sans-IO engine (tls_khannection). No dynamic allocation.
+ */
+#include "tls_transport.h"
+
+#ifdef WEBLIB_TLS
+
+#include <errno.h>
+#include <string.h>
+#include <sys/socket.h>
+
+/* Suppress SIGPIPE on send() where the platform supports the flag (Linux);
+ * elsewhere the server ignores SIGPIPE process-wide. */
+#ifdef MSG_NOSIGNAL
+#define TLS_SEND_FLAGS MSG_NOSIGNAL
+#else
+#define TLS_SEND_FLAGS 0
+#endif
+
+/* Write every byte of `buf` to `fd`, retrying short writes and EINTR. 0 / -1. */
+static int send_all_fd(int fd, const uint8_t *buf, size_t len) {
+    size_t off = 0;
+    while (off < len) {
+        ssize_t s = send(fd, buf + off, len - off, TLS_SEND_FLAGS);
+        if (s < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        off += (size_t)s;
+    }
+    return 0;
+}
+
+/*
+ * recv one chunk, feed it to the engine, flush any bytes the engine wants sent, and
+ * stash any decrypted application bytes. Must only be called with the app buffer
+ * drained (app_off == app_len). Returns 1 on progress (inspect state / app_len),
+ * 0 on a TCP EOF, -1 on a socket or engine error.
+ */
+static int transport_pump(tls_transport_t *t) {
+    uint8_t raw[TLS_TRANSPORT_RECV_CHUNK];
+    uint8_t out[TLS_RECORD_MAX_CIPHERTEXT];
+    size_t out_len = 0, app_len = 0;
+    tls_khannection_rc_t rc;
+    ssize_t n;
+
+    do {
+        n = recv(t->fd, raw, sizeof raw, 0);
+    } while (n < 0 && errno == EINTR);
+    if (n < 0) {
+        return -1;
+    }
+    if (n == 0) {
+        t->eof = 1;   /* TCP EOF without a close_notify */
+        return 0;
+    }
+
+    rc = tls_khannection_recv(&t->conn, raw, (size_t)n, out, sizeof out, &out_len,
+                              t->app, sizeof t->app, &app_len);
+    if (out_len > 0) {
+        if (send_all_fd(t->fd, out, out_len) < 0) {
+            return -1;
+        }
+    }
+    if (rc == TLS_KHANNECTION_RC_ERROR) {
+        return -1;
+    }
+    t->app_off = 0;
+    t->app_len = app_len;
+    if (rc == TLS_KHANNECTION_RC_CLOSED) {
+        t->eof = 1;
+    }
+    return 1;
+}
+
+int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *cfg) {
+    if (t == NULL) {
+        return -1;
+    }
+    tls_khannection_init(&t->conn, cfg);
+    t->fd = fd;
+    t->app_off = 0;
+    t->app_len = 0;
+    t->eof = 0;
+
+    while (tls_khannection_state(&t->conn) == TLS_KHANNECTION_HANDSHAKE) {
+        int r = transport_pump(t);
+        if (r <= 0) {
+            return -1;   /* error, or EOF before the handshake completed */
+        }
+    }
+    return (tls_khannection_state(&t->conn) == TLS_KHANNECTION_ESTABLISHED) ? 0 : -1;
+}
+
+ssize_t tls_transport_read(tls_transport_t *t, void *buf, size_t len) {
+    size_t avail, n;
+    if (t == NULL || buf == NULL) {
+        return -1;
+    }
+    if (len == 0) {
+        return 0;
+    }
+    /* Serve from the buffer; pump the socket until some application data arrives or
+     * the stream ends. */
+    while (t->app_off == t->app_len) {
+        int r;
+        if (t->eof || tls_khannection_state(&t->conn) == TLS_KHANNECTION_CLOSED) {
+            return 0;
+        }
+        r = transport_pump(t);
+        if (r < 0) {
+            return -1;
+        }
+        if (r == 0) {
+            return 0;   /* TCP EOF */
+        }
+    }
+    avail = t->app_len - t->app_off;
+    n = (avail < len) ? avail : len;
+    memcpy(buf, t->app + t->app_off, n);
+    t->app_off += n;
+    return (ssize_t)n;
+}
+
+int tls_transport_write(tls_transport_t *t, const void *buf, size_t len) {
+    const uint8_t *p = (const uint8_t *)buf;
+    uint8_t out[TLS_RECORD_MAX_CIPHERTEXT];
+    size_t off = 0;
+
+    if (t == NULL || (buf == NULL && len != 0)) {
+        return -1;
+    }
+    if (tls_khannection_state(&t->conn) != TLS_KHANNECTION_ESTABLISHED) {
+        return -1;
+    }
+    while (off < len) {
+        size_t chunk = len - off;
+        size_t out_len = 0;
+        if (chunk > TLS_RECORD_MAX_PLAINTEXT) {
+            chunk = TLS_RECORD_MAX_PLAINTEXT;   /* one record per iteration bounds `out` */
+        }
+        if (tls_khannection_send(&t->conn, p + off, chunk, out, sizeof out, &out_len)
+            != TLS_KHANNECTION_RC_OK) {
+            return -1;
+        }
+        if (send_all_fd(t->fd, out, out_len) < 0) {
+            return -1;
+        }
+        off += chunk;
+    }
+    return 0;
+}
+
+void tls_transport_close(tls_transport_t *t) {
+    if (t == NULL) {
+        return;
+    }
+    if (tls_khannection_state(&t->conn) == TLS_KHANNECTION_ESTABLISHED) {
+        uint8_t out[64];
+        size_t out_len = 0;
+        if (tls_khannection_close_notify(&t->conn, out, sizeof out, &out_len)
+                != TLS_KHANNECTION_RC_ERROR && out_len > 0) {
+            (void)send_all_fd(t->fd, out, out_len);   /* best effort */
+        }
+    }
+    tls_khannection_wipe(&t->conn);
+    t->app_off = 0;
+    t->app_len = 0;
+}
+
+#endif /* WEBLIB_TLS */

--- a/src/tls/tls_transport.h
+++ b/src/tls/tls_transport.h
@@ -1,0 +1,90 @@
+/*
+ * tls_transport.h — blocking-socket adapter over the TLS 1.3 connection engine.
+ * EXPERIMENTAL / UNAUDITED.
+ *
+ * Part of the experimental pure-C TLS layer; compiled only under
+ * -DWEBLIB_ENABLE_TLS=ON (native-only). This is the bridge between the sans-IO
+ * engine (tls_khannection.h), which only transforms byte buffers, and a real
+ * connected socket: it owns the recv()/send() loop and drives the engine to
+ * termination, then exposes a plain blocking read/write pair the HTTP layer can
+ * use in place of raw recv()/send().
+ *
+ * It deliberately does the *blocking* form (one thread per connection), matching
+ * the library's threaded server path; a non-blocking adapter for the event-loop
+ * path is a separate, later piece. This module performs socket I/O but touches no
+ * existing server code, so it is additive and unit-tested over a socketpair before
+ * any hot-path integration.
+ *
+ * SECURITY. The engine enforces the protocol; this adapter only moves bytes. It
+ * fails closed: any engine error or socket error tears the connection down, and
+ * close wipes the key material. Per-connection memory is dominated by the engine's
+ * ~16 KiB record-reassembly buffer plus this adapter's ~20 KiB application-read
+ * buffer — budget ~40 KiB per concurrent TLS connection.
+ *
+ * SCOPE / LIMITATIONS (documented): server side, blocking sockets only; inherits
+ * tls_khannection's profile and limits (one cipher/group/signature, 1-RTT, no
+ * resumption/KeyUpdate/renegotiation). The ephemeral key and ServerHello random in
+ * `cfg` must be fresh CSPRNG output per connection in production (see
+ * server_handshake.h).
+ *
+ * Verified in tests/test_tls_transport.c: a real handshake and encrypted
+ * request/response over a socketpair, cross-checked against the independent oracle
+ * keys.
+ */
+#ifndef WEBLIB_TLS_TLS_TRANSPORT_H
+#define WEBLIB_TLS_TLS_TRANSPORT_H
+
+#ifdef WEBLIB_TLS
+
+#include <stddef.h>
+#include <sys/types.h>   /* ssize_t */
+#include "tls_khannection.h"
+#include "record.h"
+
+/* recv() chunk size and the application read buffer. The engine may emit, in a
+ * single step, one buffered record's plaintext (up to 2^14) plus the plaintext of
+ * whole records contained in the fresh chunk (up to the chunk size), so the buffer
+ * must hold their sum. */
+#define TLS_TRANSPORT_RECV_CHUNK 4096
+#define TLS_TRANSPORT_APPBUF     (TLS_RECORD_MAX_PLAINTEXT + TLS_TRANSPORT_RECV_CHUNK)
+
+typedef struct {
+    tls_khannection_t conn;
+    int fd;
+    /* Decrypted application bytes produced by the engine but not yet handed to the
+     * caller: valid range is [app_off, app_len). */
+    uint8_t app[TLS_TRANSPORT_APPBUF];
+    size_t  app_off;
+    size_t  app_len;
+    int     eof;   /* peer closed (close_notify or TCP EOF); reads return 0 */
+} tls_transport_t;
+
+/*
+ * Run the server handshake over the already-connected blocking socket `fd`. `cfg`
+ * supplies the certificate, signing key, and the injected ephemeral/random (see
+ * server_handshake.h). Blocks until the handshake completes or fails. Returns 0 on
+ * success (the connection is established and ready for read/write), -1 on any
+ * failure (a fatal alert may have been written to the peer; the caller should close
+ * `fd`). Does not take ownership of `fd`.
+ */
+int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *cfg);
+
+/*
+ * Read up to `len` decrypted application bytes into `buf`, blocking until at least
+ * one byte is available. Returns the number of bytes read (>0), 0 on a clean
+ * end-of-stream (peer close_notify or TCP EOF), or -1 on error. Semantics mirror
+ * recv() closely enough to drop into the existing read loop.
+ */
+ssize_t tls_transport_read(tls_transport_t *t, void *buf, size_t len);
+
+/*
+ * Encrypt and send all `len` bytes of application data (splitting across records as
+ * needed). Returns 0 on success, -1 on error. Valid only once established.
+ */
+int tls_transport_write(tls_transport_t *t, const void *buf, size_t len);
+
+/* Send a close_notify (best effort) and wipe all key material. */
+void tls_transport_close(tls_transport_t *t);
+
+#endif /* WEBLIB_TLS */
+#endif /* WEBLIB_TLS_TLS_TRANSPORT_H */

--- a/src/tls/tls_transport.h
+++ b/src/tls/tls_transport.h
@@ -25,7 +25,13 @@
  * tls_khannection's profile and limits (one cipher/group/signature, 1-RTT, no
  * resumption/KeyUpdate/renegotiation). The ephemeral key and ServerHello random in
  * `cfg` must be fresh CSPRNG output per connection in production (see
- * server_handshake.h).
+ * server_handshake.h). No half-close: if the peer sends its close_notify before it
+ * has read a response (e.g. a one-shot client that shuts down its write side right
+ * after the request), tls_transport_accept still succeeds and the buffered request
+ * is readable, but tls_transport_write can no longer send a response (the engine is
+ * CLOSED). Full half-close (responding after the peer's close_notify) is deferred to
+ * the interoperability milestone; ordinary request/response clients that keep the
+ * connection open for the reply are unaffected.
  *
  * Verified in tests/test_tls_transport.c: a real handshake and encrypted
  * request/response over a socketpair, cross-checked against the independent oracle

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,16 @@ if(NOT EMSCRIPTEN)
         target_compile_definitions(test_tls_parse PRIVATE WEBLIB_TLS)
         target_link_libraries(test_tls_parse weblib ${PLATFORM_LIBS})
         add_test(NAME TlsParseTests COMMAND test_tls_parse)
+
+        # Blocking-socket TLS adapter: a real handshake + encrypted exchange over a
+        # socketpair (a KAT client thread vs the tls_transport server).
+        add_executable(test_tls_transport test_tls_transport.c)
+        target_include_directories(test_tls_transport PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+        target_compile_definitions(test_tls_transport PRIVATE WEBLIB_TLS)
+        target_link_libraries(test_tls_transport weblib ${PLATFORM_LIBS})
+        add_test(NAME TlsTransportTests COMMAND test_tls_transport)
     endif()
 endif()
 

--- a/tests/test_tls_transport.c
+++ b/tests/test_tls_transport.c
@@ -1,0 +1,310 @@
+/*
+ * test_tls_transport.c — the blocking-socket TLS adapter over a real socketpair.
+ * Built only with -DWEBLIB_ENABLE_TLS=ON.
+ *
+ * A server thread drives tls_transport (accept -> read one request -> write one
+ * response -> close) on one end of a socketpair. The main thread plays a TLS 1.3
+ * client on the other end using the independent-oracle known-answer vectors: it
+ * sends the ClientHello, checks the server's flight opens under the oracle's
+ * handshake key, sends the (KAT) Finished, then exchanges one encrypted
+ * request/response. This exercises the full handshake + application data path over
+ * actual sockets, cross-checked against a separate implementation's keys.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#ifdef WEBLIB_TLS
+#include <pthread.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <errno.h>
+#include "tls_transport.h"
+#include "tls_khannection.h"
+#include "record.h"
+#include "handshake.h"   /* TLS_HS_FINISHED */
+#endif
+
+static int g_failures = 0;
+
+static void check_true(const char *label, int cond) {
+    if (cond) {
+        printf("PASS: %s\n", label);
+    } else {
+        printf("FAIL: %s\n", label);
+        g_failures++;
+    }
+}
+
+#ifdef WEBLIB_TLS
+
+/* ==== oracle-derived known-answer vectors (see scratchpad/server_hs_oracle.py) ==== */
+static const uint8_t KAT_CH[144] = {
+    0x01, 0x00, 0x00, 0x8c, 0x03, 0x03, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0x20, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+    0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x00,
+    0x02, 0x13, 0x03, 0x01, 0x00, 0x00, 0x41, 0x00, 0x2b, 0x00, 0x03, 0x02,
+    0x03, 0x04, 0x00, 0x0a, 0x00, 0x04, 0x00, 0x02, 0x00, 0x1d, 0x00, 0x0d,
+    0x00, 0x04, 0x00, 0x02, 0x08, 0x07, 0x00, 0x33, 0x00, 0x26, 0x00, 0x24,
+    0x00, 0x1d, 0x00, 0x20, 0x79, 0xa6, 0x31, 0xee, 0xde, 0x1b, 0xf9, 0xc9,
+    0x8f, 0x12, 0x03, 0x2c, 0xde, 0xad, 0xd0, 0xe7, 0xa0, 0x79, 0x39, 0x8f,
+    0xc7, 0x86, 0xb8, 0x8c, 0xc8, 0x46, 0xec, 0x89, 0xaf, 0x85, 0xa5, 0x1a,
+};
+static const uint8_t KAT_CERT[96] = {
+    0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab,
+    0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7,
+    0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xa0, 0xa1, 0xa2, 0xa3,
+    0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+    0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb,
+    0xbc, 0xbd, 0xbe, 0xbf, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+    0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf, 0xb0, 0xb1, 0xb2, 0xb3,
+    0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf,
+};
+static const uint8_t KAT_ED_SEED[32] = {
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+    0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+};
+static const uint8_t KAT_ED_PUB[32] = {
+    0x79, 0xb5, 0x56, 0x2e, 0x8f, 0xe6, 0x54, 0xf9, 0x40, 0x78, 0xb1, 0x12,
+    0xe8, 0xa9, 0x8b, 0xa7, 0x90, 0x1f, 0x85, 0x3a, 0xe6, 0x95, 0xbe, 0xd7,
+    0xe0, 0xe3, 0x91, 0x0b, 0xad, 0x04, 0x96, 0x64,
+};
+static const uint8_t KAT_SERVER_EPH[32] = {
+    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b,
+    0x6c, 0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77,
+    0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+};
+static const uint8_t KAT_SERVER_RND[32] = {
+    0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e,
+    0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e,
+    0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e,
+};
+static const uint8_t KAT_SERVER_HS_KEY[32] = {
+    0x41, 0xc1, 0xe2, 0xdb, 0x19, 0x3b, 0xc8, 0x84, 0x1e, 0xb5, 0xc6, 0x4a,
+    0xe3, 0x08, 0x09, 0x30, 0x6e, 0x8a, 0xc8, 0x2e, 0x33, 0xc7, 0xd5, 0xfe,
+    0x64, 0xce, 0x20, 0x6f, 0x2f, 0x32, 0xd6, 0xa4,
+};
+static const uint8_t KAT_SERVER_HS_IV[12] = {
+    0x38, 0x9c, 0xa9, 0x76, 0x72, 0x06, 0x7e, 0x0c, 0x73, 0x31, 0xf0, 0x64,
+};
+static const uint8_t KAT_CLIENT_HS_KEY[32] = {
+    0x5d, 0x09, 0xb3, 0x22, 0x93, 0x47, 0xca, 0x9f, 0x67, 0x0f, 0x6b, 0x98,
+    0x8d, 0x30, 0xdc, 0xa3, 0x4f, 0xc4, 0x45, 0x77, 0x05, 0xf4, 0x5d, 0x30,
+    0xd2, 0xb5, 0x19, 0x39, 0x5f, 0x0b, 0x85, 0xd2,
+};
+static const uint8_t KAT_CLIENT_HS_IV[12] = {
+    0xa3, 0x18, 0xa3, 0xeb, 0x91, 0x9e, 0xb2, 0x74, 0x50, 0x5a, 0x6c, 0x9b,
+};
+static const uint8_t KAT_CLIENT_FINISHED_VD[32] = {
+    0xa3, 0xb6, 0x47, 0x2e, 0xd7, 0x60, 0xfd, 0xb0, 0xc3, 0x55, 0x79, 0xf0,
+    0x8e, 0xdb, 0x75, 0xbc, 0x87, 0x59, 0x9e, 0xa8, 0x51, 0xd1, 0x93, 0x22,
+    0x85, 0xce, 0x6f, 0x29, 0x0d, 0x0b, 0xf7, 0x4f,
+};
+static const uint8_t KAT_CLIENT_AP_KEY[32] = {
+    0x28, 0xc8, 0x92, 0x97, 0x21, 0xfa, 0x74, 0x2e, 0xc8, 0x0a, 0x78, 0x1b,
+    0xed, 0xa8, 0x12, 0x2d, 0x28, 0xad, 0x03, 0xc3, 0x04, 0xdc, 0x8d, 0x8b,
+    0x07, 0xa6, 0xbe, 0x6a, 0x35, 0x76, 0x8e, 0xa4,
+};
+static const uint8_t KAT_CLIENT_AP_IV[12] = {
+    0xa3, 0xd7, 0xd4, 0x06, 0x4c, 0x40, 0x49, 0xc6, 0xab, 0x8a, 0x76, 0xc5,
+};
+static const uint8_t KAT_SERVER_AP_KEY[32] = {
+    0x36, 0xe0, 0x70, 0xfc, 0x68, 0xdd, 0xab, 0x6d, 0xa2, 0x8f, 0xa6, 0x3b,
+    0xe1, 0xac, 0x73, 0x6b, 0x01, 0x63, 0x57, 0xb7, 0xe2, 0x3c, 0x72, 0x8a,
+    0x0e, 0xdd, 0x46, 0x05, 0xe7, 0xc3, 0xf4, 0x1d,
+};
+static const uint8_t KAT_SERVER_AP_IV[12] = {
+    0x39, 0x6b, 0x0d, 0x59, 0xec, 0xb3, 0x89, 0x34, 0x53, 0x87, 0x4a, 0xa4,
+};
+
+static const char SERVER_RESPONSE[] =
+    "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello";
+static const char CLIENT_REQUEST[] = "GET / HTTP/1.1\r\n\r\n";
+
+/* ---- blocking socket helpers (client side of the pair) ---- */
+static int write_all_c(int fd, const uint8_t *buf, size_t n) {
+    size_t off = 0;
+    while (off < n) {
+        ssize_t s = send(fd, buf + off, n - off, 0);
+        if (s < 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        off += (size_t)s;
+    }
+    return 0;
+}
+static int read_n(int fd, uint8_t *buf, size_t n) {
+    size_t off = 0;
+    while (off < n) {
+        ssize_t r = recv(fd, buf + off, n - off, 0);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (r == 0) return (int)off;   /* short read: EOF */
+        off += (size_t)r;
+    }
+    return (int)off;
+}
+/* Read exactly one TLS record (5-byte header + declared body). Returns total len. */
+static int read_record(int fd, uint8_t *buf, size_t cap) {
+    size_t body;
+    if (cap < TLS_RECORD_HEADER_LEN) return -1;
+    if (read_n(fd, buf, TLS_RECORD_HEADER_LEN) != (int)TLS_RECORD_HEADER_LEN) return -1;
+    body = ((size_t)buf[3] << 8) | buf[4];
+    if (TLS_RECORD_HEADER_LEN + body > cap) return -1;
+    if (read_n(fd, buf + TLS_RECORD_HEADER_LEN, body) != (int)body) return -1;
+    return (int)(TLS_RECORD_HEADER_LEN + body);
+}
+
+/* ---- server side, run on its own thread ---- */
+typedef struct {
+    int fd;
+    int accept_rc;
+    int write_rc;
+    ssize_t req_len;
+    char req[256];
+} srv_result_t;
+
+static void *server_thread(void *arg) {
+    static tls_transport_t t;   /* ~40 KiB; one server, so a single static is fine */
+    srv_result_t *r = (srv_result_t *)arg;
+    tls_server_config_t cfg;
+
+    memset(&cfg, 0, sizeof cfg);
+    cfg.cert_der = KAT_CERT;
+    cfg.cert_len = sizeof KAT_CERT;
+    cfg.ed25519_seed = KAT_ED_SEED;
+    cfg.ed25519_pub = KAT_ED_PUB;
+    cfg.server_eph_sk = KAT_SERVER_EPH;
+    cfg.server_random = KAT_SERVER_RND;
+
+    r->accept_rc = tls_transport_accept(&t, r->fd, &cfg);
+    if (r->accept_rc == 0) {
+        r->req_len = tls_transport_read(&t, r->req, sizeof r->req - 1);
+        if (r->req_len > 0) {
+            r->req[r->req_len] = '\0';
+        }
+        r->write_rc = tls_transport_write(&t, SERVER_RESPONSE, sizeof SERVER_RESPONSE - 1);
+    }
+    tls_transport_close(&t);
+    return NULL;
+}
+
+static void test_tls_transport(void) {
+    int sv[2];
+    pthread_t tid;
+    srv_result_t res;
+    int cfd;
+    uint8_t ch[TLS_RECORD_HEADER_LEN + sizeof KAT_CH];
+    uint8_t sh[600], flight[2048], resprec[512];
+    uint8_t flightpt[512], resppt[256];
+    uint8_t finmsg[4 + 32], rec[128];
+    size_t rl = 0;
+    int shl, fll, resl;
+    size_t ptlen = 0;
+    uint8_t ctype = 0;
+    static const uint8_t ccs[6] = { 0x14, 0x03, 0x03, 0x00, 0x01, 0x01 };
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+        check_true("transport: socketpair created", 0);
+        return;
+    }
+    res.fd = sv[0];
+    res.accept_rc = -1;
+    res.write_rc = -1;
+    res.req_len = -1;
+    cfd = sv[1];
+
+    if (pthread_create(&tid, NULL, server_thread, &res) != 0) {
+        check_true("transport: server thread started", 0);
+        close(sv[0]);
+        close(sv[1]);
+        return;
+    }
+
+    /* 1. ClientHello. */
+    ch[0] = TLS_CONTENT_HANDSHAKE;
+    ch[1] = 0x03;
+    ch[2] = 0x03;
+    ch[3] = (uint8_t)((sizeof KAT_CH) >> 8);
+    ch[4] = (uint8_t)(sizeof KAT_CH);
+    memcpy(ch + TLS_RECORD_HEADER_LEN, KAT_CH, sizeof KAT_CH);
+    check_true("transport: client sent ClientHello",
+               write_all_c(cfd, ch, sizeof ch) == 0);
+
+    /* 2. Read the server flight: a ServerHello record then a protected record. */
+    shl = read_record(cfd, sh, sizeof sh);
+    fll = read_record(cfd, flight, sizeof flight);
+    check_true("transport: server sent ServerHello + protected flight",
+               shl > 0 && sh[0] == 0x16 && fll > 0 && flight[0] == 0x17);
+    check_true("transport: flight opens under the oracle handshake key",
+               fll > 0
+               && tls_record_open(KAT_SERVER_HS_KEY, KAT_SERVER_HS_IV, 0,
+                                  flight, (size_t)fll, flightpt, sizeof flightpt,
+                                  &ptlen, &ctype) == 1
+               && ctype == TLS_CONTENT_HANDSHAKE);
+
+    /* 3. ChangeCipherSpec (dropped) then the client Finished. */
+    check_true("transport: client sent CCS", write_all_c(cfd, ccs, sizeof ccs) == 0);
+    finmsg[0] = TLS_HS_FINISHED;
+    finmsg[1] = 0x00;
+    finmsg[2] = 0x00;
+    finmsg[3] = 0x20;
+    memcpy(finmsg + 4, KAT_CLIENT_FINISHED_VD, 32);
+    check_true("transport: seal client Finished",
+               tls_record_seal(KAT_CLIENT_HS_KEY, KAT_CLIENT_HS_IV, 0,
+                               TLS_CONTENT_HANDSHAKE, finmsg, sizeof finmsg, 0,
+                               rec, sizeof rec, &rl) == 1);
+    check_true("transport: client sent Finished", write_all_c(cfd, rec, rl) == 0);
+
+    /* 4. Encrypted application request. */
+    check_true("transport: seal application request",
+               tls_record_seal(KAT_CLIENT_AP_KEY, KAT_CLIENT_AP_IV, 0,
+                               TLS_CONTENT_APPLICATION_DATA,
+                               (const uint8_t *)CLIENT_REQUEST, sizeof CLIENT_REQUEST - 1,
+                               0, rec, sizeof rec, &rl) == 1);
+    check_true("transport: client sent request", write_all_c(cfd, rec, rl) == 0);
+
+    /* 5. Read + decrypt the server's application response. */
+    resl = read_record(cfd, resprec, sizeof resprec);
+    check_true("transport: server response decrypts under the oracle app key",
+               resl > 0 && resprec[0] == 0x17
+               && tls_record_open(KAT_SERVER_AP_KEY, KAT_SERVER_AP_IV, 0,
+                                  resprec, (size_t)resl, resppt, sizeof resppt,
+                                  &ptlen, &ctype) == 1
+               && ctype == TLS_CONTENT_APPLICATION_DATA
+               && ptlen == sizeof SERVER_RESPONSE - 1
+               && memcmp(resppt, SERVER_RESPONSE, ptlen) == 0);
+
+    close(cfd);
+    pthread_join(tid, NULL);
+
+    /* 6. What the server observed. */
+    check_true("transport: server completed the handshake", res.accept_rc == 0);
+    check_true("transport: server decrypted the exact request",
+               res.req_len == (ssize_t)(sizeof CLIENT_REQUEST - 1)
+               && memcmp(res.req, CLIENT_REQUEST, (size_t)res.req_len) == 0);
+    check_true("transport: server sent its response", res.write_rc == 0);
+
+    close(sv[0]);
+}
+#endif /* WEBLIB_TLS */
+
+int main(void) {
+#ifndef WEBLIB_TLS
+    printf("FAIL: test_tls_transport built without WEBLIB_TLS defined\n");
+    return 1;
+#else
+    test_tls_transport();
+    if (g_failures == 0) {
+        printf("All TLS transport tests passed.\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+#endif
+}

--- a/tests/test_tls_transport.c
+++ b/tests/test_tls_transport.c
@@ -294,6 +294,131 @@ static void test_tls_transport(void) {
 
     close(sv[0]);
 }
+
+/* Server that only accepts + reads (no response) — for the half-close case. */
+static void *server_thread_readonly(void *arg) {
+    static tls_transport_t t;
+    srv_result_t *r = (srv_result_t *)arg;
+    tls_server_config_t cfg;
+
+    memset(&cfg, 0, sizeof cfg);
+    cfg.cert_der = KAT_CERT;
+    cfg.cert_len = sizeof KAT_CERT;
+    cfg.ed25519_seed = KAT_ED_SEED;
+    cfg.ed25519_pub = KAT_ED_PUB;
+    cfg.server_eph_sk = KAT_SERVER_EPH;
+    cfg.server_random = KAT_SERVER_RND;
+
+    r->accept_rc = tls_transport_accept(&t, r->fd, &cfg);
+    if (r->accept_rc == 0) {
+        r->req_len = tls_transport_read(&t, r->req, sizeof r->req - 1);
+        if (r->req_len > 0) {
+            r->req[r->req_len] = '\0';
+        }
+    }
+    tls_transport_close(&t);
+    return NULL;
+}
+
+/*
+ * A one-shot client that coalesces Finished + request + close_notify into a single
+ * write, so the server sees them in one recv (engine: HANDSHAKE -> ESTABLISHED ->
+ * CLOSED within one pump). accept must still succeed and the request must survive.
+ */
+static void test_tls_transport_halfclose(void) {
+    int sv[2];
+    pthread_t tid;
+    srv_result_t res;
+    int cfd, shl, fll;
+    uint8_t ch[TLS_RECORD_HEADER_LEN + sizeof KAT_CH];
+    uint8_t sh[600], flight[2048];
+    uint8_t combo[512];
+    uint8_t finmsg[4 + 32];
+    static const uint8_t ccs[6] = { 0x14, 0x03, 0x03, 0x00, 0x01, 0x01 };
+    static const uint8_t close_alert[2] = { 0x01, 0x00 };   /* warning, close_notify */
+    size_t combol = 0, n = 0;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+        check_true("halfclose: socketpair created", 0);
+        return;
+    }
+    res.fd = sv[0];
+    res.accept_rc = -1;
+    res.write_rc = -1;
+    res.req_len = -1;
+    cfd = sv[1];
+    if (pthread_create(&tid, NULL, server_thread_readonly, &res) != 0) {
+        check_true("halfclose: server thread started", 0);
+        close(sv[0]);
+        close(sv[1]);
+        return;
+    }
+
+    ch[0] = TLS_CONTENT_HANDSHAKE;
+    ch[1] = 0x03;
+    ch[2] = 0x03;
+    ch[3] = (uint8_t)((sizeof KAT_CH) >> 8);
+    ch[4] = (uint8_t)(sizeof KAT_CH);
+    memcpy(ch + TLS_RECORD_HEADER_LEN, KAT_CH, sizeof KAT_CH);
+    write_all_c(cfd, ch, sizeof ch);
+    shl = read_record(cfd, sh, sizeof sh);
+    fll = read_record(cfd, flight, sizeof flight);
+    check_true("halfclose: received the server flight", shl > 0 && fll > 0);
+
+    /* Build one buffer: CCS || Finished(hs seq0) || request(ap seq0) || close_notify(ap seq1). */
+    memcpy(combo, ccs, sizeof ccs);
+    combol = sizeof ccs;
+    finmsg[0] = TLS_HS_FINISHED;
+    finmsg[1] = 0x00;
+    finmsg[2] = 0x00;
+    finmsg[3] = 0x20;
+    memcpy(finmsg + 4, KAT_CLIENT_FINISHED_VD, 32);
+    tls_record_seal(KAT_CLIENT_HS_KEY, KAT_CLIENT_HS_IV, 0, TLS_CONTENT_HANDSHAKE,
+                    finmsg, sizeof finmsg, 0, combo + combol, sizeof combo - combol, &n);
+    combol += n;
+    tls_record_seal(KAT_CLIENT_AP_KEY, KAT_CLIENT_AP_IV, 0, TLS_CONTENT_APPLICATION_DATA,
+                    (const uint8_t *)CLIENT_REQUEST, sizeof CLIENT_REQUEST - 1, 0,
+                    combo + combol, sizeof combo - combol, &n);
+    combol += n;
+    tls_record_seal(KAT_CLIENT_AP_KEY, KAT_CLIENT_AP_IV, 1, TLS_CONTENT_ALERT,
+                    close_alert, sizeof close_alert, 0, combo + combol, sizeof combo - combol, &n);
+    combol += n;
+    check_true("halfclose: sent coalesced Finished+request+close_notify",
+               write_all_c(cfd, combo, combol) == 0);
+    close(cfd);
+    pthread_join(tid, NULL);
+
+    check_true("halfclose: accept succeeds despite the coalesced close_notify",
+               res.accept_rc == 0);
+    check_true("halfclose: the buffered request survives and reads back exactly",
+               res.req_len == (ssize_t)(sizeof CLIENT_REQUEST - 1)
+               && memcmp(res.req, CLIENT_REQUEST, (size_t)res.req_len) == 0);
+    close(sv[0]);
+}
+
+/* close/teardown must wipe the decrypted application plaintext, not just the keys. */
+static void test_tls_transport_wipe(void) {
+    static tls_transport_t t;
+    size_t i;
+    int nonzero = 0;
+
+    tls_khannection_init(&t.conn, NULL);   /* HANDSHAKE state; cfg unused without a handshake */
+    t.fd = -1;
+    t.app_off = 0;
+    t.app_len = 100;
+    memset(t.app, 0xAB, sizeof t.app);   /* stand-in for buffered decrypted request bytes */
+
+    tls_transport_close(&t);   /* not ESTABLISHED, so no close_notify send; just teardown */
+
+    for (i = 0; i < sizeof t.app; i++) {
+        if (t.app[i] != 0) {
+            nonzero = 1;
+            break;
+        }
+    }
+    check_true("wipe: teardown zeroes the buffered decrypted plaintext",
+               !nonzero && t.app_len == 0 && t.app_off == 0);
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -302,6 +427,8 @@ int main(void) {
     return 1;
 #else
     test_tls_transport();
+    test_tls_transport_halfclose();
+    test_tls_transport_wipe();
     if (g_failures == 0) {
         printf("All TLS transport tests passed.\n");
     }


### PR DESCRIPTION
## Summary

The **blocking-socket adapter** — the bridge between the sans-IO connection engine (`tls_khannection`, #117) and a real connected socket. It owns the `recv()`/`send()` loop and drives the engine to termination, then exposes a plain blocking read/write pair the HTTP layer can drop in for raw `recv()`/`send()`.

**It touches no existing server code** — purely additive, so zero regression risk to the HTTP hot path. The `http_server.c` integration that calls it (the risky seam + `http_server_enable_tls`) is a separate, small follow-up.

```
tls_transport_accept(fd, cfg) ── handshake over the socket ──► established
tls_transport_read(buf,len)   ── recv + decrypt ─────────────► app bytes
tls_transport_write(buf,len)  ── encrypt + send ─────────────► 0 / -1
tls_transport_close()         ── close_notify + wipe
```

## Design

- **accept** drives the handshake (recv records → engine → send the flight) until established or failure.
- **read** returns decrypted application bytes, buffered so a record decrypting to more than one read drains across calls; returns 0 on a clean end (`close_notify` or TCP EOF).
- **write** encrypts and sends, splitting across records.
- **Fail-closed:** any engine or socket error tears the connection down; close wipes the key material.
- Per-connection footprint ~40 KiB (engine reassembly buffer + this adapter's application buffer), documented.

## Scope / limitations (documented)

Server side, **blocking sockets only** (the event-loop / async path needs a non-blocking adapter — later). Inherits `tls_khannection`'s profile and limits (one cipher/group/signature, 1-RTT, no resumption/KeyUpdate/renegotiation). EXPERIMENTAL / UNAUDITED.

## Testing — 12 assertions (new `TlsTransportTests`)

A **real handshake + encrypted request/response over an `AF_UNIX` socketpair**: a server thread runs `tls_transport` while the main thread plays a TLS 1.3 client using the independent Python oracle's known-answer vectors — it sends the ClientHello, checks the server's flight **opens under the oracle's handshake key**, sends the KAT Finished, then exchanges one encrypted request/response (the server's response **decrypts under the oracle's application key**, and the server **decrypts the exact request**). So the whole socket path is cross-checked against a separate implementation's keys.

## Verification matrix

- **OFF build (default):** 6/6, no `tls_transport` symbols, `.o` absent.
- **TLS build:** 10/10.
- **ASan + UBSan** (`halt_on_error=1`) on the threaded socket test: clean.
- **Negative control:** dropping one decrypted byte fails exactly the request-integrity assertion; restored.
- Zero warnings (`-Wall -Wextra -pedantic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)