### PR TITLE
TLS Phase 4: http_server_enable_tls — internal TLS 1.3 termination

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,10 @@ set(WEBLIB_SOURCES_NATIVE_ONLY
 # the option off, nothing below is added and the build is byte-identical to a
 # no-TLS build. Mirrors the WEBLIB_SOURCES_NATIVE_ONLY split (see src/tls/README.md).
 option(WEBLIB_ENABLE_TLS "Build the experimental pure-C TLS 1.3 layer (native-only, UNAUDITED)" OFF)
+# TEST-ONLY: expose http_server__tls_test_rng so tests can pin the per-connection TLS
+# randomness for deterministic handshakes. NEVER enable in a production/library build
+# — a deterministic RNG would destroy TLS security. Default OFF.
+option(WEBLIB_TLS_TEST_HOOKS "Expose TLS test hooks (deterministic RNG) — TEST ONLY" OFF)
 set(WEBLIB_SOURCES_TLS
     src/tls/tls.c
     src/tls/der.c
@@ -131,6 +135,9 @@ target_compile_definitions(weblib PRIVATE
 # native target (its sources were added to WEBLIB_SOURCES above under the same guard).
 if(WEBLIB_ENABLE_TLS AND NOT EMSCRIPTEN)
     target_compile_definitions(weblib PRIVATE WEBLIB_TLS)
+    if(WEBLIB_TLS_TEST_HOOKS)
+        target_compile_definitions(weblib PRIVATE WEBLIB_TLS_TEST_HOOKS)
+    endif()
 endif()
 
 if(NOT EMSCRIPTEN)
@@ -149,6 +156,9 @@ if(NOT EMSCRIPTEN)
     )
     if(WEBLIB_ENABLE_TLS)
         target_compile_definitions(weblib_shared PRIVATE WEBLIB_TLS)
+        if(WEBLIB_TLS_TEST_HOOKS)
+            target_compile_definitions(weblib_shared PRIVATE WEBLIB_TLS_TEST_HOOKS)
+        endif()
     endif()
 endif()
 

--- a/include/kamran.k
+++ b/include/kamran.k
@@ -599,6 +599,27 @@ int event_loop_get_max_timers(void);
 int http_server_set_async(http_server_t *server, bool enable);
 
 /**
+ * Enable TLS termination on the server (EXPERIMENTAL / UNAUDITED — pure-C TLS 1.3,
+ * TLS_CHACHA20_POLY1305_SHA256 + X25519 + Ed25519, server-side, 1-RTT).
+ *
+ * Loads a PEM-encoded certificate and its PEM-encoded Ed25519 private key (PKCS#8);
+ * from then on every accepted connection is TLS-terminated before HTTP is spoken.
+ * Must be called before http_server_listen(). Only supported in the default
+ * threaded mode (returns -1 if async mode is enabled). This build is UNAUDITED and
+ * not for production use.
+ *
+ * @param server     Server instance
+ * @param cert_pem   PEM "CERTIFICATE" block (the server certificate, DER carried as-is)
+ * @param cert_len   Length of cert_pem
+ * @param key_pem    PEM "PRIVATE KEY" block (PKCS#8 Ed25519 private key)
+ * @param key_len    Length of key_pem
+ * @return 0 on success, -1 on failure (bad PEM/key, async mode, or already listening)
+ */
+int http_server_enable_tls(http_server_t *server,
+                           const char *cert_pem, size_t cert_len,
+                           const char *key_pem, size_t key_len);
+
+/**
  * Get the event loop associated with the server (async mode only)
  * @param server Server instance
  * @return Event loop instance or NULL if not in async mode

--- a/include/kamran.k
+++ b/include/kamran.k
@@ -613,7 +613,9 @@ int http_server_set_async(http_server_t *server, bool enable);
  * @param cert_len   Length of cert_pem
  * @param key_pem    PEM "PRIVATE KEY" block (PKCS#8 Ed25519 private key)
  * @param key_len    Length of key_pem
- * @return 0 on success, -1 on failure (bad PEM/key, async mode, or already listening)
+ * @return 0 on success, -1 on failure: NULL/empty arguments, malformed certificate
+ *         PEM or private key, async mode enabled, TLS already enabled, or the server
+ *         already listening.
  */
 int http_server_enable_tls(http_server_t *server,
                            const char *cert_pem, size_t cert_len,

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -870,7 +870,10 @@ static tls_transport_t *tls_do_handshake(http_server_t *server, int fd) {
     cfg.ed25519_pub = server->tls_ed25519_pub;
     cfg.server_eph_sk = eph;      /* borrowed only for the duration of the accept call */
     cfg.server_random = rnd;
-    if (tls_transport_accept(t, fd, &cfg) != 0) {
+    /* Bound the handshake by the same wall-clock budget the request loop uses, so a
+     * slow-drip client cannot pin this worker thread (slow-loris) during the
+     * handshake, which runs before the per-request deadline loop. */
+    if (tls_transport_accept(t, fd, &cfg, server->request_timeout_sec) != 0) {
         secure_zero(eph, sizeof eph);
         free(t);
         return NULL;
@@ -1327,7 +1330,16 @@ static int send_all(int fd, void *tls, const char *buf, size_t len) {
 static ssize_t conn_read(int fd, void *tls, void *buf, size_t len) {
 #ifdef WEBLIB_TLS
     if (tls != NULL) {
-        return tls_transport_read((tls_transport_t *)tls, buf, len);
+        /* tls_transport_read returns >0 bytes, 0 on close_notify, or -1 on a fatal
+         * error. The caller dispatches read failures on errno (EINTR retry / EAGAIN
+         * timeout / else 500) — a contract only recv() satisfies. A -1 here carries
+         * a STALE errno (the TLS error path performs a successful recv() then fails
+         * in the engine), which could spuriously retry (EINTR → 100% CPU spin), or
+         * become a bogus 408/500. A TLS error is always terminal — the engine has
+         * already wiped and emitted any alert — so collapse both close and error to
+         * a 0-byte end-of-stream, which the caller handles as a clean close. */
+        ssize_t r = tls_transport_read((tls_transport_t *)tls, buf, len);
+        return r > 0 ? r : 0;
     }
 #else
     (void)tls;
@@ -2453,7 +2465,17 @@ int http_server_set_async(http_server_t *server, bool enable) {
         fprintf(stderr, "Cannot change async mode while server is running\n");
         return -1;
     }
-    
+
+#ifdef WEBLIB_TLS
+    if (enable && server->tls_enabled) {
+        /* TLS termination is only wired for the threaded path; enabling async would
+         * otherwise silently serve plaintext on the HTTPS port. Mirror the reverse
+         * guard in http_server_enable_tls. */
+        fprintf(stderr, "Cannot enable async mode: TLS termination is enabled (threaded only)\n");
+        return -1;
+    }
+#endif
+
     if (enable && !server->event_loop) {
         /* Create event loop */
         server->event_loop = event_loop_create();

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -294,6 +294,17 @@ static int send_all(int fd, void *tls, const char *buf, size_t len);
 #define CONN_TLS(conn) ((void *)0)
 #endif
 static ssize_t conn_read(int fd, void *tls, void *buf, size_t len);
+
+/* True only when TLS termination is active for this server (always false in a build
+ * without TLS). Used to suppress plaintext error responses on an HTTPS port. */
+static bool server_tls_active(const http_server_t *s) {
+#ifdef WEBLIB_TLS
+    return s->tls_enabled;
+#else
+    (void)s;
+    return false;
+#endif
+}
 static http_request_t *http_request_create(void);
 static void http_request_destroy(http_request_t *req);
 static http_response_t *http_response_create(void);
@@ -680,7 +691,12 @@ static void *accept_connections(void *arg) {
         pthread_mutex_lock(&server->conn_lock);
         if (server->active_connections >= server->max_connections) {
             pthread_mutex_unlock(&server->conn_lock);
-            send_error_response(client_fd, NULL, HTTP_SERVICE_UNAVAILABLE, "Connection limit reached");
+            /* Pre-handshake overload rejection: a plaintext HTTP error on an HTTPS
+             * port would just be garbage to a TLS client (and leak plaintext), so
+             * under TLS we simply drop the connection. */
+            if (!server_tls_active(server)) {
+                send_error_response(client_fd, NULL, HTTP_SERVICE_UNAVAILABLE, "Connection limit reached");
+            }
             close(client_fd);
             continue;
         }
@@ -707,8 +723,11 @@ static void *accept_connections(void *arg) {
             
             if (server->pool) {
                 if (thread_pool_submit(server->pool, connection_work, conn) != 0) {
-                    /* Pool full or shutting down — reject connection */
-                    send_error_response(client_fd, NULL, HTTP_SERVICE_UNAVAILABLE, "Server Busy");
+                    /* Pool full or shutting down — reject connection (drop silently
+                     * under TLS; a plaintext error would be garbage to a TLS peer). */
+                    if (!server_tls_active(server)) {
+                        send_error_response(client_fd, NULL, HTTP_SERVICE_UNAVAILABLE, "Server Busy");
+                    }
                     close(client_fd);
                     free(conn);
                     pthread_mutex_lock(&server->conn_lock);
@@ -803,17 +822,28 @@ static void handle_websocket_connection(int client_fd, http_request_t *req) {
 }
 
 #ifdef WEBLIB_TLS
-/* Per-connection randomness for the TLS ephemeral key and ServerHello random.
- * Production uses the system CSPRNG; a test may install a deterministic hook via
- * http_server__tls_test_rng() (internal, not part of the public API). */
+#ifdef WEBLIB_TLS_TEST_HOOKS
+/* TEST-ONLY: pin the per-connection ephemeral key + ServerHello random for a
+ * deterministic handshake. Compiled ONLY when WEBLIB_TLS_TEST_HOOKS is defined
+ * (an opt-in CMake flag, never set in a production/library build) — installing a
+ * deterministic RNG here would destroy the security of every TLS session, so the
+ * symbol must not exist for ordinary consumers of the TLS build. */
 static int (*g_tls_rng)(void *buf, size_t len) = NULL;
 
 void http_server__tls_test_rng(int (*fn)(void *buf, size_t len)) {
     g_tls_rng = fn;
 }
+#endif /* WEBLIB_TLS_TEST_HOOKS */
 
+/* Per-connection randomness for the TLS ephemeral key and ServerHello random: the
+ * system CSPRNG (overridable only in a WEBLIB_TLS_TEST_HOOKS build). */
 static int tls_fill_random(uint8_t *buf, size_t len) {
-    return g_tls_rng ? g_tls_rng(buf, len) : secure_random_bytes(buf, len);
+#ifdef WEBLIB_TLS_TEST_HOOKS
+    if (g_tls_rng) {
+        return g_tls_rng(buf, len);
+    }
+#endif
+    return secure_random_bytes(buf, len);
 }
 
 /* Run the server TLS handshake over the accepted blocking socket. Returns an

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -5,6 +5,17 @@
 #include <time.h>
 #include <ctype.h>
 
+#ifdef WEBLIB_TLS
+/* Experimental pure-C TLS 1.3 termination (native-only, UNAUDITED). Only compiled
+ * when -DWEBLIB_ENABLE_TLS=ON; with it off, none of this is present and the server
+ * is byte-identical to a no-TLS build. */
+#include "tls/tls_transport.h"
+#include "tls/server_handshake.h"
+#include "tls/pem.h"
+#include "tls/ed25519_key.h"
+#include "tls/ed25519.h"
+#endif
+
 /* Portable case-insensitive substring search (replaces GNU strcasestr) */
 static const char *_portable_strcasestr(const char *haystack, const char *needle) {
     if (!haystack) return NULL;
@@ -214,6 +225,15 @@ struct http_server {
     struct async_connection *async_conns;  /* head of the live async-connection list,
                                               walked by the idle reaper; only touched
                                               from the (single-threaded) event loop */
+
+#ifdef WEBLIB_TLS
+    /* TLS termination config (set by http_server_enable_tls; read-only afterwards). */
+    bool tls_enabled;
+    uint8_t *tls_cert_der;            /* server certificate, DER (owned/freed by the server) */
+    size_t   tls_cert_len;
+    uint8_t  tls_ed25519_seed[32];    /* server signing key */
+    uint8_t  tls_ed25519_pub[32];
+#endif
 };
 
 /* Connection handler data */
@@ -223,6 +243,9 @@ typedef struct {
     http_parser_t parser;
     http_request_t *request;
     http_response_t *response;
+#ifdef WEBLIB_TLS
+    tls_transport_t *tls;   /* NULL = plaintext; set once the TLS handshake succeeds */
+#endif
 } connection_t;
 
 /* Async connection context */
@@ -257,9 +280,20 @@ static void *accept_connections(void *arg);
 static void *handle_connection(void *arg);
 static void handle_websocket_connection(int client_fd, http_request_t *req);
 static bool response_forces_close(http_response_t *res);
-static void send_response(int client_fd, http_response_t *res, bool keep_alive);
-static void send_error_response(int client_fd, http_status_t status, const char *message);
-static int send_all(int fd, const char *buf, size_t len);
+static void send_response(int client_fd, void *tls, http_response_t *res, bool keep_alive);
+static void send_error_response(int client_fd, void *tls, http_status_t status, const char *message);
+static int send_all(int fd, void *tls, const char *buf, size_t len);
+
+/* Transport indirection: when `tls` is non-NULL the byte goes through the TLS
+ * engine, otherwise straight to the socket. CONN_TLS(conn) is the connection's TLS
+ * transport, and evaluates to NULL in a build without TLS so every call site stays
+ * unconditional. */
+#ifdef WEBLIB_TLS
+#define CONN_TLS(conn) ((void *)(conn)->tls)
+#else
+#define CONN_TLS(conn) ((void *)0)
+#endif
+static ssize_t conn_read(int fd, void *tls, void *buf, size_t len);
 static http_request_t *http_request_create(void);
 static void http_request_destroy(http_request_t *req);
 static http_response_t *http_response_create(void);
@@ -568,7 +602,15 @@ void http_server_destroy(http_server_t *server) {
     }
     
     pthread_mutex_destroy(&server->conn_lock);
-    
+
+#ifdef WEBLIB_TLS
+    if (server->tls_cert_der) {
+        free(server->tls_cert_der);
+        server->tls_cert_der = NULL;
+    }
+    secure_zero(server->tls_ed25519_seed, sizeof server->tls_ed25519_seed);
+#endif
+
     free(server);
 }
 
@@ -638,7 +680,7 @@ static void *accept_connections(void *arg) {
         pthread_mutex_lock(&server->conn_lock);
         if (server->active_connections >= server->max_connections) {
             pthread_mutex_unlock(&server->conn_lock);
-            send_error_response(client_fd, HTTP_SERVICE_UNAVAILABLE, "Connection limit reached");
+            send_error_response(client_fd, NULL, HTTP_SERVICE_UNAVAILABLE, "Connection limit reached");
             close(client_fd);
             continue;
         }
@@ -666,7 +708,7 @@ static void *accept_connections(void *arg) {
             if (server->pool) {
                 if (thread_pool_submit(server->pool, connection_work, conn) != 0) {
                     /* Pool full or shutting down — reject connection */
-                    send_error_response(client_fd, HTTP_SERVICE_UNAVAILABLE, "Server Busy");
+                    send_error_response(client_fd, NULL, HTTP_SERVICE_UNAVAILABLE, "Server Busy");
                     close(client_fd);
                     free(conn);
                     pthread_mutex_lock(&server->conn_lock);
@@ -760,6 +802,54 @@ static void handle_websocket_connection(int client_fd, http_request_t *req) {
     websocket_connection_destroy(ws_conn);
 }
 
+#ifdef WEBLIB_TLS
+/* Per-connection randomness for the TLS ephemeral key and ServerHello random.
+ * Production uses the system CSPRNG; a test may install a deterministic hook via
+ * http_server__tls_test_rng() (internal, not part of the public API). */
+static int (*g_tls_rng)(void *buf, size_t len) = NULL;
+
+void http_server__tls_test_rng(int (*fn)(void *buf, size_t len)) {
+    g_tls_rng = fn;
+}
+
+static int tls_fill_random(uint8_t *buf, size_t len) {
+    return g_tls_rng ? g_tls_rng(buf, len) : secure_random_bytes(buf, len);
+}
+
+/* Run the server TLS handshake over the accepted blocking socket. Returns an
+ * established, heap-allocated transport on success, or NULL on failure (the
+ * transport already sent any alert and the caller closes the socket). The ephemeral
+ * key and ServerHello random are fresh per connection. */
+static tls_transport_t *tls_do_handshake(http_server_t *server, int fd) {
+    tls_transport_t *t = (tls_transport_t *)malloc(sizeof *t);
+    uint8_t eph[32], rnd[32];
+    tls_server_config_t cfg;
+
+    if (t == NULL) {
+        return NULL;
+    }
+    if (tls_fill_random(eph, sizeof eph) != 0 || tls_fill_random(rnd, sizeof rnd) != 0) {
+        secure_zero(eph, sizeof eph);
+        free(t);
+        return NULL;
+    }
+    memset(&cfg, 0, sizeof cfg);
+    cfg.cert_der = server->tls_cert_der;
+    cfg.cert_len = server->tls_cert_len;
+    cfg.ed25519_seed = server->tls_ed25519_seed;
+    cfg.ed25519_pub = server->tls_ed25519_pub;
+    cfg.server_eph_sk = eph;      /* borrowed only for the duration of the accept call */
+    cfg.server_random = rnd;
+    if (tls_transport_accept(t, fd, &cfg) != 0) {
+        secure_zero(eph, sizeof eph);
+        free(t);
+        return NULL;
+    }
+    secure_zero(eph, sizeof eph);
+    return t;
+}
+#endif /* WEBLIB_TLS */
+
 /* Handle single connection */
 static void *handle_connection(void *arg) {
     connection_t *conn = (connection_t *)arg;
@@ -769,6 +859,21 @@ static void *handle_connection(void *arg) {
     bool connection_open = true;
     char read_buf[READ_BUFFER_SIZE];
 
+#ifdef WEBLIB_TLS
+    if (server->tls_enabled) {
+        conn->tls = tls_do_handshake(server, client_fd);
+        if (conn->tls == NULL) {
+            /* Handshake failed; drop the connection (mirror the normal teardown). */
+            close(client_fd);
+            pthread_mutex_lock(&server->conn_lock);
+            server->active_connections--;
+            pthread_mutex_unlock(&server->conn_lock);
+            free(conn);
+            return NULL;
+        }
+    }
+#endif
+
     while (connection_open) {
         parser_result_t result = PARSER_INCOMPLETE;
         bool keep_alive = false;
@@ -776,7 +881,7 @@ static void *handle_connection(void *arg) {
         conn->request = http_request_create();
         conn->response = http_response_create();
         if (!conn->request || !conn->response) {
-            send_error_response(client_fd, HTTP_INTERNAL_ERROR, "Internal Server Error");
+            send_error_response(client_fd, CONN_TLS(conn), HTTP_INTERNAL_ERROR, "Internal Server Error");
             connection_open = false;
             goto iteration_cleanup;
         }
@@ -788,7 +893,7 @@ static void *handle_connection(void *arg) {
             http_parser_init(&conn->parser, conn->request);
             parser_initialized = true;
             if (conn->parser.state == PARSE_STATE_ERROR) {
-                send_error_response(client_fd, conn->parser.error_status, conn->parser.error_message);
+                send_error_response(client_fd, CONN_TLS(conn), conn->parser.error_status, conn->parser.error_message);
                 connection_open = false;
                 goto iteration_cleanup;
             }
@@ -809,7 +914,7 @@ static void *handle_connection(void *arg) {
              * from holding the worker thread indefinitely (slow-loris). */
             if (server->request_timeout_sec > 0 &&
                 (long)(monotonic_seconds() - request_start) >= (long)server->request_timeout_sec) {
-                send_error_response(client_fd, HTTP_REQUEST_TIMEOUT, "Request Timeout");
+                send_error_response(client_fd, CONN_TLS(conn), HTTP_REQUEST_TIMEOUT, "Request Timeout");
                 connection_open = false;
                 goto iteration_cleanup;
             }
@@ -817,9 +922,9 @@ static void *handle_connection(void *arg) {
             if (result == PARSER_EXPECT_CONTINUE) {
                 /* RFC 7231 §5.1.1: send 100 Continue before waiting for body */
                 static const char CONTINUE_RESP[] = "HTTP/1.1 100 Continue\r\n\r\n";
-                if (send_all(client_fd, CONTINUE_RESP, sizeof(CONTINUE_RESP) - 1) < 0) {
+                if (send_all(client_fd, CONN_TLS(conn), CONTINUE_RESP, sizeof(CONTINUE_RESP) - 1) < 0) {
                     perror("send 100 Continue failed");
-                    send_error_response(client_fd, HTTP_INTERNAL_ERROR, "Socket write error");
+                    send_error_response(client_fd, CONN_TLS(conn), HTTP_INTERNAL_ERROR, "Socket write error");
                     connection_open = false;
                     goto iteration_cleanup;
                 }
@@ -831,7 +936,7 @@ static void *handle_connection(void *arg) {
                 result = http_parser_execute(&conn->parser, NULL, 0);
                 continue;
             }
-            ssize_t bytes_read = recv(client_fd, read_buf, sizeof(read_buf), 0);
+            ssize_t bytes_read = conn_read(client_fd, CONN_TLS(conn), read_buf, sizeof(read_buf));
             if (bytes_read < 0) {
                 if (errno == EINTR) {
                     continue;
@@ -840,12 +945,12 @@ static void *handle_connection(void *arg) {
                     /* SO_RCVTIMEO fired: the client stalled without completing
                      * the request. That is a client timeout (408), not a
                      * server error (500). */
-                    send_error_response(client_fd, HTTP_REQUEST_TIMEOUT, "Request Timeout");
+                    send_error_response(client_fd, CONN_TLS(conn), HTTP_REQUEST_TIMEOUT, "Request Timeout");
                     connection_open = false;
                     goto iteration_cleanup;
                 }
                 perror("recv failed");
-                send_error_response(client_fd, HTTP_INTERNAL_ERROR, "Socket read error");
+                send_error_response(client_fd, CONN_TLS(conn), HTTP_INTERNAL_ERROR, "Socket read error");
                 connection_open = false;
                 goto iteration_cleanup;
             }
@@ -859,7 +964,7 @@ static void *handle_connection(void *arg) {
 
         if (result == PARSER_ERROR) {
             http_status_t status = conn->parser.error_status ? conn->parser.error_status : HTTP_BAD_REQUEST;
-            send_error_response(client_fd, status, conn->parser.error_message);
+            send_error_response(client_fd, CONN_TLS(conn), status, conn->parser.error_message);
             connection_open = false;
             goto iteration_cleanup;
         }
@@ -874,19 +979,30 @@ static void *handle_connection(void *arg) {
 
         /* Check for WebSocket upgrade (status 101 Switching Protocols) */
         if (conn->response->status == HTTP_SWITCHING_PROTOCOLS) {
+#ifdef WEBLIB_TLS
+            if (conn->tls != NULL) {
+                /* WebSocket-over-TLS (wss) is not wired yet; refuse the upgrade
+                 * cleanly instead of speaking plaintext WS frames over the TLS
+                 * connection (deferred to the interoperability milestone). */
+                send_error_response(client_fd, CONN_TLS(conn), HTTP_SERVICE_UNAVAILABLE,
+                                    "WebSocket over TLS not supported");
+                connection_open = false;
+                goto iteration_cleanup;
+            }
+#endif
             /* Send the upgrade response */
-            send_response(client_fd, conn->response, false);
-            
+            send_response(client_fd, CONN_TLS(conn), conn->response, false);
+
             /* Enter WebSocket mode - this function won't return until WS closes */
             handle_websocket_connection(client_fd, conn->request);
-            
+
             /* WebSocket closed, exit connection loop */
             connection_open = false;
             goto iteration_cleanup;
         }
 
         keep_alive = conn->parser.keep_alive && !response_forces_close(conn->response);
-        send_response(client_fd, conn->response, keep_alive);
+        send_response(client_fd, CONN_TLS(conn), conn->response, keep_alive);
 
         if (!keep_alive) {
             connection_open = false;
@@ -906,13 +1022,20 @@ static void *handle_connection(void *arg) {
     if (parser_initialized) {
         http_parser_destroy(&conn->parser);
     }
+#ifdef WEBLIB_TLS
+    if (conn->tls != NULL) {
+        tls_transport_close(conn->tls);   /* close_notify (best effort) + wipe keys */
+        free(conn->tls);
+        conn->tls = NULL;
+    }
+#endif
     close(client_fd);
-    
+
     /* BUG-6 fix: Decrement active connection count */
     pthread_mutex_lock(&server->conn_lock);
     server->active_connections--;
     pthread_mutex_unlock(&server->conn_lock);
-    
+
     free(conn);
     return NULL;
 }
@@ -1148,7 +1271,14 @@ static void http_response_destroy(http_response_t *res) {
     free(res);
 }
 
-static int send_all(int fd, const char *buf, size_t len) {
+static int send_all(int fd, void *tls, const char *buf, size_t len) {
+#ifdef WEBLIB_TLS
+    if (tls != NULL) {
+        return tls_transport_write((tls_transport_t *)tls, buf, len);
+    }
+#else
+    (void)tls;
+#endif
     size_t sent_total = 0;
     while (sent_total < len) {
         ssize_t sent = send(fd, buf + sent_total, len - sent_total, SEND_FLAGS);
@@ -1161,6 +1291,18 @@ static int send_all(int fd, const char *buf, size_t len) {
         sent_total += (size_t)sent;
     }
     return 0;
+}
+
+/* recv() equivalent that transparently decrypts application data when `tls` is set. */
+static ssize_t conn_read(int fd, void *tls, void *buf, size_t len) {
+#ifdef WEBLIB_TLS
+    if (tls != NULL) {
+        return tls_transport_read((tls_transport_t *)tls, buf, len);
+    }
+#else
+    (void)tls;
+#endif
+    return recv(fd, buf, len, 0);
 }
 
 static int serialize_response(http_response_t *res, bool keep_alive, char **header_out, size_t *header_len_out) {
@@ -1285,7 +1427,7 @@ static bool response_forces_close(http_response_t *res) {
     return false;
 }
 
-static void send_response(int client_fd, http_response_t *res, bool keep_alive) {
+static void send_response(int client_fd, void *tls, http_response_t *res, bool keep_alive) {
     if (!res || res->sent) {
         return;
     }
@@ -1296,9 +1438,9 @@ static void send_response(int client_fd, http_response_t *res, bool keep_alive) 
         return;
     }
 
-    if (send_all(client_fd, header_buf, header_len) == 0) {
+    if (send_all(client_fd, tls, header_buf, header_len) == 0) {
         if (res->body && res->body_length > 0) {
-            send_all(client_fd, res->body, res->body_length);
+            send_all(client_fd, tls, res->body, res->body_length);
         }
     }
 
@@ -1306,14 +1448,14 @@ static void send_response(int client_fd, http_response_t *res, bool keep_alive) 
     res->sent = true;
 }
 
-static void send_error_response(int client_fd, http_status_t status, const char *message) {
+static void send_error_response(int client_fd, void *tls, http_status_t status, const char *message) {
     http_response_t *res = http_response_create();
     if (!res) {
         return;
     }
     const char *body = message ? message : "";
     http_response_send_text(res, status, body);
-    send_response(client_fd, res, false);
+    send_response(client_fd, tls, res, false);
     http_response_destroy(res);
 }
 
@@ -2299,6 +2441,72 @@ int http_server_set_async(http_server_t *server, bool enable) {
     return 0;
 }
 
+#ifdef WEBLIB_TLS
+int http_server_enable_tls(http_server_t *server, const char *cert_pem, size_t cert_len,
+                           const char *key_pem, size_t key_len) {
+    uint8_t *cert_der;
+    size_t cert_der_len = 0;
+    uint8_t key_der[256];   /* a PKCS#8 Ed25519 key is ~48 bytes; 256 is ample */
+    size_t key_der_len = 0;
+    uint8_t seed[32], pub[32];
+
+    if (!server || !cert_pem || cert_len == 0 || !key_pem || key_len == 0) {
+        return -1;
+    }
+    if (server->running) {
+        return -1;   /* must be configured before http_server_listen() */
+    }
+    if (server->async_mode) {
+        return -1;   /* TLS termination is only wired for the threaded path */
+    }
+    if (server->tls_enabled) {
+        return -1;   /* already enabled */
+    }
+
+    /* Certificate: decode the PEM "CERTIFICATE" block to DER (kept opaque and sent
+     * as-is in the handshake). The DER never exceeds the PEM's length. */
+    cert_der = (uint8_t *)malloc(cert_len);
+    if (!cert_der) {
+        return -1;
+    }
+    if (pem_decode("CERTIFICATE", cert_pem, cert_len, cert_der, cert_len, &cert_der_len) != 0
+        || cert_der_len == 0) {
+        free(cert_der);
+        return -1;
+    }
+
+    /* Private key: PEM "PRIVATE KEY" -> PKCS#8 DER -> raw Ed25519 seed; derive pub. */
+    if (pem_decode("PRIVATE KEY", key_pem, key_len, key_der, sizeof key_der, &key_der_len) != 0
+        || ed25519_parse_pkcs8(key_der, key_der_len, seed) != 0) {
+        secure_zero(key_der, sizeof key_der);
+        secure_zero(seed, sizeof seed);
+        free(cert_der);
+        return -1;
+    }
+    ed25519_public_key(pub, seed);
+
+    server->tls_cert_der = cert_der;
+    server->tls_cert_len = cert_der_len;
+    memcpy(server->tls_ed25519_seed, seed, sizeof server->tls_ed25519_seed);
+    memcpy(server->tls_ed25519_pub, pub, sizeof server->tls_ed25519_pub);
+    server->tls_enabled = true;
+
+    secure_zero(key_der, sizeof key_der);
+    secure_zero(seed, sizeof seed);
+    return 0;
+}
+#else
+int http_server_enable_tls(http_server_t *server, const char *cert_pem, size_t cert_len,
+                           const char *key_pem, size_t key_len) {
+    (void)server;
+    (void)cert_pem;
+    (void)cert_len;
+    (void)key_pem;
+    (void)key_len;
+    return -1;   /* built without TLS (reconfigure with -DWEBLIB_ENABLE_TLS=ON) */
+}
+#endif /* WEBLIB_TLS */
+
 /* Get event loop */
 event_loop_t *http_server_get_event_loop(http_server_t *server) {
     if (!server || !server->async_mode) {
@@ -2589,7 +2797,7 @@ static void async_accept_handler(int fd, int events, void *user_data) {
     conn->is_websocket = false;
     conn->ws_conn = NULL;
     if (!conn->request || !conn->response) {
-        send_error_response(client_fd, HTTP_INTERNAL_ERROR, "Internal Server Error");
+        send_error_response(client_fd, NULL, HTTP_INTERNAL_ERROR, "Internal Server Error");
         free_async_connection(conn);
         return;
     }
@@ -2598,7 +2806,7 @@ static void async_accept_handler(int fd, int events, void *user_data) {
     conn->parser_initialized = true;
     if (conn->parser.state == PARSE_STATE_ERROR) {
         http_status_t status = conn->parser.error_status ? conn->parser.error_status : HTTP_INTERNAL_ERROR;
-        send_error_response(client_fd, status, conn->parser.error_message);
+        send_error_response(client_fd, NULL, status, conn->parser.error_message);
         free_async_connection(conn);
         return;
     }

--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -64,12 +64,15 @@ ctest --test-dir build-tls
   the engine over a real fd; for the 1-RTT `TLS_CHACHA20_POLY1305_SHA256` + X25519 +
   Ed25519 flow, each cross-checked against an independent Python oracle (the adapter
   over an actual socketpair).
-- **Phase 4 — integration (next):** wire `tls_transport` into the threaded server
-  path and add `http_server_enable_tls`; internal TLS termination validated with a
-  local self-signed cert.
+- **Phase 4 — integration (landed):** `http_server_enable_tls()` wires
+  `tls_transport` into the threaded server path — the handshake runs on accept and
+  the request/response I/O is TLS-routed, so the server terminates TLS internally.
+  The non-TLS path is byte-identical (the stress suite passes unchanged), and an
+  end-to-end test drives a real TLS 1.3 request/response against the live server.
+  Threaded mode only; WebSocket-over-TLS and the async path are not yet wired.
 - **Interoperability (separate milestone):** real `curl` / `openssl s_client` /
   browser interop, negotiation edge cases, ClientHello fuzzing, honest security
-  labeling — tracked as its own milestone, not folded into integration.
+  labeling — tracked as its own milestone (#1), not folded into integration.
 
 Design references in-repo: the "Pure C TLS (not OpenSSL)" ADR in
 [`NEXT_PHASE.md`](../../NEXT_PHASE.md) and the Phase 11 TLS plan in

--- a/src/tls/tls_transport.c
+++ b/src/tls/tls_transport.c
@@ -12,6 +12,7 @@
 #include "kamran.k"   /* secure_zero */
 #include <errno.h>
 #include <string.h>
+#include <time.h>
 #include <sys/socket.h>
 
 /* Suppress SIGPIPE on send() where the platform supports the flag (Linux);
@@ -97,7 +98,9 @@ static int transport_pump(tls_transport_t *t) {
     return 1;
 }
 
-int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *cfg) {
+int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *cfg,
+                         int timeout_seconds) {
+    time_t start;
     if (t == NULL) {
         return -1;
     }
@@ -115,8 +118,13 @@ int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *
     t->app_off = 0;
     t->app_len = 0;
     t->eof = 0;
+    start = time(NULL);
 
     while (tls_khannection_state(&t->conn) == TLS_KHANNECTION_HANDSHAKE) {
+        if (timeout_seconds > 0 && (long)(time(NULL) - start) >= (long)timeout_seconds) {
+            transport_wipe(t);   /* slow-loris: handshake exceeded its wall-clock budget */
+            return -1;
+        }
         if (transport_pump(t) <= 0) {
             transport_wipe(t);   /* error or EOF mid-handshake: fail closed */
             return -1;

--- a/src/tls/tls_transport.h
+++ b/src/tls/tls_transport.h
@@ -72,8 +72,14 @@ typedef struct {
  * success (the connection is established and ready for read/write), -1 on any
  * failure (a fatal alert may have been written to the peer; the caller should close
  * `fd`). Does not take ownership of `fd`.
+ *
+ * `timeout_seconds` bounds the TOTAL wall-clock time of the handshake (0 = no
+ * limit). Per-recv socket timeouts (SO_RCVTIMEO) only bound a single read, so a
+ * slow-drip client dribbling a byte at a time could otherwise pin this call
+ * indefinitely; this aggregate deadline is the slow-loris guard for the handshake.
  */
-int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *cfg);
+int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *cfg,
+                         int timeout_seconds);
 
 /*
  * Read up to `len` decrypted application bytes into `buf`, blocking until at least

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,14 +73,17 @@ if(NOT EMSCRIPTEN)
         add_test(NAME TlsTransportTests COMMAND test_tls_transport)
 
         # End-to-end http_server_enable_tls: a real TLS server + a KAT client doing a
-        # full HTTPS request/response over a loopback socket.
-        add_executable(test_tls_http test_tls_http.c)
-        target_include_directories(test_tls_http PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls
-            ${CMAKE_CURRENT_SOURCE_DIR}/../src)
-        target_compile_definitions(test_tls_http PRIVATE WEBLIB_TLS)
-        target_link_libraries(test_tls_http weblib ${PLATFORM_LIBS})
-        add_test(NAME TlsHttpTests COMMAND test_tls_http)
+        # full HTTPS request/response over a loopback socket. Needs the deterministic
+        # RNG test hook, so it is built only when WEBLIB_TLS_TEST_HOOKS is enabled.
+        if(WEBLIB_TLS_TEST_HOOKS)
+            add_executable(test_tls_http test_tls_http.c)
+            target_include_directories(test_tls_http PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls
+                ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+            target_compile_definitions(test_tls_http PRIVATE WEBLIB_TLS)
+            target_link_libraries(test_tls_http weblib ${PLATFORM_LIBS})
+            add_test(NAME TlsHttpTests COMMAND test_tls_http)
+        endif()
     endif()
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,16 @@ if(NOT EMSCRIPTEN)
         target_compile_definitions(test_tls_transport PRIVATE WEBLIB_TLS)
         target_link_libraries(test_tls_transport weblib ${PLATFORM_LIBS})
         add_test(NAME TlsTransportTests COMMAND test_tls_transport)
+
+        # End-to-end http_server_enable_tls: a real TLS server + a KAT client doing a
+        # full HTTPS request/response over a loopback socket.
+        add_executable(test_tls_http test_tls_http.c)
+        target_include_directories(test_tls_http PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+        target_compile_definitions(test_tls_http PRIVATE WEBLIB_TLS)
+        target_link_libraries(test_tls_http weblib ${PLATFORM_LIBS})
+        add_test(NAME TlsHttpTests COMMAND test_tls_http)
     endif()
 endif()
 

--- a/tests/test_tls_http.c
+++ b/tests/test_tls_http.c
@@ -1,0 +1,284 @@
+/*
+ * test_tls_http.c — end-to-end http_server_enable_tls integration.
+ * Built only with -DWEBLIB_ENABLE_TLS=ON.
+ *
+ * Starts a real threaded http_server with TLS enabled on a loopback port, its
+ * per-connection ephemeral key + ServerHello random pinned (via the internal test
+ * RNG hook) to the independent oracle's known-answer values. A client socket then
+ * drives a full TLS 1.3 handshake with the oracle's KAT vectors, sends an encrypted
+ * HTTP request, and checks the encrypted HTTP response — proving the handshake-on-
+ * accept and the TLS-routed request/response path both work.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#ifdef WEBLIB_TLS
+#include <pthread.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+#include "kamran.k"
+#include "record.h"
+#include "handshake.h"   /* TLS_HS_FINISHED, TLS_CONTENT_* */
+#endif
+
+static int g_failures = 0;
+static void check_true(const char *label, int cond) {
+    if (cond) {
+        printf("PASS: %s\n", label);
+    } else {
+        printf("FAIL: %s\n", label);
+        g_failures++;
+    }
+}
+
+#ifdef WEBLIB_TLS
+
+/* ==== oracle-derived known-answer vectors (subset) ==== */
+static const uint8_t KAT_CH[144] = {
+    0x01, 0x00, 0x00, 0x8c, 0x03, 0x03, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0x20, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+    0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x00,
+    0x02, 0x13, 0x03, 0x01, 0x00, 0x00, 0x41, 0x00, 0x2b, 0x00, 0x03, 0x02,
+    0x03, 0x04, 0x00, 0x0a, 0x00, 0x04, 0x00, 0x02, 0x00, 0x1d, 0x00, 0x0d,
+    0x00, 0x04, 0x00, 0x02, 0x08, 0x07, 0x00, 0x33, 0x00, 0x26, 0x00, 0x24,
+    0x00, 0x1d, 0x00, 0x20, 0x79, 0xa6, 0x31, 0xee, 0xde, 0x1b, 0xf9, 0xc9,
+    0x8f, 0x12, 0x03, 0x2c, 0xde, 0xad, 0xd0, 0xe7, 0xa0, 0x79, 0x39, 0x8f,
+    0xc7, 0x86, 0xb8, 0x8c, 0xc8, 0x46, 0xec, 0x89, 0xaf, 0x85, 0xa5, 0x1a,
+};
+static const uint8_t KAT_SERVER_EPH[32] = {
+    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b,
+    0x6c, 0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77,
+    0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+};
+static const uint8_t KAT_SERVER_RND[32] = {
+    0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e,
+    0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e,
+    0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e, 0x5e,
+};
+static const uint8_t KAT_SERVER_HS_KEY[32] = {
+    0x41, 0xc1, 0xe2, 0xdb, 0x19, 0x3b, 0xc8, 0x84, 0x1e, 0xb5, 0xc6, 0x4a,
+    0xe3, 0x08, 0x09, 0x30, 0x6e, 0x8a, 0xc8, 0x2e, 0x33, 0xc7, 0xd5, 0xfe,
+    0x64, 0xce, 0x20, 0x6f, 0x2f, 0x32, 0xd6, 0xa4,
+};
+static const uint8_t KAT_SERVER_HS_IV[12] = {
+    0x38, 0x9c, 0xa9, 0x76, 0x72, 0x06, 0x7e, 0x0c, 0x73, 0x31, 0xf0, 0x64,
+};
+static const uint8_t KAT_CLIENT_HS_KEY[32] = {
+    0x5d, 0x09, 0xb3, 0x22, 0x93, 0x47, 0xca, 0x9f, 0x67, 0x0f, 0x6b, 0x98,
+    0x8d, 0x30, 0xdc, 0xa3, 0x4f, 0xc4, 0x45, 0x77, 0x05, 0xf4, 0x5d, 0x30,
+    0xd2, 0xb5, 0x19, 0x39, 0x5f, 0x0b, 0x85, 0xd2,
+};
+static const uint8_t KAT_CLIENT_HS_IV[12] = {
+    0xa3, 0x18, 0xa3, 0xeb, 0x91, 0x9e, 0xb2, 0x74, 0x50, 0x5a, 0x6c, 0x9b,
+};
+static const uint8_t KAT_CLIENT_FINISHED_VD[32] = {
+    0xa3, 0xb6, 0x47, 0x2e, 0xd7, 0x60, 0xfd, 0xb0, 0xc3, 0x55, 0x79, 0xf0,
+    0x8e, 0xdb, 0x75, 0xbc, 0x87, 0x59, 0x9e, 0xa8, 0x51, 0xd1, 0x93, 0x22,
+    0x85, 0xce, 0x6f, 0x29, 0x0d, 0x0b, 0xf7, 0x4f,
+};
+static const uint8_t KAT_CLIENT_AP_KEY[32] = {
+    0x28, 0xc8, 0x92, 0x97, 0x21, 0xfa, 0x74, 0x2e, 0xc8, 0x0a, 0x78, 0x1b,
+    0xed, 0xa8, 0x12, 0x2d, 0x28, 0xad, 0x03, 0xc3, 0x04, 0xdc, 0x8d, 0x8b,
+    0x07, 0xa6, 0xbe, 0x6a, 0x35, 0x76, 0x8e, 0xa4,
+};
+static const uint8_t KAT_CLIENT_AP_IV[12] = {
+    0xa3, 0xd7, 0xd4, 0x06, 0x4c, 0x40, 0x49, 0xc6, 0xab, 0x8a, 0x76, 0xc5,
+};
+static const uint8_t KAT_SERVER_AP_KEY[32] = {
+    0x36, 0xe0, 0x70, 0xfc, 0x68, 0xdd, 0xab, 0x6d, 0xa2, 0x8f, 0xa6, 0x3b,
+    0xe1, 0xac, 0x73, 0x6b, 0x01, 0x63, 0x57, 0xb7, 0xe2, 0x3c, 0x72, 0x8a,
+    0x0e, 0xdd, 0x46, 0x05, 0xe7, 0xc3, 0xf4, 0x1d,
+};
+static const uint8_t KAT_SERVER_AP_IV[12] = {
+    0x39, 0x6b, 0x0d, 0x59, 0xec, 0xb3, 0x89, 0x34, 0x53, 0x87, 0x4a, 0xa4,
+};
+
+/* Cert = the KAT cert blob; key = PKCS#8 Ed25519 wrapping the KAT seed (precomputed). */
+static const char CERT_PEM[] =
+    "-----BEGIN CERTIFICATE-----\n"
+    "oKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr+goaKjpKWmp6ipqqusra6v"
+    "sLGys7S1tre4ubq7vL2+v6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/\n"
+    "-----END CERTIFICATE-----\n";
+static const char KEY_PEM[] =
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MC4CAQAwBQYDK2VwBCIEIAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8g\n"
+    "-----END PRIVATE KEY-----\n";
+
+/* Internal test hook (defined in http_server.c, not part of the public API). */
+extern void http_server__tls_test_rng(int (*fn)(void *buf, size_t len));
+
+static int g_rng_call = 0;
+static int test_rng(void *buf, size_t len) {
+    if (len != 32) {
+        return -1;
+    }
+    /* tls_do_handshake asks for the ephemeral key first, then the ServerHello
+     * random — supply the KAT values in that order so the handshake is deterministic. */
+    memcpy(buf, (g_rng_call++ % 2 == 0) ? KAT_SERVER_EPH : KAT_SERVER_RND, 32);
+    return 0;
+}
+
+static void hello_handler(http_request_t *req, http_response_t *res) {
+    (void)req;
+    http_response_send_text(res, HTTP_OK, "TLS-OK");
+}
+
+/* ---- client-side socket + record helpers ---- */
+static int write_all_c(int fd, const uint8_t *buf, size_t n) {
+    size_t off = 0;
+    while (off < n) {
+        ssize_t s = send(fd, buf + off, n - off, 0);
+        if (s < 0) { if (errno == EINTR) continue; return -1; }
+        off += (size_t)s;
+    }
+    return 0;
+}
+static int read_n(int fd, uint8_t *buf, size_t n) {
+    size_t off = 0;
+    while (off < n) {
+        ssize_t r = recv(fd, buf + off, n - off, 0);
+        if (r < 0) { if (errno == EINTR) continue; return -1; }
+        if (r == 0) return (int)off;
+        off += (size_t)r;
+    }
+    return (int)off;
+}
+static int read_record(int fd, uint8_t *buf, size_t cap) {
+    size_t body;
+    if (cap < TLS_RECORD_HEADER_LEN) return -1;
+    if (read_n(fd, buf, TLS_RECORD_HEADER_LEN) != (int)TLS_RECORD_HEADER_LEN) return -1;
+    body = ((size_t)buf[3] << 8) | buf[4];
+    if (TLS_RECORD_HEADER_LEN + body > cap) return -1;
+    if (read_n(fd, buf + TLS_RECORD_HEADER_LEN, body) != (int)body) return -1;
+    return (int)(TLS_RECORD_HEADER_LEN + body);
+}
+
+static void test_tls_http(void) {
+    http_server_t *server;
+    router_t *router;
+    uint16_t port = 0;
+    int listening = 0, p;
+    int cfd;
+    struct sockaddr_in addr;
+    uint8_t ch[TLS_RECORD_HEADER_LEN + sizeof KAT_CH], sh[600], flight[2048], rec[512];
+    uint8_t flightpt[512];
+    size_t rl = 0, ptl = 0;
+    uint8_t ctype = 0, finmsg[4 + 32];
+    static const uint8_t ccs[6] = { 0x14, 0x03, 0x03, 0x00, 0x01, 0x01 };
+    static const char REQ[] = "GET /hello HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n";
+    char resp[4096];
+    size_t resp_len = 0;
+    uint64_t sseq = 0;
+    int i, shl, fll;
+
+    server = http_server_create();
+    router = router_create();
+    check_true("http-tls: server + router created", server != NULL && router != NULL);
+    if (!server || !router) return;
+    router_add_route(router, HTTP_GET, "/hello", hello_handler);
+    http_server_set_router(server, router);
+
+    g_rng_call = 0;
+    http_server__tls_test_rng(test_rng);
+    check_true("http-tls: enable_tls with a valid cert/key",
+               http_server_enable_tls(server, CERT_PEM, strlen(CERT_PEM),
+                                      KEY_PEM, strlen(KEY_PEM)) == 0);
+
+    for (p = 45443; p < 45473; p++) {
+        if (http_server_listen(server, (uint16_t)p) == 0) {
+            port = (uint16_t)p;
+            listening = 1;
+            break;
+        }
+    }
+    check_true("http-tls: server listening on a loopback port", listening);
+    if (!listening) { http_server_destroy(server); router_destroy(router); return; }
+
+    cfd = socket(AF_INET, SOCK_STREAM, 0);
+    memset(&addr, 0, sizeof addr);
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    check_true("http-tls: client connected", cfd >= 0
+               && connect(cfd, (struct sockaddr *)&addr, sizeof addr) == 0);
+
+    /* Handshake (KAT client). */
+    ch[0] = TLS_CONTENT_HANDSHAKE;
+    ch[1] = 0x03; ch[2] = 0x03;
+    ch[3] = (uint8_t)((sizeof KAT_CH) >> 8);
+    ch[4] = (uint8_t)(sizeof KAT_CH);
+    memcpy(ch + TLS_RECORD_HEADER_LEN, KAT_CH, sizeof KAT_CH);
+    write_all_c(cfd, ch, sizeof ch);
+    shl = read_record(cfd, sh, sizeof sh);
+    fll = read_record(cfd, flight, sizeof flight);
+    check_true("http-tls: server flight opens under the oracle handshake key",
+               shl > 0 && sh[0] == 0x16 && fll > 0 && flight[0] == 0x17
+               && tls_record_open(KAT_SERVER_HS_KEY, KAT_SERVER_HS_IV, 0,
+                                  flight, (size_t)fll, flightpt, sizeof flightpt,
+                                  &ptl, &ctype) == 1
+               && ctype == TLS_CONTENT_HANDSHAKE);
+
+    write_all_c(cfd, ccs, sizeof ccs);
+    finmsg[0] = TLS_HS_FINISHED; finmsg[1] = 0; finmsg[2] = 0; finmsg[3] = 0x20;
+    memcpy(finmsg + 4, KAT_CLIENT_FINISHED_VD, 32);
+    tls_record_seal(KAT_CLIENT_HS_KEY, KAT_CLIENT_HS_IV, 0, TLS_CONTENT_HANDSHAKE,
+                    finmsg, sizeof finmsg, 0, rec, sizeof rec, &rl);
+    write_all_c(cfd, rec, rl);
+
+    /* Encrypted HTTP request. */
+    tls_record_seal(KAT_CLIENT_AP_KEY, KAT_CLIENT_AP_IV, 0, TLS_CONTENT_APPLICATION_DATA,
+                    (const uint8_t *)REQ, sizeof REQ - 1, 0, rec, sizeof rec, &rl);
+    check_true("http-tls: sent encrypted HTTP request", write_all_c(cfd, rec, rl) == 0);
+
+    /* Read + decrypt the encrypted HTTP response (header record, then body record). */
+    for (i = 0; i < 6; i++) {
+        uint8_t recbuf[4096], pt[4096];
+        size_t pl = 0;
+        uint8_t ct = 0;
+        int r = read_record(cfd, recbuf, sizeof recbuf);
+        if (r <= 0 || recbuf[0] != 0x17) break;
+        if (!tls_record_open(KAT_SERVER_AP_KEY, KAT_SERVER_AP_IV, sseq,
+                             recbuf, (size_t)r, pt, sizeof pt, &pl, &ct)) break;
+        sseq++;
+        if (ct == TLS_CONTENT_APPLICATION_DATA) {
+            if (resp_len + pl < sizeof resp) {
+                memcpy(resp + resp_len, pt, pl);
+                resp_len += pl;
+                resp[resp_len] = '\0';
+            }
+            if (strstr(resp, "TLS-OK") != NULL) break;   /* got the body */
+        } else if (ct == TLS_CONTENT_ALERT) {
+            break;   /* close_notify */
+        }
+    }
+    resp[resp_len < sizeof resp ? resp_len : sizeof resp - 1] = '\0';
+    check_true("http-tls: response is HTTP 200 over TLS", strstr(resp, "200") != NULL);
+    check_true("http-tls: response body routed + encrypted correctly",
+               strstr(resp, "TLS-OK") != NULL);
+
+    close(cfd);
+    http_server_stop(server);
+    http_server_destroy(server);
+    router_destroy(router);
+}
+#endif /* WEBLIB_TLS */
+
+int main(void) {
+#ifndef WEBLIB_TLS
+    printf("FAIL: test_tls_http built without WEBLIB_TLS defined\n");
+    return 1;
+#else
+    test_tls_http();
+    if (g_failures == 0) {
+        printf("All TLS http integration tests passed.\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+#endif
+}

--- a/tests/test_tls_http.c
+++ b/tests/test_tls_http.c
@@ -200,6 +200,11 @@ static void test_tls_http(void) {
         }
     }
 
+    /* Enabling async after TLS must be refused — otherwise the async path would
+     * silently serve plaintext on the HTTPS port (adversarial-review finding). */
+    check_true("http-tls: set_async(true) rejected once TLS is enabled",
+               http_server_set_async(server, true) == -1);
+
     for (p = 45443; p < 46443; p++) {
         if (http_server_listen(server, (uint16_t)p) == 0) {
             port = (uint16_t)p;

--- a/tests/test_tls_http.c
+++ b/tests/test_tls_http.c
@@ -187,11 +187,20 @@ static void test_tls_http(void) {
 
     g_rng_call = 0;
     http_server__tls_test_rng(test_rng);
-    check_true("http-tls: enable_tls with a valid cert/key",
-               http_server_enable_tls(server, CERT_PEM, strlen(CERT_PEM),
-                                      KEY_PEM, strlen(KEY_PEM)) == 0);
+    {
+        int tls_rc = http_server_enable_tls(server, CERT_PEM, strlen(CERT_PEM),
+                                            KEY_PEM, strlen(KEY_PEM));
+        check_true("http-tls: enable_tls with a valid cert/key", tls_rc == 0);
+        if (tls_rc != 0) {
+            /* Bail: otherwise we would speak a TLS ClientHello to a plaintext server
+             * and read_record() would block on the misframed HTTP response. */
+            http_server_destroy(server);
+            router_destroy(router);
+            return;
+        }
+    }
 
-    for (p = 45443; p < 45473; p++) {
+    for (p = 45443; p < 46443; p++) {
         if (http_server_listen(server, (uint16_t)p) == 0) {
             port = (uint16_t)p;
             listening = 1;
@@ -206,8 +215,19 @@ static void test_tls_http(void) {
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-    check_true("http-tls: client connected", cfd >= 0
-               && connect(cfd, (struct sockaddr *)&addr, sizeof addr) == 0);
+    {
+        int connected = (cfd >= 0
+                         && connect(cfd, (struct sockaddr *)&addr, sizeof addr) == 0);
+        check_true("http-tls: client connected", connected);
+        if (!connected) {
+            /* Bail cleanly rather than driving read_n()/read_record() on a dead fd. */
+            if (cfd >= 0) close(cfd);
+            http_server_stop(server);
+            http_server_destroy(server);
+            router_destroy(router);
+            return;
+        }
+    }
 
     /* Handshake (KAT client). */
     ch[0] = TLS_CONTENT_HANDSHAKE;

--- a/tests/test_tls_transport.c
+++ b/tests/test_tls_transport.c
@@ -17,6 +17,7 @@
 #ifdef WEBLIB_TLS
 #include <pthread.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 #include <errno.h>
 #include "tls_transport.h"
@@ -184,7 +185,7 @@ static void *server_thread(void *arg) {
     cfg.server_eph_sk = KAT_SERVER_EPH;
     cfg.server_random = KAT_SERVER_RND;
 
-    r->accept_rc = tls_transport_accept(&t, r->fd, &cfg);
+    r->accept_rc = tls_transport_accept(&t, r->fd, &cfg, 0);   /* 0 = no handshake time limit */
     if (r->accept_rc == 0) {
         r->req_len = tls_transport_read(&t, r->req, sizeof r->req - 1);
         if (r->req_len > 0) {
@@ -309,7 +310,7 @@ static void *server_thread_readonly(void *arg) {
     cfg.server_eph_sk = KAT_SERVER_EPH;
     cfg.server_random = KAT_SERVER_RND;
 
-    r->accept_rc = tls_transport_accept(&t, r->fd, &cfg);
+    r->accept_rc = tls_transport_accept(&t, r->fd, &cfg, 0);   /* 0 = no handshake time limit */
     if (r->accept_rc == 0) {
         r->req_len = tls_transport_read(&t, r->req, sizeof r->req - 1);
         if (r->req_len > 0) {
@@ -419,6 +420,71 @@ static void test_tls_transport_wipe(void) {
     check_true("wipe: teardown zeroes the buffered decrypted plaintext",
                !nonzero && t.app_len == 0 && t.app_off == 0);
 }
+
+/* Server that accepts with a 1-second aggregate handshake deadline. */
+static void *server_thread_slowloris(void *arg) {
+    static tls_transport_t t;
+    srv_result_t *r = (srv_result_t *)arg;
+    tls_server_config_t cfg;
+    struct timeval tv;
+
+    memset(&cfg, 0, sizeof cfg);
+    cfg.cert_der = KAT_CERT;
+    cfg.cert_len = sizeof KAT_CERT;
+    cfg.ed25519_seed = KAT_ED_SEED;
+    cfg.ed25519_pub = KAT_ED_PUB;
+    cfg.server_eph_sk = KAT_SERVER_EPH;
+    cfg.server_random = KAT_SERVER_RND;
+    /* A generous per-recv timeout so recv returns between drips (each drip is
+     * "progress"); the 1-second AGGREGATE deadline is what must fire. */
+    tv.tv_sec = 3;
+    tv.tv_usec = 0;
+    setsockopt(r->fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    r->accept_rc = tls_transport_accept(&t, r->fd, &cfg, 1);
+    tls_transport_close(&t);
+    return NULL;
+}
+
+/*
+ * Slow-loris guard: a client that opens a handshake record with a large declared
+ * body and then dribbles bytes (never completing it) must be cut off by the
+ * aggregate handshake deadline, not pin the worker forever.
+ */
+static void test_tls_transport_handshake_timeout(void) {
+    int sv[2];
+    pthread_t tid;
+    srv_result_t res;
+    int cfd, i;
+    /* Handshake record header declaring a 4096-byte body we will never finish. */
+    static const uint8_t hdr[5] = { 0x16, 0x03, 0x03, 0x10, 0x00 };
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+        check_true("slowloris: socketpair created", 0);
+        return;
+    }
+    res.fd = sv[0];
+    res.accept_rc = 999;
+    cfd = sv[1];
+    if (pthread_create(&tid, NULL, server_thread_slowloris, &res) != 0) {
+        check_true("slowloris: server thread started", 0);
+        close(sv[0]);
+        close(sv[1]);
+        return;
+    }
+    write_all_c(cfd, hdr, sizeof hdr);
+    for (i = 0; i < 20; i++) {
+        uint8_t b = (uint8_t)i;
+        if (write_all_c(cfd, &b, 1) != 0) {
+            break;   /* server closed the connection when its deadline fired */
+        }
+        usleep(150000);   /* 150 ms between drips — the record never completes */
+    }
+    close(cfd);
+    pthread_join(tid, NULL);
+    check_true("slowloris: dribbled handshake aborted by the wall-clock deadline",
+               res.accept_rc != 0);
+    close(sv[0]);
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -429,6 +495,7 @@ int main(void) {
     test_tls_transport();
     test_tls_transport_halfclose();
     test_tls_transport_wipe();
+    test_tls_transport_handshake_timeout();
     if (g_failures == 0) {
         printf("All TLS transport tests passed.\n");
     }


### PR DESCRIPTION
## Summary

Wires the pure-C TLS 1.3 stack into the **threaded HTTP server**. After `http_server_enable_tls()`, every accepted connection runs the TLS handshake before HTTP is spoken, and the request/response bytes are transparently encrypted/decrypted. **This is the first real HTTPS round-trip through the server** — internal termination, no dependencies.

```c
http_server_t *s = http_server_create();
http_server_set_router(s, router);
http_server_enable_tls(s, cert_pem, cert_len, key_pem, key_len);  /* PEM cert + Ed25519 key */
http_server_listen(s, 443);
```

## What it does

- **`http_server_enable_tls`** — decodes the PEM `CERTIFICATE` to DER (kept opaque), parses the PKCS#8 Ed25519 key to a seed + derives the public key, stores them on the server. Threaded-mode only (async rejected), must precede `listen`. A `-1` stub exists in a build without TLS.
- **Hot-path seam** — `send_all` / `send_response` / `send_error_response` and a new `conn_read` take a nullable transport pointer and route through `tls_transport` when set, else raw `recv`/`send`. The threaded path passes the connection's transport (`CONN_TLS(conn)`); the **shared async path** and the pre-connection overload rejections pass `NULL`. In a non-TLS build the pointer is always NULL → the path is byte-identical.
- **Handshake on accept** — `handle_connection` runs the handshake (fresh CSPRNG ephemeral + ServerHello random per connection) via `tls_transport`, then reads/writes over it, wiping + freeing the transport on teardown. WebSocket-over-TLS is refused for now (deferred to interop); the async path stays plaintext.

## No-regression proof (the important part)

This edits the production request/response path shared by the existing non-TLS server. The seam is designed so the non-TLS path is **byte-identical**, and that's proven: the **OFF build's full stress suite passes unchanged (6/6)**.

## Testing — end-to-end (new `TlsHttpTests`)

Starts a **real TLS-enabled server on a loopback port** and drives a full TLS 1.3 handshake + encrypted `GET /hello` from a client using the independent Python oracle's known-answer vectors (server randomness pinned via an internal test hook). It verifies the server's flight opens under the oracle's handshake key and the decrypted response is `HTTP 200` carrying the routed body. So the whole server TLS path is checked against a separate implementation.

## Verification matrix

- **OFF build:** 6/6 incl. the full stress suite — **non-TLS hot path byte-identical**.
- **TLS build:** 11/11.
- **ASan + UBSan** (`halt_on_error=1`) on the threaded server test: clean.
- **Negative control:** disabling the TLS write routing fails exactly the response-over-TLS assertions; restored.
- Zero warnings (`-Wall -Wextra -pedantic`).

## Scope / limitations (documented)

Threaded mode only; WebSocket-over-TLS (wss) and the async/event-loop path are not yet wired. Cert is carried opaque (the user supplies a real PEM). EXPERIMENTAL / UNAUDITED. **Real curl/openssl/browser interop is the separate interoperability milestone (#1)** — this PR is internal termination only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)