### PR TITLE
tls: HelloRetryRequest support (RFC 8446 §4.1.4)

### DIFF
--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -76,10 +76,12 @@ ctest --test-dir build-tls
 - **Interoperability (milestone #1, in progress):** ✅ `openssl s_client` (OpenSSL
   3.x) completes a real TLS 1.3 handshake + encrypted HTTP request/response against
   the server — a genuine third-party client — locked in by `tests/interop_openssl.sh`
-  and demonstrated by `examples/tls_server.c`. Remaining: browser interop; clients
-  that offer only a non-X25519 key_share (needs HelloRetryRequest); optional
-  middlebox-compat ChangeCipherSpec emission and ALPN; ClientHello fuzzing. Known
-  bound: Ed25519-only, so a client not offering `ed25519` is correctly refused.
+  and demonstrated by `examples/tls_server.c`. ✅ **HelloRetryRequest** (RFC 8446
+  §4.1.4): a client that offers X25519 but sends no X25519 key_share is now
+  negotiated via a single HRR (with the §4.4.1 synthetic-transcript rewrite), rather
+  than refused. ✅ ClientHello / record fuzzing (`tests/test_tls_fuzz.c`). Remaining:
+  browser interop; optional middlebox-compat ChangeCipherSpec emission and ALPN.
+  Known bound: Ed25519-only, so a client not offering `ed25519` is correctly refused.
 
 Design references in-repo: the "Pure C TLS (not OpenSSL)" ADR in
 [`NEXT_PHASE.md`](../../NEXT_PHASE.md) and the Phase 11 TLS plan in

--- a/src/tls/handshake.c
+++ b/src/tls/handshake.c
@@ -293,6 +293,60 @@ int tls_build_server_hello(tls_writer_t *w, const uint8_t random[32],
     return tls_writer_ok(w);
 }
 
+/* RFC 8446 §4.1.3: the fixed Random a ServerHello carries when it is in fact a
+ * HelloRetryRequest — SHA-256("HelloRetryRequest"). A client detects HRR by this
+ * exact value, so it must be reproduced byte-for-byte. */
+static const uint8_t HELLO_RETRY_REQUEST_RANDOM[32] = {
+    0xCF, 0x21, 0xAD, 0x74, 0xE5, 0x9A, 0x61, 0x11, 0xBE, 0x1D, 0x8C, 0x02,
+    0x1E, 0x65, 0xB8, 0x91, 0xC2, 0xA2, 0x11, 0x16, 0x7A, 0xBB, 0x8C, 0x5E,
+    0x07, 0x9E, 0x09, 0xE2, 0xC8, 0xA8, 0x33, 0x9C,
+};
+
+int tls_build_hello_retry_request(tls_writer_t *w,
+                                  const uint8_t *session_id, size_t session_id_len) {
+    size_t hdr, sid, exts, sv_ext, ks_ext;
+
+    if (w == NULL) {
+        return 0;
+    }
+    if (session_id == NULL && session_id_len != 0) {
+        return 0;
+    }
+    if (session_id_len > 32) {
+        return 0;   /* legacy_session_id_echo<0..32> */
+    }
+
+    tls_write_u8(w, TLS_HS_SERVER_HELLO);        /* HRR shares the ServerHello type */
+    hdr = tls_writer_open_vector(w, 3);
+
+    tls_write_u16(w, 0x0303);                    /* legacy_version */
+    tls_write_bytes(w, HELLO_RETRY_REQUEST_RANDOM, 32);
+    sid = tls_writer_open_vector(w, 1);          /* legacy_session_id_echo */
+    tls_write_bytes(w, session_id, session_id_len);
+    tls_writer_close_vector(w, sid, 1);
+    tls_write_u16(w, SUITE_CHACHA20_SHA256);     /* cipher_suite */
+    tls_write_u8(w, 0x00);                       /* legacy_compression_method */
+
+    exts = tls_writer_open_vector(w, 2);
+
+    /* supported_versions: the single selected_version, as in ServerHello. */
+    tls_write_u16(w, EXT_SUPPORTED_VERSIONS);
+    sv_ext = tls_writer_open_vector(w, 2);
+    tls_write_u16(w, VERSION_TLS13);
+    tls_writer_close_vector(w, sv_ext, 2);
+
+    /* key_share HRR form (RFC 8446 §4.2.8): KeyShareHelloRetryRequest is just the
+     * selected NamedGroup — no key_exchange. */
+    tls_write_u16(w, EXT_KEY_SHARE);
+    ks_ext = tls_writer_open_vector(w, 2);
+    tls_write_u16(w, GROUP_X25519);
+    tls_writer_close_vector(w, ks_ext, 2);
+
+    tls_writer_close_vector(w, exts, 2);
+    tls_writer_close_vector(w, hdr, 3);
+    return tls_writer_ok(w);
+}
+
 int tls_build_encrypted_extensions(tls_writer_t *w) {
     size_t hdr, exts;
     if (w == NULL) {

--- a/src/tls/handshake.h
+++ b/src/tls/handshake.h
@@ -71,6 +71,15 @@ int tls_build_server_hello(tls_writer_t *w, const uint8_t random[32],
                            const uint8_t *session_id, size_t session_id_len,
                            const uint8_t x25519_public_key[32]);
 
+/* HelloRetryRequest (RFC 8446 §4.1.4): structurally a ServerHello carrying the
+ * special "HelloRetryRequest" Random (SHA-256 of "HelloRetryRequest"), echoing
+ * `session_id` (<=32), selecting TLS_CHACHA20_POLY1305_SHA256, and carrying
+ * supported_versions (0x0304) and a key_share naming only the group the server
+ * requires (X25519) with no key_exchange. Sent when the ClientHello offers X25519
+ * in supported_groups but did not include an X25519 key_share. */
+int tls_build_hello_retry_request(tls_writer_t *w,
+                                  const uint8_t *session_id, size_t session_id_len);
+
 /* EncryptedExtensions (RFC 8446 §4.3.1): an empty extensions block. */
 int tls_build_encrypted_extensions(tls_writer_t *w);
 

--- a/src/tls/handshake_auth.c
+++ b/src/tls/handshake_auth.c
@@ -41,6 +41,21 @@ void tls_transcript_current(const tls_transcript_t *t, uint8_t out[32]) {
     sha256_final(&snapshot, out);
 }
 
+void tls_transcript_reinit_after_hrr(tls_transcript_t *t, const uint8_t ch1_hash[32]) {
+    /* message_hash(254) || 00 00 20 (uint24 length = SHA-256 size) || Hash(CH1). */
+    uint8_t synthetic[4 + SHA256_DIGEST_SIZE];
+    if (t == NULL || ch1_hash == NULL) {
+        return;
+    }
+    synthetic[0] = 254;                    /* HandshakeType message_hash */
+    synthetic[1] = 0x00;
+    synthetic[2] = 0x00;
+    synthetic[3] = (uint8_t)SHA256_DIGEST_SIZE;   /* 32 */
+    memcpy(synthetic + 4, ch1_hash, SHA256_DIGEST_SIZE);
+    tls_transcript_init(t);
+    tls_transcript_update(t, synthetic, sizeof synthetic);
+}
+
 void tls_finished_verify_data(const uint8_t finished_key[32],
                               const uint8_t transcript_hash[32],
                               uint8_t out[32]) {

--- a/src/tls/handshake_auth.h
+++ b/src/tls/handshake_auth.h
@@ -37,6 +37,21 @@ void tls_transcript_update(tls_transcript_t *t, const uint8_t *msg, size_t len);
 void tls_transcript_current(const tls_transcript_t *t, uint8_t out[32]);
 
 /*
+ * Re-initialize a transcript for the HelloRetryRequest case (RFC 8446 §4.4.1).
+ * When the server sends a HelloRetryRequest, the first ClientHello is *replaced*
+ * in the transcript by a synthetic "message_hash" handshake message:
+ *
+ *     Hash(message_hash(254) || uint24(Hash.length) || Hash(ClientHello1) || ...)
+ *
+ * This resets `t` and absorbs exactly that synthetic message from `ch1_hash` =
+ * Hash(ClientHello1). The caller then absorbs the HelloRetryRequest, the second
+ * ClientHello, and the rest of the flight as usual. Getting this rewrite wrong is
+ * a classic TLS-1.3 pitfall, so it is isolated here and pinned by a known-answer
+ * test against an independent oracle.
+ */
+void tls_transcript_reinit_after_hrr(tls_transcript_t *t, const uint8_t ch1_hash[32]);
+
+/*
  * Finished.verify_data (RFC 8446 §4.4.4) = HMAC-SHA256(finished_key,
  * transcript_hash), where finished_key is derived from a Base traffic secret via
  * the key schedule. Writes 32 bytes.

--- a/src/tls/server_handshake.c
+++ b/src/tls/server_handshake.c
@@ -3,18 +3,23 @@
  * EXPERIMENTAL / UNAUDITED. See server_handshake.h.
  *
  * Compiled only under -DWEBLIB_ENABLE_TLS=ON. This is the orchestration layer that
- * sequences the verified primitives into a live 1-RTT handshake. The security
- * properties it must uphold — none of which the primitives can enforce on their own
- * — are:
+ * sequences the verified primitives into a live 1-RTT handshake (with an optional
+ * HelloRetryRequest round trip). The security properties it must uphold — none of
+ * which the primitives can enforce on their own — are:
  *
  *   1. Sequencing: an explicit phase gates every entry point (a message is accepted
- *      in exactly one phase, then the phase advances and can never move back).
+ *      in exactly one phase, then the phase advances and can never move back). At
+ *      most one HelloRetryRequest is ever sent — WAIT_CH2 leads only to
+ *      WAIT_FINISHED or FAILED, never back to START.
  *   2. Authentication: DONE is reached, and application keys released, only after
  *      the client Finished deprotects and its verify_data matches in constant time.
  *   3. Fail-closed: every failure latches a terminal FAILED phase, records the alert
  *      to send, and wipes all secret material before returning.
  *   4. Contributory behaviour: an all-zero X25519 shared secret is rejected
  *      (RFC 8446 §7.4.2).
+ *   5. HRR transcript integrity: on the HRR path the first ClientHello is replaced
+ *      by the synthetic message_hash (RFC 8446 §4.4.1) and CH1+HRR+CH2 are all bound
+ *      into the transcript, so a tampered second ClientHello is fatal at Finished.
  *
  * These are implemented directly below and exercised adversarially in the tests.
  */
@@ -71,15 +76,25 @@ void tls_server_hs_init(tls_server_hs_t *hs) {
     hs->alert = 0;
 }
 
-int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
-                                     const tls_server_config_t *cfg,
-                                     const uint8_t *ch_msg, size_t ch_len,
-                                     uint8_t *out, size_t out_cap, size_t *out_len) {
-    /* Secret scratch — all wiped at `done` regardless of outcome. */
-    tls_transcript_t transcript;
-    tls_client_hello_t ch;
+/*
+ * Shared tail of both ClientHello paths. On entry `transcript` already contains
+ * the ClientHello(s) (a single CH1, or the synthetic message_hash + HRR + CH2). We
+ * perform the X25519 agreement with the chosen client share, write the ServerHello
+ * record + protected flight into `out`, absorb each message into `transcript`,
+ * derive the application keys and the expected client Finished, and advance to
+ * WAIT_FINISHED. Returns 1 on success; on failure returns 0 and writes the alert to
+ * *alert (the caller latches FAILED via fail()). All secret scratch is wiped here
+ * regardless of outcome; the persistent hs->* keys written on success are wiped by
+ * the caller's fail() on the failure path.
+ */
+static int emit_server_flight(tls_server_hs_t *hs, const tls_server_config_t *cfg,
+                              tls_transcript_t *transcript,
+                              const uint8_t client_share[32],
+                              const uint8_t *session_id, size_t session_id_len,
+                              uint8_t *out, size_t out_cap, size_t *out_len,
+                              uint8_t *alert) {
     uint8_t ecdhe[32];
-    uint8_t server_pub[32];                       /* public */
+    uint8_t server_pub[32];                        /* public */
     uint8_t zero32[32];
     uint8_t empty_hash[32];                        /* public */
     uint8_t early_secret[32], derived[32], derived2[32];
@@ -95,70 +110,30 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
 
     tls_writer_t w;
     size_t sh_len = 0, out_used = 0, flight_len = 0, rec_len = 0, mlen = 0;
-    uint8_t alert = TLS_ALERT_INTERNAL_ERROR;
+    uint8_t local_alert = TLS_ALERT_INTERNAL_ERROR;
     int ok = 0;
-
-    if (out_len != NULL) {
-        *out_len = 0;
-    }
-    if (hs == NULL) {
-        return 0;
-    }
-    /* Phase gate: ClientHello is accepted only in START. Anything else (including a
-     * replay after we have advanced, or a call on a FAILED handshake) is a protocol
-     * violation. */
-    if (hs->phase != TLS_SERVER_HS_START) {
-        return fail(hs, TLS_ALERT_UNEXPECTED_MESSAGE);
-    }
-    if (cfg == NULL || ch_msg == NULL || out == NULL || out_len == NULL ||
-        cfg->cert_der == NULL || cfg->ed25519_seed == NULL || cfg->ed25519_pub == NULL ||
-        cfg->server_eph_sk == NULL || cfg->server_random == NULL) {
-        /* out_len is required: a caller must always learn the response length so it
-         * never sends an unknown/unbounded number of bytes (cf. tls_record_seal). */
-        return fail(hs, TLS_ALERT_INTERNAL_ERROR);
-    }
 
     memset(zero32, 0, sizeof zero32);
 
-    /* 1. Parse the (attacker-controlled) ClientHello. */
-    if (!tls_parse_client_hello(ch_msg, ch_len, &ch)) {
-        alert = TLS_ALERT_DECODE_ERROR;
-        goto done;
-    }
-
-    /* 2. Require the one profile we implement. Distinct alerts per RFC 8446 §6. */
-    if (!ch.offers_tls13) {
-        alert = TLS_ALERT_PROTOCOL_VERSION;   /* no TLS 1.3 in supported_versions */
-        goto done;
-    }
-    if (!ch.offers_chacha20_poly1305 || !ch.offers_ed25519 ||
-        !ch.offers_x25519 || ch.x25519_key_share == NULL) {
-        /* No common cipher / signature / group, or (no HRR support) no X25519 share. */
-        alert = TLS_ALERT_HANDSHAKE_FAILURE;
-        goto done;
-    }
-
-    /* 3. X25519 key agreement, then the RFC 8446 §7.4.2 contributory-behaviour
+    /* 1. X25519 key agreement, then the RFC 8446 §7.4.2 contributory-behaviour
      * check: reject an all-zero shared secret (a degenerate / small-order peer
      * key). Constant-time over the secret. */
-    x25519(ecdhe, cfg->server_eph_sk, ch.x25519_key_share);
+    x25519(ecdhe, cfg->server_eph_sk, client_share);
     if (all_zero(ecdhe, sizeof ecdhe)) {
-        alert = TLS_ALERT_ILLEGAL_PARAMETER;
+        local_alert = TLS_ALERT_ILLEGAL_PARAMETER;
         goto done;
     }
     x25519_base(server_pub, cfg->server_eph_sk);
 
-    /* 4. Transcript = ClientHello, then ServerHello. Build the ServerHello directly
-     * into `out` behind a 5-byte record header, then backfill the header. */
-    tls_transcript_init(&transcript);
-    tls_transcript_update(&transcript, ch_msg, ch_len);
-
+    /* 2. Build the ServerHello directly into `out` behind a 5-byte record header,
+     * then backfill the header, and absorb it into the transcript (which already
+     * carries the ClientHello context). */
     if (out_cap < TLS_RECORD_HEADER_LEN) {
         goto done;   /* internal_error */
     }
     tls_writer_init(&w, out + TLS_RECORD_HEADER_LEN, out_cap - TLS_RECORD_HEADER_LEN);
-    if (!tls_build_server_hello(&w, cfg->server_random, ch.session_id,
-                                ch.session_id_len, server_pub) ||
+    if (!tls_build_server_hello(&w, cfg->server_random, session_id, session_id_len,
+                                server_pub) ||
         !tls_writer_finish(&w, &sh_len)) {
         goto done;   /* output buffer too small -> internal_error */
     }
@@ -170,10 +145,10 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
     out[2] = 0x03;                              /* legacy_record_version */
     out[3] = (uint8_t)(sh_len >> 8);
     out[4] = (uint8_t)(sh_len & 0xff);
-    tls_transcript_update(&transcript, out + TLS_RECORD_HEADER_LEN, sh_len);
+    tls_transcript_update(transcript, out + TLS_RECORD_HEADER_LEN, sh_len);
     out_used = TLS_RECORD_HEADER_LEN + sh_len;
 
-    /* 5. Key schedule through the handshake secret (RFC 8446 §7.1). */
+    /* 3. Key schedule through the handshake secret (RFC 8446 §7.1). */
     tls13_extract(NULL, 0, zero32, sizeof zero32, early_secret);   /* no PSK */
     tls13_empty_transcript_hash(empty_hash);
     if (!tls13_derive_secret(early_secret, "derived", empty_hash, derived)) {
@@ -181,7 +156,7 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
     }
     tls13_extract(derived, sizeof derived, ecdhe, sizeof ecdhe, handshake_secret);
 
-    tls_transcript_current(&transcript, th);   /* TH(ClientHello || ServerHello) */
+    tls_transcript_current(transcript, th);   /* TH(.. || ServerHello) */
     if (!tls13_derive_secret(handshake_secret, "s hs traffic", th, s_hs_secret) ||
         !tls13_derive_secret(handshake_secret, "c hs traffic", th, c_hs_secret) ||
         !tls13_traffic_keys(s_hs_secret, server_hs_key, sizeof server_hs_key, server_hs_iv) ||
@@ -192,7 +167,7 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
         goto done;
     }
 
-    /* 6. Assemble the server flight, absorbing each message into the transcript in
+    /* 4. Assemble the server flight, absorbing each message into the transcript in
      * order. CertificateVerify signs the transcript through Certificate; the server
      * Finished MACs the transcript through CertificateVerify. Each message is built
      * with its own writer at a running offset so its exact bytes are known. */
@@ -201,7 +176,7 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
     if (!tls_build_encrypted_extensions(&w) || !tls_writer_finish(&w, &mlen)) {
         goto done;
     }
-    tls_transcript_update(&transcript, flight, mlen);
+    tls_transcript_update(transcript, flight, mlen);
     flight_len = mlen;
     /* Certificate */
     tls_writer_init(&w, flight + flight_len, sizeof flight - flight_len);
@@ -209,30 +184,30 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
         !tls_writer_finish(&w, &mlen)) {
         goto done;   /* certificate too large for the flight buffer */
     }
-    tls_transcript_update(&transcript, flight + flight_len, mlen);
+    tls_transcript_update(transcript, flight + flight_len, mlen);
     flight_len += mlen;
-    /* CertificateVerify — sign TH(ClientHello .. Certificate). */
-    tls_transcript_current(&transcript, th);
+    /* CertificateVerify — sign TH(.. .. Certificate). */
+    tls_transcript_current(transcript, th);
     tls_sign_server_cert_verify(cfg->ed25519_seed, cfg->ed25519_pub, th, cv_sig);
     tls_writer_init(&w, flight + flight_len, sizeof flight - flight_len);
     if (!tls_build_certificate_verify(&w, cv_sig) || !tls_writer_finish(&w, &mlen)) {
         goto done;
     }
-    tls_transcript_update(&transcript, flight + flight_len, mlen);
+    tls_transcript_update(transcript, flight + flight_len, mlen);
     flight_len += mlen;
-    /* Finished — MAC TH(ClientHello .. CertificateVerify) with the server finished key. */
-    tls_transcript_current(&transcript, th);
+    /* Finished — MAC TH(.. .. CertificateVerify) with the server finished key. */
+    tls_transcript_current(transcript, th);
     tls_finished_verify_data(s_finished_key, th, verify_data);
     tls_writer_init(&w, flight + flight_len, sizeof flight - flight_len);
     if (!tls_build_finished(&w, verify_data) || !tls_writer_finish(&w, &mlen)) {
         goto done;
     }
-    tls_transcript_update(&transcript, flight + flight_len, mlen);
+    tls_transcript_update(transcript, flight + flight_len, mlen);
     flight_len += mlen;
 
-    /* 7. Application traffic keys and the expected client Finished, both over
-     * TH(ClientHello .. server Finished) (RFC 8446 §7.1, §4.4.4). */
-    tls_transcript_current(&transcript, th);
+    /* 5. Application traffic keys and the expected client Finished, both over
+     * TH(.. .. server Finished) (RFC 8446 §7.1, §4.4.4). */
+    tls_transcript_current(transcript, th);
     if (!tls13_derive_secret(handshake_secret, "derived", empty_hash, derived2)) {
         goto done;
     }
@@ -248,7 +223,7 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
     /* The client will MAC the same transcript with its own finished key. */
     tls_finished_verify_data(c_finished_key, th, hs->expected_client_finished);
 
-    /* 8. Seal the flight as one protected record (server handshake key, seq 0),
+    /* 6. Seal the flight as one protected record (server handshake key, seq 0),
      * appended after the ServerHello record. */
     if (!tls_record_seal(server_hs_key, server_hs_iv, 0, TLS_CONTENT_HANDSHAKE,
                          flight, flight_len, 0, out + out_used, out_cap - out_used,
@@ -257,7 +232,7 @@ int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
     }
     out_used += rec_len;
 
-    *out_len = out_used;   /* out_len is guaranteed non-NULL (checked above) */
+    *out_len = out_used;
     hs->phase = TLS_SERVER_HS_WAIT_FINISHED;
     ok = 1;
 
@@ -278,13 +253,192 @@ done:
     secure_zero(s_ap_secret, sizeof s_ap_secret);
     secure_zero(verify_data, sizeof verify_data);
     secure_zero(flight, sizeof flight);
-    /* transcript, th, cv_sig, server_pub, empty_hash are non-secret (hashes of and
-     * signatures over public handshake messages); left as-is. */
+    /* th, cv_sig, server_pub, empty_hash are non-secret (hashes of and signatures
+     * over public handshake messages); left as-is. */
 
     if (!ok) {
-        return fail(hs, alert);   /* fail-closed: FAILED + alert + wipe hs secrets */
+        *alert = local_alert;
+    }
+    return ok;
+}
+
+/*
+ * HelloRetryRequest path (RFC 8446 §4.1.4). The ClientHello offered X25519 in
+ * supported_groups but sent no X25519 key_share; ask for one. Writes the HRR record
+ * to `out`, performs the §4.4.1 transcript rewrite (message_hash(Hash(CH1)) || HRR)
+ * into hs->transcript, remembers what CH2 must echo unchanged, and advances to
+ * WAIT_CH2. No key material exists yet (the key agreement waits for CH2's share).
+ */
+static int send_hello_retry_request(tls_server_hs_t *hs, const tls_client_hello_t *ch,
+                                    const uint8_t *ch_msg, size_t ch_len,
+                                    uint8_t *out, size_t out_cap, size_t *out_len) {
+    tls_transcript_t tmp;
+    tls_writer_t w;
+    uint8_t ch1_hash[32];
+    size_t hrr_len = 0;
+
+    /* Build the HRR message into `out` behind a 5-byte record header. */
+    if (out_cap < TLS_RECORD_HEADER_LEN) {
+        return fail(hs, TLS_ALERT_INTERNAL_ERROR);
+    }
+    tls_writer_init(&w, out + TLS_RECORD_HEADER_LEN, out_cap - TLS_RECORD_HEADER_LEN);
+    if (!tls_build_hello_retry_request(&w, ch->session_id, ch->session_id_len) ||
+        !tls_writer_finish(&w, &hrr_len)) {
+        return fail(hs, TLS_ALERT_INTERNAL_ERROR);
+    }
+    if (hrr_len > TLS_RECORD_MAX_PLAINTEXT) {
+        return fail(hs, TLS_ALERT_INTERNAL_ERROR);
+    }
+    out[0] = TLS_CONTENT_HANDSHAKE;
+    out[1] = 0x03;
+    out[2] = 0x03;
+    out[3] = (uint8_t)(hrr_len >> 8);
+    out[4] = (uint8_t)(hrr_len & 0xff);
+
+    /* Transcript rewrite (RFC 8446 §4.4.1): the first ClientHello is replaced by
+     * the synthetic message_hash(Hash(CH1)); then the HRR is absorbed. `tmp` is a
+     * throwaway used only to take Hash(CH1). */
+    tls_transcript_init(&tmp);
+    tls_transcript_update(&tmp, ch_msg, ch_len);
+    tls_transcript_current(&tmp, ch1_hash);
+    tls_transcript_reinit_after_hrr(&hs->transcript, ch1_hash);
+    tls_transcript_update(&hs->transcript, out + TLS_RECORD_HEADER_LEN, hrr_len);
+
+    /* Remember what the second ClientHello must echo unchanged (RFC 8446 §4.1.2).
+     * session_id_len is <=32 (enforced by the parser). */
+    memcpy(hs->ch1_random, ch->random, 32);
+    if (ch->session_id_len > 0) {
+        memcpy(hs->ch1_session_id, ch->session_id, ch->session_id_len);
+    }
+    hs->ch1_session_id_len = (uint8_t)ch->session_id_len;
+
+    *out_len = TLS_RECORD_HEADER_LEN + hrr_len;
+    hs->phase = TLS_SERVER_HS_WAIT_CH2;
+    hs->alert = 0;
+    return 1;
+}
+
+/* Validate the offered parameters common to both ClientHellos: TLS 1.3 and our one
+ * cipher / signature / group must all be on offer. Returns 1 if acceptable; on a
+ * mismatch returns 0 having latched FAILED with the RFC 8446 §6 alert. */
+static int require_profile(tls_server_hs_t *hs, const tls_client_hello_t *ch) {
+    if (!ch->offers_tls13) {
+        return fail(hs, TLS_ALERT_PROTOCOL_VERSION);   /* no TLS 1.3 offered */
+    }
+    if (!ch->offers_chacha20_poly1305 || !ch->offers_ed25519 || !ch->offers_x25519) {
+        /* No common cipher / signature / group. Without X25519 even offered there is
+         * no group to retry with, so this is terminal (not HRR-eligible). */
+        return fail(hs, TLS_ALERT_HANDSHAKE_FAILURE);
     }
     return 1;
+}
+
+/* Phase START: the first ClientHello. Either complete the 1-RTT flight, or (if the
+ * X25519 key_share is absent) send a HelloRetryRequest. */
+static int handle_client_hello_1(tls_server_hs_t *hs, const tls_server_config_t *cfg,
+                                 const uint8_t *ch_msg, size_t ch_len,
+                                 uint8_t *out, size_t out_cap, size_t *out_len) {
+    tls_client_hello_t ch;
+    tls_transcript_t transcript;
+    uint8_t alert = TLS_ALERT_INTERNAL_ERROR;
+
+    if (!tls_parse_client_hello(ch_msg, ch_len, &ch)) {
+        return fail(hs, TLS_ALERT_DECODE_ERROR);
+    }
+    if (!require_profile(hs, &ch)) {
+        return 0;   /* require_profile already latched FAILED + alert */
+    }
+    if (ch.x25519_key_share == NULL) {
+        /* X25519 offered but no share supplied -> HelloRetryRequest. */
+        return send_hello_retry_request(hs, &ch, ch_msg, ch_len, out, out_cap, out_len);
+    }
+    /* Normal 1-RTT: transcript = {ClientHello}, then the server flight. */
+    tls_transcript_init(&transcript);
+    tls_transcript_update(&transcript, ch_msg, ch_len);
+    if (!emit_server_flight(hs, cfg, &transcript, ch.x25519_key_share,
+                            ch.session_id, ch.session_id_len, out, out_cap, out_len,
+                            &alert)) {
+        return fail(hs, alert);
+    }
+    return 1;
+}
+
+/* Phase WAIT_CH2: the second ClientHello after our HelloRetryRequest. It must now
+ * carry the X25519 key_share and be consistent with the first (RFC 8446 §4.1.2). We
+ * never answer a still-share-less CH2 with a second HRR (§4.1.4) — we abort. */
+static int handle_client_hello_2(tls_server_hs_t *hs, const tls_server_config_t *cfg,
+                                 const uint8_t *ch_msg, size_t ch_len,
+                                 uint8_t *out, size_t out_cap, size_t *out_len) {
+    tls_client_hello_t ch;
+    uint8_t alert = TLS_ALERT_INTERNAL_ERROR;
+
+    if (!tls_parse_client_hello(ch_msg, ch_len, &ch)) {
+        return fail(hs, TLS_ALERT_DECODE_ERROR);
+    }
+    if (!require_profile(hs, &ch)) {
+        return 0;
+    }
+    if (ch.x25519_key_share == NULL) {
+        /* The client ignored the retry request. Do not loop; abort. */
+        return fail(hs, TLS_ALERT_ILLEGAL_PARAMETER);
+    }
+    /* Consistency with CH1 (the subset of RFC 8446 §4.1.2 we enforce): the Random
+     * and legacy_session_id must be unchanged. These are public, so a plain compare
+     * is fine. The transcript binds CH1+HRR+CH2 regardless, making any on-the-wire
+     * change fatal at the client Finished. */
+    if (memcmp(ch.random, hs->ch1_random, 32) != 0) {
+        return fail(hs, TLS_ALERT_ILLEGAL_PARAMETER);
+    }
+    if (ch.session_id_len != hs->ch1_session_id_len ||
+        (ch.session_id_len > 0 &&
+         memcmp(ch.session_id, hs->ch1_session_id, ch.session_id_len) != 0)) {
+        return fail(hs, TLS_ALERT_ILLEGAL_PARAMETER);
+    }
+
+    /* Continue the transcript with CH2 (message_hash(CH1) + HRR already absorbed),
+     * then complete the flight. */
+    tls_transcript_update(&hs->transcript, ch_msg, ch_len);
+    if (!emit_server_flight(hs, cfg, &hs->transcript, ch.x25519_key_share,
+                            ch.session_id, ch.session_id_len, out, out_cap, out_len,
+                            &alert)) {
+        return fail(hs, alert);
+    }
+    /* The HRR round-trip scratch is no longer needed. */
+    memset(&hs->transcript, 0, sizeof hs->transcript);
+    secure_zero(hs->ch1_random, sizeof hs->ch1_random);
+    secure_zero(hs->ch1_session_id, sizeof hs->ch1_session_id);
+    hs->ch1_session_id_len = 0;
+    return 1;
+}
+
+int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
+                                     const tls_server_config_t *cfg,
+                                     const uint8_t *ch_msg, size_t ch_len,
+                                     uint8_t *out, size_t out_cap, size_t *out_len) {
+    if (out_len != NULL) {
+        *out_len = 0;
+    }
+    if (hs == NULL) {
+        return 0;
+    }
+    if (cfg == NULL || ch_msg == NULL || out == NULL || out_len == NULL ||
+        cfg->cert_der == NULL || cfg->ed25519_seed == NULL || cfg->ed25519_pub == NULL ||
+        cfg->server_eph_sk == NULL || cfg->server_random == NULL) {
+        /* out_len is required: a caller must always learn the response length so it
+         * never sends an unknown/unbounded number of bytes (cf. tls_record_seal). */
+        return fail(hs, TLS_ALERT_INTERNAL_ERROR);
+    }
+
+    /* Phase gate: a ClientHello is accepted in START (the first) or WAIT_CH2 (the
+     * second, after our HRR). Anything else — a replay after we advanced, or a call
+     * on a FAILED handshake — is a protocol violation. */
+    if (hs->phase == TLS_SERVER_HS_START) {
+        return handle_client_hello_1(hs, cfg, ch_msg, ch_len, out, out_cap, out_len);
+    }
+    if (hs->phase == TLS_SERVER_HS_WAIT_CH2) {
+        return handle_client_hello_2(hs, cfg, ch_msg, ch_len, out, out_cap, out_len);
+    }
+    return fail(hs, TLS_ALERT_UNEXPECTED_MESSAGE);
 }
 
 int tls_server_hs_read_client_finished(tls_server_hs_t *hs,
@@ -396,6 +550,11 @@ void tls_server_hs_wipe(tls_server_hs_t *hs) {
     secure_zero(hs->server_ap_iv, sizeof hs->server_ap_iv);
     secure_zero(hs->client_ap_key, sizeof hs->client_ap_key);
     secure_zero(hs->client_ap_iv, sizeof hs->client_ap_iv);
+    /* HRR round-trip scratch (non-secret, but reset for a clean discard). */
+    memset(&hs->transcript, 0, sizeof hs->transcript);
+    secure_zero(hs->ch1_random, sizeof hs->ch1_random);
+    secure_zero(hs->ch1_session_id, sizeof hs->ch1_session_id);
+    hs->ch1_session_id_len = 0;
     hs->phase = TLS_SERVER_HS_FAILED;
     hs->alert = 0;
 }

--- a/src/tls/server_handshake.h
+++ b/src/tls/server_handshake.h
@@ -25,9 +25,16 @@
  *     defeating small-subgroup / degenerate-key inputs.
  *
  * SCOPE / KNOWN LIMITATIONS (this phase — all documented, none silent):
- *   - Full 1-RTT handshake only. No HelloRetryRequest: a ClientHello that does not
- *     already carry an X25519 key_share is rejected with handshake_failure rather
- *     than negotiated down via HRR.
+ *   - HelloRetryRequest (RFC 8446 §4.1.4) IS supported for the one case it can
+ *     matter here: a ClientHello that offers X25519 in supported_groups but sends
+ *     no X25519 key_share triggers a single HRR, and the client's second
+ *     ClientHello (now carrying the share) completes the handshake. A client that
+ *     does not offer X25519 at all is still rejected with handshake_failure (there
+ *     is no other group to retry with). The CH1/CH2 consistency check per §4.1.2
+ *     is a documented subset (Random and legacy_session_id must be unchanged); the
+ *     full extension-by-extension diff is not performed, which is safe because the
+ *     transcript binds CH1+HRR+CH2 and any on-the-wire tampering is fatal at the
+ *     client Finished. At most one HRR is ever sent (no HRR loop).
  *   - No client authentication (no CertificateRequest), no session resumption / PSK,
  *     no early data, no KeyUpdate.
  *   - The whole server flight {EncryptedExtensions, Certificate, CertificateVerify,
@@ -55,6 +62,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "handshake_auth.h"   /* tls_transcript_t, retained across an HRR round trip */
 
 /* ---- alerts we may raise (RFC 8446 §6) --------------------------------- */
 #define TLS_ALERT_UNEXPECTED_MESSAGE 10
@@ -69,11 +77,15 @@
 /* ---- phases ------------------------------------------------------------ */
 /*
  * The single source of truth for "what will I accept now". Phases only advance
- * START -> WAIT_FINISHED -> DONE on success; any error jumps to FAILED, which is
- * terminal (every entry point refuses to do further work once FAILED).
+ * START -> [WAIT_CH2 ->] WAIT_FINISHED -> DONE on success; any error jumps to
+ * FAILED, which is terminal (every entry point refuses to do further work once
+ * FAILED). WAIT_CH2 is entered only on the HelloRetryRequest path and is left for
+ * WAIT_FINISHED once the second ClientHello is processed — never back to START,
+ * and a second HRR is never sent.
  */
 typedef enum {
-    TLS_SERVER_HS_START = 0,     /* awaiting ClientHello */
+    TLS_SERVER_HS_START = 0,     /* awaiting (first) ClientHello */
+    TLS_SERVER_HS_WAIT_CH2,      /* HelloRetryRequest sent; awaiting second ClientHello */
     TLS_SERVER_HS_WAIT_FINISHED, /* server flight emitted; awaiting client Finished */
     TLS_SERVER_HS_DONE,          /* client Finished verified; application keys ready */
     TLS_SERVER_HS_FAILED         /* terminal error; all secrets wiped */
@@ -115,6 +127,16 @@ typedef struct {
     uint8_t  server_ap_iv[12];
     uint8_t  client_ap_key[32];
     uint8_t  client_ap_iv[12];
+
+    /* Live only across a HelloRetryRequest round trip (phase WAIT_CH2). Non-secret
+     * (hashes/echoes of public handshake messages); reset once CH2 is processed.
+     * `transcript` already contains the synthetic message_hash(CH1) and the HRR, so
+     * the second ClientHello is absorbed directly onto it. `ch1_random` /
+     * `ch1_session_id` pin the §4.1.2 consistency check on CH2. */
+    tls_transcript_t transcript;
+    uint8_t  ch1_random[32];
+    uint8_t  ch1_session_id[32];
+    uint8_t  ch1_session_id_len;
 } tls_server_hs_t;
 
 /*
@@ -124,30 +146,39 @@ typedef struct {
 void tls_server_hs_init(tls_server_hs_t *hs);
 
 /*
- * Event 1 — process the ClientHello.
+ * Event 1 — process a ClientHello (the first one, or the second after an HRR).
  *
  * `ch_msg`/`ch_len` is the ClientHello *handshake message* (HandshakeType ||
  * uint24 length || body), i.e. the record payload with the 5-byte record header
  * already stripped by the transport. `cfg` supplies the server identity and the
- * injected ephemeral/random.
+ * injected ephemeral/random. This entry point is re-entrant across the HRR round
+ * trip: the caller feeds every plaintext-handshake ClientHello record to it and it
+ * dispatches on the current phase.
  *
- * On success (phase START only): validates the offered parameters, performs the
- * X25519 key agreement (with the §7.4.2 all-zero check), runs the key schedule,
- * builds and transcript-absorbs the server flight, and writes the response to
- * `out` (capacity `out_cap`), setting *out_len to its length. `out` and `out_len`
- * must be non-NULL — a NULL `out_len` is rejected with internal_error so a caller
- * always learns the response length. The response is:
+ * From phase START:
+ *   - If the ClientHello already carries an acceptable X25519 key_share, it does
+ *     the full 1-RTT flight (as below) and advances START -> WAIT_FINISHED.
+ *   - If it offers X25519 in supported_groups but sent no X25519 key_share, it
+ *     writes a HelloRetryRequest record to `out`, remembers the transcript, and
+ *     advances START -> WAIT_CH2, returning 1 with *out_len set to the HRR record.
+ *
+ * From phase WAIT_CH2: processes the second ClientHello (which must now carry the
+ * X25519 key_share and be consistent with the first per RFC 8446 §4.1.2), then
+ * does the full flight and advances WAIT_CH2 -> WAIT_FINISHED.
+ *
+ * The full-flight response written to `out` (capacity `out_cap`) is:
  *
  *     ServerHello record  (TLSPlaintext, ContentType handshake)
  *   || protected flight   (one TLSCiphertext, ContentType application_data,
  *                          sealing {EncryptedExtensions, Certificate,
  *                          CertificateVerify, Finished})
  *
- * Advances START -> WAIT_FINISHED and returns 1.
+ * `out` and `out_len` must be non-NULL — a NULL `out_len` is rejected with
+ * internal_error so a caller always learns the response length.
  *
  * On any failure returns 0, latches phase FAILED, sets the alert (query with
  * tls_server_hs_alert), leaves *out_len 0, and wipes every secret. Calling in any
- * phase other than START is itself a failure (unexpected_message).
+ * phase other than START or WAIT_CH2 is itself a failure (unexpected_message).
  */
 int tls_server_hs_read_client_hello(tls_server_hs_t *hs,
                                      const tls_server_config_t *cfg,

--- a/src/tls/tls_khannection.c
+++ b/src/tls/tls_khannection.c
@@ -103,8 +103,12 @@ static tls_khannection_rc_t process_record(tls_khannection_t *c, const uint8_t *
     if (c->state == TLS_KHANNECTION_HANDSHAKE) {
         switch (type) {
         case TLS_CONTENT_HANDSHAKE: {
-            /* Plaintext handshake record — the ClientHello. read_client_hello
-             * writes the ServerHello + protected flight straight into `out`. */
+            /* Plaintext handshake record — a ClientHello. read_client_hello is
+             * re-entrant across a HelloRetryRequest: on the first it writes either
+             * the ServerHello + protected flight or an HRR record straight into
+             * `out`; on a second (post-HRR) ClientHello it writes the flight. The
+             * handshake state machine tracks which via its own phase, so dispatch
+             * here stays purely by record type. */
             size_t produced = 0;
             size_t room = (out_cap >= *out_len) ? out_cap - *out_len : 0;
             if (!tls_server_hs_read_client_hello(&c->hs, c->cfg, content, content_len,
@@ -112,7 +116,7 @@ static tls_khannection_rc_t process_record(tls_khannection_t *c, const uint8_t *
                 return conn_fail(c, out, out_cap, out_len, tls_server_hs_alert(&c->hs));
             }
             *out_len += produced;
-            return TLS_KHANNECTION_RC_OK;   /* now awaiting the client Finished */
+            return TLS_KHANNECTION_RC_OK;   /* awaiting the client Finished, or CH2 after an HRR */
         }
         case TLS_CONTENT_CHANGE_CIPHER_SPEC:
             /* RFC 8446 §5 / §D.4: a legitimate middlebox-compat CCS is exactly the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,7 +57,9 @@ if(NOT EMSCRIPTEN)
 
         # TLS parsing tests (DER/ASN.1, later PEM/X.509) — malformed-input hardened
         add_executable(test_tls_parse test_tls_parse.c)
-        target_include_directories(test_tls_parse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls)
+        target_include_directories(test_tls_parse PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/tls
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src)
         target_compile_definitions(test_tls_parse PRIVATE WEBLIB_TLS)
         target_link_libraries(test_tls_parse weblib ${PLATFORM_LIBS})
         add_test(NAME TlsParseTests COMMAND test_tls_parse)

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -782,6 +782,81 @@ static const uint8_t KAT_FLIGHT_PLAIN[223] = {
     0xc0, 0x68, 0xa1, 0x2d, 0xba, 0xb5, 0xe3,
 };
 
+/* ===== HelloRetryRequest flow, from the independent hrr_oracle.py =====
+ * CH1 offers X25519 in supported_groups but a key_share for secp256r1 only, so the
+ * server must answer with a HelloRetryRequest. CH2 is the same ClientHello (same
+ * Random + session_id) now carrying the X25519 key_share. The keys below are
+ * derived over the §4.4.1-rewritten transcript
+ *   message_hash(Hash(CH1)) || HRR || CH2 || ServerHello || <flight...>
+ * so matching them proves the C server's transcript rewrite is correct. */
+static const uint8_t KAT_CH1[144] = {
+    0x01, 0x00, 0x00, 0x8c, 0x03, 0x03, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0x20, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+    0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x00,
+    0x02, 0x13, 0x03, 0x01, 0x00, 0x00, 0x41, 0x00, 0x2b, 0x00, 0x03, 0x02,
+    0x03, 0x04, 0x00, 0x0a, 0x00, 0x04, 0x00, 0x02, 0x00, 0x1d, 0x00, 0x0d,
+    0x00, 0x04, 0x00, 0x02, 0x08, 0x07, 0x00, 0x33, 0x00, 0x26, 0x00, 0x24,
+    0x00, 0x17, 0x00, 0x20, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+    0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+    0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+};
+static const uint8_t KAT_CH2[144] = {
+    0x01, 0x00, 0x00, 0x8c, 0x03, 0x03, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0x20, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+    0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x00,
+    0x02, 0x13, 0x03, 0x01, 0x00, 0x00, 0x41, 0x00, 0x2b, 0x00, 0x03, 0x02,
+    0x03, 0x04, 0x00, 0x0a, 0x00, 0x04, 0x00, 0x02, 0x00, 0x1d, 0x00, 0x0d,
+    0x00, 0x04, 0x00, 0x02, 0x08, 0x07, 0x00, 0x33, 0x00, 0x26, 0x00, 0x24,
+    0x00, 0x1d, 0x00, 0x20, 0x79, 0xa6, 0x31, 0xee, 0xde, 0x1b, 0xf9, 0xc9,
+    0x8f, 0x12, 0x03, 0x2c, 0xde, 0xad, 0xd0, 0xe7, 0xa0, 0x79, 0x39, 0x8f,
+    0xc7, 0x86, 0xb8, 0x8c, 0xc8, 0x46, 0xec, 0x89, 0xaf, 0x85, 0xa5, 0x1a,
+};
+static const uint8_t KAT_HRR_RECORD[93] = {
+    0x16, 0x03, 0x03, 0x00, 0x58, 0x02, 0x00, 0x00, 0x54, 0x03, 0x03, 0xcf,
+    0x21, 0xad, 0x74, 0xe5, 0x9a, 0x61, 0x11, 0xbe, 0x1d, 0x8c, 0x02, 0x1e,
+    0x65, 0xb8, 0x91, 0xc2, 0xa2, 0x11, 0x16, 0x7a, 0xbb, 0x8c, 0x5e, 0x07,
+    0x9e, 0x09, 0xe2, 0xc8, 0xa8, 0x33, 0x9c, 0x20, 0x00, 0x01, 0x02, 0x03,
+    0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+    0x1c, 0x1d, 0x1e, 0x1f, 0x13, 0x03, 0x00, 0x00, 0x0c, 0x00, 0x2b, 0x00,
+    0x02, 0x03, 0x04, 0x00, 0x33, 0x00, 0x02, 0x00, 0x1d,
+};
+static const uint8_t KAT_HRR_CLIENT_HS_KEY[32] = {
+    0x4e, 0x54, 0x60, 0x2c, 0x2a, 0xfd, 0x29, 0x53, 0x3a, 0x0e, 0xbe, 0x44,
+    0xb7, 0x9d, 0x32, 0x6d, 0xb5, 0x8a, 0xd3, 0x1c, 0x71, 0x7b, 0x12, 0xe4,
+    0xfb, 0x4d, 0x51, 0x71, 0x48, 0x09, 0x04, 0x4a,
+};
+static const uint8_t KAT_HRR_CLIENT_HS_IV[12] = {
+    0xef, 0x8e, 0x55, 0x6a, 0x59, 0x11, 0x72, 0x4d, 0x37, 0x5f, 0x29, 0x0f,
+};
+static const uint8_t KAT_HRR_CLIENT_FINISHED_VD[32] = {
+    0x57, 0xfb, 0xf1, 0x46, 0x76, 0xc1, 0xa3, 0xc2, 0xfa, 0xed, 0x3d, 0xdf,
+    0xe8, 0xfd, 0x46, 0x1e, 0x33, 0x46, 0x90, 0xa8, 0x90, 0x8c, 0xb9, 0x44,
+    0x50, 0x98, 0x56, 0x13, 0x99, 0xd0, 0x82, 0xc6,
+};
+static const uint8_t KAT_HRR_SERVER_AP_KEY[32] = {
+    0x21, 0xfa, 0xcf, 0xaf, 0x91, 0x18, 0xfe, 0xcb, 0x3b, 0xee, 0x6e, 0x3e,
+    0xe5, 0x1f, 0x3d, 0xd2, 0xa3, 0x14, 0x38, 0x6b, 0xee, 0xc5, 0x4f, 0xf8,
+    0x00, 0x88, 0x6a, 0x77, 0x04, 0xc0, 0x5f, 0x25,
+};
+static const uint8_t KAT_HRR_SERVER_AP_IV[12] = {
+    0x14, 0x4b, 0x17, 0x5a, 0x77, 0x70, 0x47, 0x77, 0x6e, 0xda, 0xd8, 0xd9,
+};
+static const uint8_t KAT_HRR_CLIENT_AP_KEY[32] = {
+    0x6f, 0xf4, 0x9d, 0xd9, 0x89, 0xf0, 0x84, 0xc8, 0x91, 0xbf, 0xc0, 0xa2,
+    0x4f, 0x25, 0xc2, 0x0c, 0xa6, 0x0d, 0x90, 0x18, 0x15, 0xf7, 0x43, 0xa5,
+    0xcb, 0x2b, 0x37, 0x03, 0xc6, 0x27, 0x73, 0x96,
+};
+static const uint8_t KAT_HRR_CLIENT_AP_IV[12] = {
+    0x29, 0x78, 0x47, 0x1c, 0x5e, 0x51, 0x8d, 0x97, 0xde, 0x56, 0x82, 0x66,
+};
+
 /* Find the first occurrence of `needle` in `hay` (portable; avoids memmem). */
 static long find_bytes(const uint8_t *hay, size_t hn, const uint8_t *needle, size_t nn) {
     size_t i;
@@ -798,17 +873,23 @@ static long find_bytes(const uint8_t *hay, size_t hn, const uint8_t *needle, siz
 
 /* Seal a client Finished { type(20) || u24 len(32) || verify_data } record with
  * the given client handshake key/IV at sequence 0 (what a real client sends). */
-static int seal_client_finished(const uint8_t *vd, uint8_t *rec, size_t rec_cap,
-                                size_t *rec_len) {
+static int seal_client_finished_with(const uint8_t *vd, const uint8_t *key,
+                                      const uint8_t *iv, uint8_t *rec, size_t rec_cap,
+                                      size_t *rec_len) {
     uint8_t msg[4 + 32];
     msg[0] = TLS_HS_FINISHED;
     msg[1] = 0x00;
     msg[2] = 0x00;
     msg[3] = 0x20;
     memcpy(msg + 4, vd, 32);
-    return tls_record_seal(KAT_CLIENT_HS_KEY, KAT_CLIENT_HS_IV, 0,
-                           TLS_CONTENT_HANDSHAKE, msg, sizeof msg, 0,
+    return tls_record_seal(key, iv, 0, TLS_CONTENT_HANDSHAKE, msg, sizeof msg, 0,
                            rec, rec_cap, rec_len);
+}
+
+static int seal_client_finished(const uint8_t *vd, uint8_t *rec, size_t rec_cap,
+                                size_t *rec_len) {
+    return seal_client_finished_with(vd, KAT_CLIENT_HS_KEY, KAT_CLIENT_HS_IV,
+                                     rec, rec_cap, rec_len);
 }
 
 /* Copy KAT_CH, overwrite `repl` at the offset of `pat`, feed it, and require the
@@ -966,8 +1047,12 @@ static void test_server_handshake(void) {
         static const uint8_t r_suite[]= {0x13,0x01};   /* AES-128-GCM, not ChaCha20 */
         static const uint8_t p_sig[]  = {0x00,0x0d,0x00,0x04,0x00,0x02,0x08,0x07};
         static const uint8_t r_sig[]  = {0x08,0x08};   /* ed448, not ed25519 */
-        static const uint8_t p_ks[]   = {0x00,0x33,0x00,0x26,0x00,0x24,0x00,0x1d,0x00,0x20};
-        static const uint8_t r_ks[]   = {0x00,0x1e};   /* wrong key_share group -> no X25519 share */
+        /* Drop X25519 from supported_groups entirely: with no group left to retry
+         * with, this is the terminal handshake_failure (not an HRR trigger). A
+         * key_share for a non-X25519 group while X25519 is still *offered* triggers
+         * an HRR instead — exercised in full by test_tls_hrr below. */
+        static const uint8_t p_grp[]  = {0x00,0x0a,0x00,0x04,0x00,0x02,0x00,0x1d};
+        static const uint8_t r_grp[]  = {0x00,0x1e};   /* x25519 -> unknown group */
         check_ch_reject("srv hs: no TLS 1.3 -> protocol_version", &cfg,
                         p_ver, sizeof p_ver, 5, r_ver, sizeof r_ver,
                         TLS_ALERT_PROTOCOL_VERSION);
@@ -977,8 +1062,8 @@ static void test_server_handshake(void) {
         check_ch_reject("srv hs: no ed25519 -> handshake_failure", &cfg,
                         p_sig, sizeof p_sig, 6, r_sig, sizeof r_sig,
                         TLS_ALERT_HANDSHAKE_FAILURE);
-        check_ch_reject("srv hs: no X25519 key_share -> handshake_failure", &cfg,
-                        p_ks, sizeof p_ks, 6, r_ks, sizeof r_ks,
+        check_ch_reject("srv hs: no X25519 group at all -> handshake_failure", &cfg,
+                        p_grp, sizeof p_grp, 6, r_grp, sizeof r_grp,
                         TLS_ALERT_HANDSHAKE_FAILURE);
     }
 
@@ -1051,15 +1136,20 @@ static void conn_set_cfg(tls_server_config_t *cfg) {
     cfg->server_random = KAT_SERVER_RND;
 }
 
-/* Frame KAT_CH as a plaintext handshake record. */
-static size_t conn_make_ch_record(uint8_t *rec) {
+/* Frame arbitrary handshake-message bytes as one plaintext handshake record. */
+static size_t frame_hs_record(uint8_t *rec, const uint8_t *msg, size_t n) {
     rec[0] = TLS_CONTENT_HANDSHAKE;
     rec[1] = 0x03;
     rec[2] = 0x03;
-    rec[3] = (uint8_t)((sizeof KAT_CH) >> 8);
-    rec[4] = (uint8_t)(sizeof KAT_CH);
-    memcpy(rec + 5, KAT_CH, sizeof KAT_CH);
-    return 5 + sizeof KAT_CH;
+    rec[3] = (uint8_t)(n >> 8);
+    rec[4] = (uint8_t)(n & 0xff);
+    memcpy(rec + 5, msg, n);
+    return 5 + n;
+}
+
+/* Frame KAT_CH as a plaintext handshake record. */
+static size_t conn_make_ch_record(uint8_t *rec) {
+    return frame_hs_record(rec, KAT_CH, sizeof KAT_CH);
 }
 
 /* Drive a fresh connection to ESTABLISHED (ClientHello then client Finished). */
@@ -1071,6 +1161,98 @@ static void conn_establish(tls_khannection_t *c, const tls_server_config_t *cfg)
     tls_khannection_recv(c, ch, chl, out, sizeof out, &ol, app, sizeof app, &al);
     seal_client_finished(KAT_CLIENT_FINISHED_VD, fin, sizeof fin, &finl);
     tls_khannection_recv(c, fin, finl, out, sizeof out, &ol, app, sizeof app, &al);
+}
+
+/* HelloRetryRequest round trip (RFC 8446 §4.1.4), checked against hrr_oracle.py.
+ * The synthetic-transcript rewrite (§4.4.1) is the highest-risk new logic, so the
+ * app keys — which depend on the ENTIRE rewritten transcript — are matched against
+ * the independent oracle: agreement proves the rewrite is byte-correct. */
+static void test_tls_hrr(void) {
+    tls_server_hs_t hs;
+    tls_server_config_t cfg;
+    uint8_t out[2048];
+    size_t out_len = 0;
+    uint8_t rec[128];
+    size_t rec_len = 0;
+    uint8_t sk[32], siv[12], ck[32], civ[12];
+
+    memset(&cfg, 0, sizeof cfg);
+    cfg.cert_der = KAT_CERT;
+    cfg.cert_len = sizeof KAT_CERT;
+    cfg.ed25519_seed = KAT_ED_SEED;
+    cfg.ed25519_pub = KAT_ED_PUB;
+    cfg.server_eph_sk = KAT_SERVER_EPH;
+    cfg.server_random = KAT_SERVER_RND;
+
+    /* ===== Part A: the happy path CH1 -> HRR -> CH2 -> flight -> DONE ===== */
+    tls_server_hs_init(&hs);
+    check_true("hrr: CH1 (no X25519 share) accepted",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH1, sizeof KAT_CH1,
+                                               out, sizeof out, &out_len) == 1);
+    check_true("hrr: phase -> WAIT_CH2",
+               tls_server_hs_phase(&hs) == TLS_SERVER_HS_WAIT_CH2);
+    check_true("hrr: HRR record matches independent oracle byte-for-byte",
+               out_len == sizeof KAT_HRR_RECORD
+               && memcmp(out, KAT_HRR_RECORD, out_len) == 0);
+    check_true("hrr: app keys withheld in WAIT_CH2",
+               tls_server_hs_app_keys(&hs, sk, siv, ck, civ) == 0);
+
+    check_true("hrr: CH2 (with X25519 share) accepted",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH2, sizeof KAT_CH2,
+                                               out, sizeof out, &out_len) == 1);
+    check_true("hrr: phase -> WAIT_FINISHED",
+               tls_server_hs_phase(&hs) == TLS_SERVER_HS_WAIT_FINISHED);
+    check_true("hrr: flight ServerHello record framed (type 22)",
+               out_len > 5 && out[0] == 0x16);
+
+    check_true("hrr: (harness) seal client Finished over rewritten transcript",
+               seal_client_finished_with(KAT_HRR_CLIENT_FINISHED_VD,
+                                         KAT_HRR_CLIENT_HS_KEY, KAT_HRR_CLIENT_HS_IV,
+                                         rec, sizeof rec, &rec_len) == 1);
+    check_true("hrr: client Finished verified -> DONE",
+               tls_server_hs_read_client_finished(&hs, rec, rec_len) == 1
+               && tls_server_hs_phase(&hs) == TLS_SERVER_HS_DONE);
+    check_true("hrr: app keys released after DONE",
+               tls_server_hs_app_keys(&hs, sk, siv, ck, civ) == 1);
+    check_true("hrr: server app key matches oracle", memcmp(sk, KAT_HRR_SERVER_AP_KEY, 32) == 0);
+    check_true("hrr: server app iv matches oracle",  memcmp(siv, KAT_HRR_SERVER_AP_IV, 12) == 0);
+    check_true("hrr: client app key matches oracle", memcmp(ck, KAT_HRR_CLIENT_AP_KEY, 32) == 0);
+    check_true("hrr: client app iv matches oracle",  memcmp(civ, KAT_HRR_CLIENT_AP_IV, 12) == 0);
+
+    /* ===== Part B: HRR-specific state-machine defences ===== */
+    /* B1: a client that ignores the retry (CH2 still lacks an X25519 share) is
+     * aborted with illegal_parameter — never answered with a second HRR. */
+    tls_server_hs_init(&hs);
+    tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH1, sizeof KAT_CH1, out, sizeof out, &out_len);
+    check_true("hrr: still-share-less CH2 -> illegal_parameter (no HRR loop)",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH1, sizeof KAT_CH1,
+                                               out, sizeof out, &out_len) == 0
+               && tls_server_hs_phase(&hs) == TLS_SERVER_HS_FAILED
+               && tls_server_hs_alert(&hs) == TLS_ALERT_ILLEGAL_PARAMETER);
+
+    /* B2: CH2 whose Random differs from CH1 violates RFC 8446 §4.1.2 -> abort. */
+    {
+        uint8_t ch2_bad[sizeof KAT_CH2];
+        memcpy(ch2_bad, KAT_CH2, sizeof KAT_CH2);
+        ch2_bad[6] ^= 0xff;   /* the 32-byte Random begins at offset 6 */
+        tls_server_hs_init(&hs);
+        tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH1, sizeof KAT_CH1, out, sizeof out, &out_len);
+        check_true("hrr: CH2 with altered Random -> illegal_parameter",
+                   tls_server_hs_read_client_hello(&hs, &cfg, ch2_bad, sizeof ch2_bad,
+                                                   out, sizeof out, &out_len) == 0
+                   && tls_server_hs_phase(&hs) == TLS_SERVER_HS_FAILED
+                   && tls_server_hs_alert(&hs) == TLS_ALERT_ILLEGAL_PARAMETER);
+    }
+
+    /* B3: after CH2 (WAIT_FINISHED) a further ClientHello is unexpected_message. */
+    tls_server_hs_init(&hs);
+    tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH1, sizeof KAT_CH1, out, sizeof out, &out_len);
+    tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH2, sizeof KAT_CH2, out, sizeof out, &out_len);
+    check_true("hrr: ClientHello after WAIT_FINISHED -> unexpected_message",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH2, sizeof KAT_CH2,
+                                               out, sizeof out, &out_len) == 0
+               && tls_server_hs_phase(&hs) == TLS_SERVER_HS_FAILED
+               && tls_server_hs_alert(&hs) == TLS_ALERT_UNEXPECTED_MESSAGE);
 }
 
 static void test_tls_khannection(void) {
@@ -1308,6 +1490,59 @@ static void test_tls_khannection(void) {
 }
 #endif /* WEBLIB_TLS */
 
+/* HelloRetryRequest driven end-to-end through the connection engine: its
+ * record-type dispatch must route CH1 -> HRR, tolerate a middlebox-compat CCS
+ * between HRR and CH2, route CH2 -> flight, and the client Finished ->
+ * ESTABLISHED, after which application data flows under the HRR-derived keys. */
+static void test_tls_khannection_hrr(void) {
+    static uint8_t out[2048], app[256];
+    tls_server_config_t cfg;
+    tls_khannection_t c;
+    uint8_t ch1[5 + sizeof KAT_CH1], ch2[5 + sizeof KAT_CH2], fin[128];
+    static const uint8_t ccs_rec[6] = { 0x14, 0x03, 0x03, 0x00, 0x01, 0x01 };
+    size_t ch1l, ch2l, out_len = 0, app_len = 0, finl = 0;
+    tls_khannection_rc_t rc;
+
+    conn_set_cfg(&cfg);
+    ch1l = frame_hs_record(ch1, KAT_CH1, sizeof KAT_CH1);
+    ch2l = frame_hs_record(ch2, KAT_CH2, sizeof KAT_CH2);
+
+    tls_khannection_init(&c, &cfg);
+    rc = tls_khannection_recv(&c, ch1, ch1l, out, sizeof out, &out_len, app, sizeof app, &app_len);
+    check_true("conn/hrr: CH1 -> HelloRetryRequest, still HANDSHAKE",
+               rc == TLS_KHANNECTION_RC_OK && tls_khannection_state(&c) == TLS_KHANNECTION_HANDSHAKE
+               && out_len == sizeof KAT_HRR_RECORD && memcmp(out, KAT_HRR_RECORD, out_len) == 0);
+
+    rc = tls_khannection_recv(&c, ccs_rec, sizeof ccs_rec, out, sizeof out, &out_len, app, sizeof app, &app_len);
+    check_true("conn/hrr: CCS between HRR and CH2 dropped",
+               rc == TLS_KHANNECTION_RC_OK && out_len == 0
+               && tls_khannection_state(&c) == TLS_KHANNECTION_HANDSHAKE);
+
+    rc = tls_khannection_recv(&c, ch2, ch2l, out, sizeof out, &out_len, app, sizeof app, &app_len);
+    check_true("conn/hrr: CH2 -> flight emitted",
+               rc == TLS_KHANNECTION_RC_OK && out_len > 5 && out[0] == 0x16
+               && tls_khannection_state(&c) == TLS_KHANNECTION_HANDSHAKE);
+
+    seal_client_finished_with(KAT_HRR_CLIENT_FINISHED_VD, KAT_HRR_CLIENT_HS_KEY,
+                              KAT_HRR_CLIENT_HS_IV, fin, sizeof fin, &finl);
+    rc = tls_khannection_recv(&c, fin, finl, out, sizeof out, &out_len, app, sizeof app, &app_len);
+    check_true("conn/hrr: client Finished -> ESTABLISHED",
+               rc == TLS_KHANNECTION_RC_OK && tls_khannection_state(&c) == TLS_KHANNECTION_ESTABLISHED);
+
+    {
+        static const uint8_t req[] = "ping-after-hrr";
+        uint8_t recq[128];
+        size_t recql = 0;
+        tls_record_seal(KAT_HRR_CLIENT_AP_KEY, KAT_HRR_CLIENT_AP_IV, 0,
+                        TLS_CONTENT_APPLICATION_DATA, req, sizeof req - 1, 0,
+                        recq, sizeof recq, &recql);
+        rc = tls_khannection_recv(&c, recq, recql, out, sizeof out, &out_len, app, sizeof app, &app_len);
+        check_true("conn/hrr: client app data decrypts under the HRR-derived key",
+                   rc == TLS_KHANNECTION_RC_OK && app_len == sizeof req - 1
+                   && memcmp(app, req, app_len) == 0);
+    }
+}
+
 int main(void) {
 #ifndef WEBLIB_TLS
     printf("FAIL: test_tls_parse built without WEBLIB_TLS defined\n");
@@ -1323,7 +1558,9 @@ int main(void) {
     test_client_hello();
     test_hs_build();
     test_server_handshake();
+    test_tls_hrr();
     test_tls_khannection();
+    test_tls_khannection_hrr();
 
     if (g_failures == 0) {
         printf("All TLS parse tests passed.\n");


### PR DESCRIPTION
## What

Adds **HelloRetryRequest** to the pure-C TLS 1.3 server. A ClientHello that offers X25519 in `supported_groups` but sends **no X25519 `key_share`** is now negotiated via a single HRR — the client resends with the share and the handshake completes — instead of being refused with `handshake_failure`. This closes the last handshake-level interop gap from [Milestone #1](https://github.com/kamrankhan78694/modern-c-web-library/milestone/1) for clients that don't preemptively guess our group.

## Why this is the high-risk one

Per the project's own guidance, the handshake **state machine** — not the primitives — is where TLS CVEs live, and HRR's §4.4.1 **synthetic-transcript rewrite** (the first ClientHello is replaced by `message_hash(Hash(CH1))`) is a classic pitfall. So the design isolates and independently pins exactly that.

## Design

- **State machine** (`server_handshake.c`): new phase `WAIT_CH2` between `START` and `WAIT_FINISHED`. Phases still only advance; **at most one HRR** is ever sent (`WAIT_CH2 → WAIT_FINISHED | FAILED`, never back to `START`) so no HRR loop is possible. `read_client_hello` is now re-entrant (dispatch on phase); the post-key_share logic is factored into a shared `emit_server_flight` so the **normal 1-RTT path is byte-identical** to before.
- **CH2 validation**: must now carry the X25519 share (else `illegal_parameter` — never a second HRR) and be consistent with CH1 (`Random` + `legacy_session_id` unchanged — a documented subset of §4.1.2; the transcript binds CH1+HRR+CH2, so any on-the-wire tampering is fatal at the client Finished).
- **§4.4.1 rewrite** (`handshake_auth.c`): isolated in `tls_transcript_reinit_after_hrr` (`message_hash(254) || uint24(32) || Hash(CH1)`).
- **HRR message** (`handshake.c`): `tls_build_hello_retry_request` — a ServerHello with the special HRR Random and a `key_share` naming only the selected group (§4.2.8), no key_exchange.
- **Connection engine** (`tls_khannection.c`): **no functional change** — record-type dispatch routes a post-HRR ClientHello to `read_client_hello` and the Finished to `read_client_finished` automatically. Comment clarified.

## Independent verification (symmetry-breaking)

A separate Python oracle (`hrr_oracle.py`, `cryptography`-backed) drives the whole HRR flow and predicts, from first principles over the §4.4.1-rewritten transcript, both the HRR record and the entire post-CH2 key schedule. `test_tls_parse` gains **23 assertions**:
- the HRR record matches the oracle **byte-for-byte**;
- the **application keys match the oracle** — since those depend on the *entire* rewritten transcript, agreement proves the rewrite is byte-correct;
- negatives: still-share-less CH2 → `illegal_parameter` (no loop), altered CH2 `Random` → `illegal_parameter`, ClientHello after `WAIT_FINISHED` → `unexpected_message`;
- an **end-to-end run through the connection engine**, including a middlebox-compat CCS between HRR and CH2.

## Verification matrix

- TLS build: **13/13** ✅
- Default (TLS-off) build: **6/6** ✅, byte-identical (no HRR symbols leak — `nm` clean)
- Zero warnings (`-Wall -Wextra -pedantic`) ✅
- **ASan/UBSan** clean over the HRR paths and the fuzzer ✅
- **Negative control**: corrupting the §4.4.1 `message_hash` byte breaks the client-Finished + app-key KATs, proving the test genuinely pins the rewrite ✅
- **No interop regression**: `TlsInteropOpenssl` still passes — a real OpenSSL client (which sends an X25519 share) still gets 1-RTT, not an HRR ✅
- **Adversarial gate**: a 5-lens review (transcript, state-machine, memory-safety, fail-closed, RFC/interop), each finding adversarially refuted — **no confirmed findings**.

## Follow-up (not this PR)

Browser interop; optional middlebox-compat ChangeCipherSpec *emission* and ALPN. Known bound unchanged: Ed25519-only, so a client not offering `ed25519` is correctly refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)