### PR TITLE
TLS interop (milestone #1): real openssl s_client HTTPS round-trip + example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,6 +21,12 @@ if(NOT EMSCRIPTEN)
     add_executable(rest_api_server rest_api_server.c)
     target_link_libraries(rest_api_server weblib ${PLATFORM_LIBS})
 
+    # HTTPS example — only when the experimental pure-C TLS layer is enabled
+    if(WEBLIB_ENABLE_TLS)
+        add_executable(tls_server tls_server.c)
+        target_link_libraries(tls_server weblib ${PLATFORM_LIBS})
+    endif()
+
     # Installation
     install(TARGETS simple_server async_server websocket_echo_server async_websocket_echo_server rest_api_server DESTINATION bin)
 endif()

--- a/examples/tls_server.c
+++ b/examples/tls_server.c
@@ -1,0 +1,135 @@
+/*
+ * tls_server.c — HTTPS example using the experimental pure-C TLS 1.3 layer.
+ *
+ * Build with -DWEBLIB_ENABLE_TLS=ON. Generate a self-signed Ed25519 cert first:
+ *
+ *   openssl genpkey -algorithm ed25519 -out key.pem
+ *   openssl req -x509 -new -key key.pem -out cert.pem -days 365 -subj "/CN=localhost"
+ *
+ * Run:   ./tls_server [cert.pem] [key.pem] [port]     (defaults: cert.pem key.pem 8443)
+ * Test:  curl -k https://localhost:8443/hello
+ *        printf 'GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n' \
+ *            | openssl s_client -quiet -connect localhost:8443
+ *
+ * The profile is TLS_CHACHA20_POLY1305_SHA256 + X25519 + Ed25519, so the client
+ * must accept an Ed25519 certificate (modern OpenSSL/browsers do). EXPERIMENTAL /
+ * UNAUDITED — not for production.
+ */
+#include "kamran.k"
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <unistd.h>
+
+static http_server_t *g_server = NULL;
+static volatile sig_atomic_t shutdown_requested = 0;
+
+static void signal_handler(int signum) {
+    (void)signum;
+    shutdown_requested = 1;
+}
+
+static void handle_root(http_request_t *req, http_response_t *res) {
+    (void)req;
+    http_response_send_text(res, HTTP_OK, "Hello over pure-C TLS 1.3!\n");
+}
+
+static void handle_hello(http_request_t *req, http_response_t *res) {
+    (void)req;
+    http_response_send_text(res, HTTP_OK, "Hello, World! (encrypted)\n");
+}
+
+/* Read an entire file into a NUL-terminated buffer; caller frees. */
+static char *read_file(const char *path, size_t *len_out) {
+    FILE *f = fopen(path, "rb");
+    long sz;
+    char *buf;
+    size_t got;
+    if (!f) {
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0 || (sz = ftell(f)) < 0) {
+        fclose(f);
+        return NULL;
+    }
+    rewind(f);
+    buf = (char *)malloc((size_t)sz + 1);
+    if (!buf) {
+        fclose(f);
+        return NULL;
+    }
+    got = fread(buf, 1, (size_t)sz, f);
+    buf[got] = '\0';
+    *len_out = got;
+    fclose(f);
+    return buf;
+}
+
+int main(int argc, char **argv) {
+    const char *cert_path = argc > 1 ? argv[1] : "cert.pem";
+    const char *key_path = argc > 2 ? argv[2] : "key.pem";
+    uint16_t port = (uint16_t)(argc > 3 ? atoi(argv[3]) : 8443);
+    char *cert, *key;
+    size_t cert_len = 0, key_len = 0;
+    router_t *router;
+
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);
+
+    cert = read_file(cert_path, &cert_len);
+    key = read_file(key_path, &key_len);
+    if (!cert || !key) {
+        fprintf(stderr, "Failed to read cert '%s' or key '%s'.\n", cert_path, key_path);
+        fprintf(stderr, "Generate them with:\n"
+                        "  openssl genpkey -algorithm ed25519 -out key.pem\n"
+                        "  openssl req -x509 -new -key key.pem -out cert.pem "
+                        "-days 365 -subj \"/CN=localhost\"\n");
+        free(cert);
+        free(key);
+        return 1;
+    }
+
+    g_server = http_server_create();
+    router = router_create();
+    if (!g_server || !router) {
+        fprintf(stderr, "Failed to allocate server/router\n");
+        free(cert);
+        free(key);
+        return 1;
+    }
+    router_add_route(router, HTTP_GET, "/", handle_root);
+    router_add_route(router, HTTP_GET, "/hello", handle_hello);
+    http_server_set_router(g_server, router);
+
+    if (http_server_enable_tls(g_server, cert, cert_len, key, key_len) != 0) {
+        fprintf(stderr, "http_server_enable_tls failed — is this a -DWEBLIB_ENABLE_TLS=ON "
+                        "build, and are the cert/key a valid Ed25519 pair?\n");
+        free(cert);
+        free(key);
+        router_destroy(router);
+        http_server_destroy(g_server);
+        return 1;
+    }
+    /* enable_tls copied what it needs; the PEM buffers can go now. */
+    free(cert);
+    free(key);
+
+    if (http_server_listen(g_server, port) < 0) {
+        fprintf(stderr, "Failed to listen on port %u\n", (unsigned)port);
+        router_destroy(router);
+        http_server_destroy(g_server);
+        return 1;
+    }
+    printf("HTTPS server (EXPERIMENTAL pure-C TLS 1.3) on https://localhost:%u/\n", (unsigned)port);
+    printf("  GET /       GET /hello    (Ctrl+C to stop)\n");
+    fflush(stdout);
+
+    while (!shutdown_requested) {
+        sleep(1);
+    }
+
+    http_server_stop(g_server);
+    http_server_destroy(g_server);
+    router_destroy(router);
+    return 0;
+}

--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -1,13 +1,16 @@
 # `src/tls/` — Experimental pure-C TLS 1.3 (EXPERIMENTAL · UNAUDITED)
 
-> **Status: components built and cross-checked; not yet integrated or audited.**
-> The cryptographic primitives, certificate/key loading, key schedule, record
-> layer, handshake messages, and the **server handshake state machine** now exist,
-> each landed with a known-answer test against an official RFC vector or an
-> independent reference implementation. What does **not** yet exist: the transport
-> integration (`http_server_enable_tls`) and real-client (`curl` / `openssl
-> s_client`) interop — so nothing here terminates a real TLS connection yet. The
-> code is **UNAUDITED**; do **not** rely on it for any security property.
+> **Status: working end-to-end, but UNAUDITED.** The full stack is built and
+> integrated: primitives, cert/key loading, key schedule, record layer, handshake
+> state machine, the sans-IO connection engine, the socket adapter, and
+> `http_server_enable_tls()`. A real **`openssl s_client` (OpenSSL 3.x) completes a
+> TLS 1.3 handshake and an encrypted HTTP request/response** against the server
+> (`tests/interop_openssl.sh`), so it genuinely interoperates with a mainstream TLS
+> implementation. It has **NOT been security-audited**; do **not** rely on it for
+> any security property in production. Known interop bound: the profile is
+> Ed25519-only, so a client that does not offer `ed25519` in its
+> `signature_algorithms` (e.g. an old LibreSSL) is — correctly — refused with
+> `handshake_failure`.
 
 ## Why hand-written TLS
 
@@ -70,9 +73,13 @@ ctest --test-dir build-tls
   The non-TLS path is byte-identical (the stress suite passes unchanged), and an
   end-to-end test drives a real TLS 1.3 request/response against the live server.
   Threaded mode only; WebSocket-over-TLS and the async path are not yet wired.
-- **Interoperability (separate milestone):** real `curl` / `openssl s_client` /
-  browser interop, negotiation edge cases, ClientHello fuzzing, honest security
-  labeling — tracked as its own milestone (#1), not folded into integration.
+- **Interoperability (milestone #1, in progress):** ✅ `openssl s_client` (OpenSSL
+  3.x) completes a real TLS 1.3 handshake + encrypted HTTP request/response against
+  the server — a genuine third-party client — locked in by `tests/interop_openssl.sh`
+  and demonstrated by `examples/tls_server.c`. Remaining: browser interop; clients
+  that offer only a non-X25519 key_share (needs HelloRetryRequest); optional
+  middlebox-compat ChangeCipherSpec emission and ALPN; ClientHello fuzzing. Known
+  bound: Ed25519-only, so a client not offering `ed25519` is correctly refused.
 
 Design references in-repo: the "Pure C TLS (not OpenSSL)" ADR in
 [`NEXT_PHASE.md`](../../NEXT_PHASE.md) and the Phase 11 TLS plan in

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,6 +84,13 @@ if(NOT EMSCRIPTEN)
             target_link_libraries(test_tls_http weblib ${PLATFORM_LIBS})
             add_test(NAME TlsHttpTests COMMAND test_tls_http)
         endif()
+
+        # Real-client interoperability: openssl s_client vs the tls_server example.
+        # Skips gracefully if openssl is missing/too old (see the script).
+        if(TARGET tls_server)
+            add_test(NAME TlsInteropOpenssl
+                     COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/interop_openssl.sh $<TARGET_FILE:tls_server>)
+        endif()
     endif()
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,10 +86,13 @@ if(NOT EMSCRIPTEN)
         endif()
 
         # Real-client interoperability: openssl s_client vs the tls_server example.
-        # Skips gracefully if openssl is missing/too old (see the script).
-        if(TARGET tls_server)
+        # Skips gracefully if openssl is missing/too old (see the script). Registered
+        # only when a bash interpreter exists, so systems without bash (minimal CI /
+        # Windows-native) don't get a hard launch failure.
+        find_program(BASH_EXECUTABLE bash)
+        if(TARGET tls_server AND BASH_EXECUTABLE)
             add_test(NAME TlsInteropOpenssl
-                     COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/interop_openssl.sh $<TARGET_FILE:tls_server>)
+                     COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/interop_openssl.sh $<TARGET_FILE:tls_server>)
         endif()
     endif()
 endif()

--- a/tests/interop_openssl.sh
+++ b/tests/interop_openssl.sh
@@ -22,6 +22,14 @@ trap cleanup EXIT
 command -v openssl >/dev/null 2>&1 || skip "openssl not found"
 [ -x "$SERVER" ] || skip "server binary '$SERVER' not found"
 
+# This test drives a real OpenSSL client through TLS 1.3 with an Ed25519 cert. A
+# different implementation behind the `openssl` name (LibreSSL/BoringSSL) or one
+# without a TLS 1.3-capable s_client behaves differently, so skip rather than fail
+# spuriously — a genuine server regression still fails, because on a capable OpenSSL
+# these pre-flight checks pass and only the handshake itself can then break.
+openssl version 2>/dev/null | grep -qi "^OpenSSL " || skip "not OpenSSL (e.g. LibreSSL); TLS 1.3 / Ed25519 support differs"
+openssl s_client -help 2>&1 | grep -q -- "-tls1_3" || skip "this openssl s_client has no -tls1_3"
+
 TO=""
 command -v timeout >/dev/null 2>&1 && TO="timeout 10"
 

--- a/tests/interop_openssl.sh
+++ b/tests/interop_openssl.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Real-client interoperability test: drive the pure-C TLS 1.3 server with a genuine
+# `openssl s_client` handshake and a plain HTTP GET, and check the encrypted response.
+#
+# Skips (exit 0) when the environment can't run it — no openssl, or an openssl too old
+# for Ed25519 / TLS 1.3 — so it never produces a false failure on such machines.
+#
+# Usage: interop_openssl.sh <path-to-tls_server-binary>
+set -u
+
+SERVER="${1:?usage: interop_openssl.sh <tls_server binary>}"
+SRV_PID=""
+TMP=""
+
+skip() { echo "SKIP: $*"; exit 0; }
+fail() { echo "FAIL: $*"; [ -n "${TMP}" ] && [ -f "$TMP/srv.log" ] && { echo "--- server log ---"; cat "$TMP/srv.log"; }; exit 1; }
+
+cleanup() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null; wait "$SRV_PID" 2>/dev/null; [ -n "$TMP" ] && rm -rf "$TMP"; }
+trap cleanup EXIT
+
+command -v openssl >/dev/null 2>&1 || skip "openssl not found"
+[ -x "$SERVER" ] || skip "server binary '$SERVER' not found"
+
+TO=""
+command -v timeout >/dev/null 2>&1 && TO="timeout 10"
+
+TMP="$(mktemp -d)" || skip "mktemp failed"
+
+# Self-signed Ed25519 cert — if this openssl has no Ed25519, it can't talk to an
+# Ed25519-only server anyway, so skip rather than fail.
+openssl genpkey -algorithm ed25519 -out "$TMP/key.pem" >/dev/null 2>&1 || skip "openssl lacks Ed25519"
+openssl req -x509 -new -key "$TMP/key.pem" -out "$TMP/cert.pem" -days 2 \
+    -subj "/CN=localhost" >/dev/null 2>&1 || skip "openssl req failed"
+
+# Start the server, retrying a few ports if one is taken.
+PORT=$(( ($$ % 2000) + 45000 ))
+started=0
+for _try in 1 2 3 4 5; do
+    "$SERVER" "$TMP/cert.pem" "$TMP/key.pem" "$PORT" >"$TMP/srv.log" 2>&1 &
+    SRV_PID=$!
+    for _i in $(seq 1 50); do
+        if grep -q "HTTPS server" "$TMP/srv.log" 2>/dev/null; then started=1; break; fi
+        kill -0 "$SRV_PID" 2>/dev/null || break
+        sleep 0.1
+    done
+    [ "$started" = 1 ] && break
+    kill "$SRV_PID" 2>/dev/null; wait "$SRV_PID" 2>/dev/null; SRV_PID=""
+    PORT=$((PORT + 1))
+done
+[ "$started" = 1 ] || fail "server did not become ready"
+
+# Genuine TLS 1.3 handshake + HTTP GET via openssl s_client.
+RESP="$(printf 'GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' \
+    | $TO openssl s_client -quiet -connect "127.0.0.1:$PORT" -tls1_3 2>/dev/null)"
+
+echo "--- openssl s_client response ---"
+printf '%s\n' "$RESP" | head -8
+
+if printf '%s' "$RESP" | grep -q "HTTP/1.1 200" \
+   && printf '%s' "$RESP" | grep -q "Hello over pure-C TLS 1.3"; then
+    echo "PASS: openssl s_client completed a TLS 1.3 + HTTPS round-trip against the pure-C server"
+    exit 0
+fi
+fail "no valid HTTPS 200 response received over TLS"


### PR DESCRIPTION
## Summary

The **moment of truth for the hand-written stack**: a genuine third-party client interoperates with it. `openssl s_client` (OpenSSL 3.x) completes a real **TLS 1.3 handshake** (`TLS_CHACHA20_POLY1305_SHA256` + X25519 + Ed25519) and an **encrypted HTTP request/response** against the pure-C server — over the production path (fresh CSPRNG per connection, no test hooks).

```
$ printf 'GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' \
    | openssl s_client -quiet -connect localhost:PORT -tls1_3
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Server: weblib/1.0.0 (author:kamran)
...
Hello over pure-C TLS 1.3!
```

## Contents (purely additive — no `src/` changes)

- **`examples/tls_server.c`** — a runnable HTTPS example for `http_server_enable_tls` with a self-signed Ed25519 cert (built only under `-DWEBLIB_ENABLE_TLS=ON`).
- **`tests/interop_openssl.sh` + `TlsInteropOpenssl` ctest** — generates an Ed25519 cert, starts the example server, drives `openssl s_client -tls1_3` with an HTTP GET, and asserts a decrypted `HTTP 200` with the routed body. **Skips cleanly** when openssl is missing or too old for Ed25519/TLS 1.3, so it never fails spuriously in CI.
- **README** — status updated to *"working end-to-end, UNAUDITED"*, documenting the OpenSSL interop result.

## Honest interop bound (documented, not a bug)

The profile is **Ed25519-only**. A client that doesn't offer `ed25519` in its `signature_algorithms` cannot negotiate and is **correctly refused with `handshake_failure`** (RFC 8446 §9.1). I confirmed this by parsing the ClientHello of the macOS system `curl` (LibreSSL 3.3.6): it offers ChaCha20 ✓, X25519 group ✓, X25519 key_share ✓, but **no `ed25519`** — so the refusal is right, and modern OpenSSL (which does offer it) works.

## Verification

- **TLS build:** 12/12 (incl. `TlsInteropOpenssl` driving real openssl).
- **OFF build:** 6/6 (unaffected — example/test are TLS-gated).
- Zero warnings (`-Wall -Wextra -pedantic`).

## Remaining under milestone #1

Browser interop; HelloRetryRequest for clients that offer only a non-X25519 key_share; optional middlebox-compat ChangeCipherSpec emission and ALPN; ClientHello fuzzing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)