### PR TITLE
tls: ALPN negotiation for HTTP/1.1 (RFC 7301)

### DIFF
--- a/src/tls/handshake.c
+++ b/src/tls/handshake.c
@@ -24,8 +24,12 @@
 #define EXT_SERVER_NAME         0x0000
 #define EXT_SUPPORTED_GROUPS    0x000a
 #define EXT_SIGNATURE_ALGS      0x000d
+#define EXT_ALPN                0x0010
 #define EXT_SUPPORTED_VERSIONS  0x002b
 #define EXT_KEY_SHARE           0x0033
+
+/* The one application protocol this server implements (RFC 7301 ALPN). */
+static const uint8_t ALPN_HTTP11[8] = { 'h', 't', 't', 'p', '/', '1', '.', '1' };
 
 /* Return 1 if the u16 list `r` contains `want` (scanning to its end). */
 static int list_u16_contains(tls_reader_t *r, uint16_t want) {
@@ -202,6 +206,42 @@ int tls_parse_client_hello(const uint8_t *msg, size_t msg_len, tls_client_hello_
             }
             break;
         }
+        case EXT_ALPN: {
+            /* application_layer_protocol_negotiation (RFC 7301):
+             * ProtocolName protocol_name_list<2..2^16-1>, each opaque<1..2^8-1>.
+             * Read every name in full (a truncated one fails) and note whether the
+             * list includes "http/1.1"; the actual selection is the caller's. */
+            tls_reader_t names;
+            if (!tls_read_vector(&ext_data, 2, &names)) {
+                return 0;
+            }
+            if (tls_reader_remaining(&names) < 1) {
+                return 0;   /* protocol_name_list<2..> must hold at least one name */
+            }
+            out->alpn_present = 1;
+            while (tls_reader_remaining(&names) > 0) {
+                tls_reader_t name;
+                if (!tls_read_vector(&names, 1, &name)) {
+                    return 0;
+                }
+                if (tls_reader_remaining(&name) < 1) {
+                    return 0;   /* ProtocolName<1..> must be non-empty */
+                }
+                if (tls_reader_remaining(&name) == sizeof ALPN_HTTP11) {
+                    const uint8_t *p;
+                    if (!tls_read_bytes(&name, &p, sizeof ALPN_HTTP11)) {
+                        return 0;
+                    }
+                    if (memcmp(p, ALPN_HTTP11, sizeof ALPN_HTTP11) == 0) {
+                        out->alpn_http11 = 1;
+                    }
+                }
+            }
+            if (!tls_reader_eof(&ext_data)) {
+                return 0;
+            }
+            break;
+        }
         case EXT_SERVER_NAME: {
             /* ServerNameList server_name_list<1..2^16-1>. Each entry is
              * { NameType name_type; HostName host_name<1..2^16-1> } (host_name is
@@ -347,14 +387,31 @@ int tls_build_hello_retry_request(tls_writer_t *w,
     return tls_writer_ok(w);
 }
 
-int tls_build_encrypted_extensions(tls_writer_t *w) {
-    size_t hdr, exts;
+int tls_build_encrypted_extensions(tls_writer_t *w, const uint8_t *alpn, size_t alpn_len) {
+    size_t hdr, exts, ext_data, list, name;
     if (w == NULL) {
         return 0;
     }
+    if (alpn == NULL && alpn_len != 0) {
+        return 0;
+    }
+    if (alpn != NULL && (alpn_len < 1 || alpn_len > 255)) {
+        return 0;   /* ProtocolName<1..2^8-1> */
+    }
     tls_write_u8(w, TLS_HS_ENCRYPTED_EXTENSIONS);
     hdr = tls_writer_open_vector(w, 3);
-    exts = tls_writer_open_vector(w, 2);         /* empty extensions block */
+    exts = tls_writer_open_vector(w, 2);
+    if (alpn != NULL) {
+        /* One ALPN extension (RFC 7301) with a single selected ProtocolName. */
+        tls_write_u16(w, EXT_ALPN);
+        ext_data = tls_writer_open_vector(w, 2);
+        list = tls_writer_open_vector(w, 2);     /* ProtocolNameList */
+        name = tls_writer_open_vector(w, 1);     /* ProtocolName<1..255> */
+        tls_write_bytes(w, alpn, alpn_len);
+        tls_writer_close_vector(w, name, 1);
+        tls_writer_close_vector(w, list, 2);
+        tls_writer_close_vector(w, ext_data, 2);
+    }
     tls_writer_close_vector(w, exts, 2);
     tls_writer_close_vector(w, hdr, 3);
     return tls_writer_ok(w);

--- a/src/tls/handshake.c
+++ b/src/tls/handshake.c
@@ -28,9 +28,6 @@
 #define EXT_SUPPORTED_VERSIONS  0x002b
 #define EXT_KEY_SHARE           0x0033
 
-/* The one application protocol this server implements (RFC 7301 ALPN). */
-static const uint8_t ALPN_HTTP11[8] = { 'h', 't', 't', 'p', '/', '1', '.', '1' };
-
 /* Return 1 if the u16 list `r` contains `want` (scanning to its end). */
 static int list_u16_contains(tls_reader_t *r, uint16_t want) {
     uint16_t v;
@@ -227,12 +224,12 @@ int tls_parse_client_hello(const uint8_t *msg, size_t msg_len, tls_client_hello_
                 if (tls_reader_remaining(&name) < 1) {
                     return 0;   /* ProtocolName<1..> must be non-empty */
                 }
-                if (tls_reader_remaining(&name) == sizeof ALPN_HTTP11) {
+                if (tls_reader_remaining(&name) == TLS_ALPN_HTTP11_LEN) {
                     const uint8_t *p;
-                    if (!tls_read_bytes(&name, &p, sizeof ALPN_HTTP11)) {
+                    if (!tls_read_bytes(&name, &p, TLS_ALPN_HTTP11_LEN)) {
                         return 0;
                     }
-                    if (memcmp(p, ALPN_HTTP11, sizeof ALPN_HTTP11) == 0) {
+                    if (memcmp(p, TLS_ALPN_HTTP11, TLS_ALPN_HTTP11_LEN) == 0) {
                         out->alpn_http11 = 1;
                     }
                 }

--- a/src/tls/handshake.h
+++ b/src/tls/handshake.h
@@ -44,6 +44,8 @@ typedef struct {
     const uint8_t *x25519_key_share;   /* client's 32-byte X25519 public key, or NULL */
     const uint8_t *server_name;        /* SNI host_name (not NUL-terminated), or NULL */
     size_t server_name_len;
+    int alpn_present;                  /* an ALPN extension (RFC 7301) was offered */
+    int alpn_http11;                   /* the ALPN list includes "http/1.1" */
 } tls_client_hello_t;
 
 /*
@@ -80,8 +82,10 @@ int tls_build_server_hello(tls_writer_t *w, const uint8_t random[32],
 int tls_build_hello_retry_request(tls_writer_t *w,
                                   const uint8_t *session_id, size_t session_id_len);
 
-/* EncryptedExtensions (RFC 8446 §4.3.1): an empty extensions block. */
-int tls_build_encrypted_extensions(tls_writer_t *w);
+/* EncryptedExtensions (RFC 8446 §4.3.1). If `alpn` is non-NULL it carries a single
+ * application_layer_protocol_negotiation (RFC 7301) selecting the `alpn_len`-byte
+ * protocol name (1..255); otherwise the extensions block is empty. */
+int tls_build_encrypted_extensions(tls_writer_t *w, const uint8_t *alpn, size_t alpn_len);
 
 /* Certificate (RFC 8446 §4.4.2): empty certificate_request_context and a single
  * CertificateEntry carrying `cert_der` (with no per-certificate extensions). */

--- a/src/tls/handshake.h
+++ b/src/tls/handshake.h
@@ -28,6 +28,12 @@
 #define TLS_HS_CERTIFICATE_VERIFY   15
 #define TLS_HS_FINISHED             20
 
+/* The single ALPN protocol id this server implements (RFC 7301). Defined once so
+ * the parser (which detects it being offered), the EncryptedExtensions builder
+ * (which echoes it) and the handshake's selection logic can never drift apart. */
+#define TLS_ALPN_HTTP11     "http/1.1"
+#define TLS_ALPN_HTTP11_LEN (sizeof(TLS_ALPN_HTTP11) - 1)   /* 8, without the NUL */
+
 /*
  * The parsed subset of a ClientHello. The pointer fields borrow into the caller's
  * message buffer and are valid only as long as it lives; they are NULL / 0 when

--- a/src/tls/server_handshake.c
+++ b/src/tls/server_handshake.c
@@ -76,15 +76,13 @@ void tls_server_hs_init(tls_server_hs_t *hs) {
     hs->alert = 0;
 }
 
-/* The single application protocol this server speaks (RFC 7301 ALPN). */
-static const uint8_t ALPN_HTTP11[8] = { 'h', 't', 't', 'p', '/', '1', '.', '1' };
-
 /*
- * ALPN selection (RFC 7301). We offer only HTTP/1.1. Returns 1 with *proto set to
- * the chosen protocol name (or NULL/0 when the client offered no ALPN at all), or 0
- * when the client offered ALPN but nothing we support — the caller must then abort
- * with no_application_protocol rather than silently proceeding with a protocol the
- * peer didn't agree to.
+ * ALPN selection (RFC 7301). We offer only HTTP/1.1 (TLS_ALPN_HTTP11, the same id
+ * the parser matches and the EncryptedExtensions builder echoes). Returns 1 with
+ * *proto set to the chosen protocol name (or NULL/0 when the client offered no ALPN
+ * at all), or 0 when the client offered ALPN but nothing we support — the caller
+ * must then abort with no_application_protocol rather than silently proceeding with
+ * a protocol the peer didn't agree to.
  */
 static int select_alpn(const tls_client_hello_t *ch,
                        const uint8_t **proto, size_t *proto_len) {
@@ -94,8 +92,8 @@ static int select_alpn(const tls_client_hello_t *ch,
         return 1;
     }
     if (ch->alpn_http11) {
-        *proto = ALPN_HTTP11;
-        *proto_len = sizeof ALPN_HTTP11;
+        *proto = (const uint8_t *)TLS_ALPN_HTTP11;
+        *proto_len = TLS_ALPN_HTTP11_LEN;
         return 1;
     }
     return 0;

--- a/src/tls/server_handshake.c
+++ b/src/tls/server_handshake.c
@@ -76,6 +76,31 @@ void tls_server_hs_init(tls_server_hs_t *hs) {
     hs->alert = 0;
 }
 
+/* The single application protocol this server speaks (RFC 7301 ALPN). */
+static const uint8_t ALPN_HTTP11[8] = { 'h', 't', 't', 'p', '/', '1', '.', '1' };
+
+/*
+ * ALPN selection (RFC 7301). We offer only HTTP/1.1. Returns 1 with *proto set to
+ * the chosen protocol name (or NULL/0 when the client offered no ALPN at all), or 0
+ * when the client offered ALPN but nothing we support — the caller must then abort
+ * with no_application_protocol rather than silently proceeding with a protocol the
+ * peer didn't agree to.
+ */
+static int select_alpn(const tls_client_hello_t *ch,
+                       const uint8_t **proto, size_t *proto_len) {
+    if (!ch->alpn_present) {
+        *proto = NULL;
+        *proto_len = 0;
+        return 1;
+    }
+    if (ch->alpn_http11) {
+        *proto = ALPN_HTTP11;
+        *proto_len = sizeof ALPN_HTTP11;
+        return 1;
+    }
+    return 0;
+}
+
 /*
  * Shared tail of both ClientHello paths. On entry `transcript` already contains
  * the ClientHello(s) (a single CH1, or the synthetic message_hash + HRR + CH2). We
@@ -91,6 +116,7 @@ static int emit_server_flight(tls_server_hs_t *hs, const tls_server_config_t *cf
                               tls_transcript_t *transcript,
                               const uint8_t client_share[32],
                               const uint8_t *session_id, size_t session_id_len,
+                              const uint8_t *alpn, size_t alpn_len,
                               uint8_t *out, size_t out_cap, size_t *out_len,
                               uint8_t *alert) {
     uint8_t ecdhe[32];
@@ -173,7 +199,7 @@ static int emit_server_flight(tls_server_hs_t *hs, const tls_server_config_t *cf
      * with its own writer at a running offset so its exact bytes are known. */
     /* EncryptedExtensions */
     tls_writer_init(&w, flight, sizeof flight);
-    if (!tls_build_encrypted_extensions(&w) || !tls_writer_finish(&w, &mlen)) {
+    if (!tls_build_encrypted_extensions(&w, alpn, alpn_len) || !tls_writer_finish(&w, &mlen)) {
         goto done;
     }
     tls_transcript_update(transcript, flight, mlen);
@@ -340,6 +366,8 @@ static int handle_client_hello_1(tls_server_hs_t *hs, const tls_server_config_t 
                                  uint8_t *out, size_t out_cap, size_t *out_len) {
     tls_client_hello_t ch;
     tls_transcript_t transcript;
+    const uint8_t *alpn = NULL;
+    size_t alpn_len = 0;
     uint8_t alert = TLS_ALERT_INTERNAL_ERROR;
 
     if (!tls_parse_client_hello(ch_msg, ch_len, &ch)) {
@@ -352,12 +380,16 @@ static int handle_client_hello_1(tls_server_hs_t *hs, const tls_server_config_t 
         /* X25519 offered but no share supplied -> HelloRetryRequest. */
         return send_hello_retry_request(hs, &ch, ch_msg, ch_len, out, out_cap, out_len);
     }
+    /* Negotiate ALPN before committing to the flight. */
+    if (!select_alpn(&ch, &alpn, &alpn_len)) {
+        return fail(hs, TLS_ALERT_NO_APPLICATION_PROTOCOL);
+    }
     /* Normal 1-RTT: transcript = {ClientHello}, then the server flight. */
     tls_transcript_init(&transcript);
     tls_transcript_update(&transcript, ch_msg, ch_len);
     if (!emit_server_flight(hs, cfg, &transcript, ch.x25519_key_share,
-                            ch.session_id, ch.session_id_len, out, out_cap, out_len,
-                            &alert)) {
+                            ch.session_id, ch.session_id_len, alpn, alpn_len,
+                            out, out_cap, out_len, &alert)) {
         return fail(hs, alert);
     }
     return 1;
@@ -370,6 +402,8 @@ static int handle_client_hello_2(tls_server_hs_t *hs, const tls_server_config_t 
                                  const uint8_t *ch_msg, size_t ch_len,
                                  uint8_t *out, size_t out_cap, size_t *out_len) {
     tls_client_hello_t ch;
+    const uint8_t *alpn = NULL;
+    size_t alpn_len = 0;
     uint8_t alert = TLS_ALERT_INTERNAL_ERROR;
 
     if (!tls_parse_client_hello(ch_msg, ch_len, &ch)) {
@@ -395,12 +429,15 @@ static int handle_client_hello_2(tls_server_hs_t *hs, const tls_server_config_t 
         return fail(hs, TLS_ALERT_ILLEGAL_PARAMETER);
     }
 
+    if (!select_alpn(&ch, &alpn, &alpn_len)) {
+        return fail(hs, TLS_ALERT_NO_APPLICATION_PROTOCOL);
+    }
     /* Continue the transcript with CH2 (message_hash(CH1) + HRR already absorbed),
      * then complete the flight. */
     tls_transcript_update(&hs->transcript, ch_msg, ch_len);
     if (!emit_server_flight(hs, cfg, &hs->transcript, ch.x25519_key_share,
-                            ch.session_id, ch.session_id_len, out, out_cap, out_len,
-                            &alert)) {
+                            ch.session_id, ch.session_id_len, alpn, alpn_len,
+                            out, out_cap, out_len, &alert)) {
         return fail(hs, alert);
     }
     /* The HRR round-trip scratch is no longer needed. */

--- a/src/tls/server_handshake.h
+++ b/src/tls/server_handshake.h
@@ -73,6 +73,7 @@
 #define TLS_ALERT_DECRYPT_ERROR      51
 #define TLS_ALERT_PROTOCOL_VERSION   70
 #define TLS_ALERT_INTERNAL_ERROR     80
+#define TLS_ALERT_NO_APPLICATION_PROTOCOL 120   /* RFC 7301: no common ALPN protocol */
 
 /* ---- phases ------------------------------------------------------------ */
 /*

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -634,10 +634,33 @@ static void test_hs_build(void) {
                && out_len == sizeof expect_sh && memcmp(buf, expect_sh, out_len) == 0);
 
     tls_writer_init(&w, buf, sizeof buf);
-    check_true("hs build: EncryptedExtensions wire",
-               tls_build_encrypted_extensions(&w) == 1
+    check_true("hs build: EncryptedExtensions wire (empty, no ALPN)",
+               tls_build_encrypted_extensions(&w, NULL, 0) == 1
                && tls_writer_finish(&w, &out_len) == 1
                && out_len == sizeof expect_ee && memcmp(buf, expect_ee, out_len) == 0);
+    /* With ALPN "http/1.1": EE carries one ALPN extension (RFC 7301). Wire, with
+     * every nested length spelled out:
+     *   08            EncryptedExtensions
+     *   00 00 11      body length = 17
+     *   00 0f         extensions vector = 15
+     *   00 10         ext_type = ALPN
+     *   00 0b         extension_data = 11
+     *   00 09         ProtocolNameList = 9
+     *   08            ProtocolName length = 8
+     *   "http/1.1"    the protocol name */
+    {
+        static const uint8_t h11[8] = { 'h','t','t','p','/','1','.','1' };
+        static const uint8_t expect_ee_alpn[] = {
+            0x08, 0x00, 0x00, 0x11, 0x00, 0x0f, 0x00, 0x10, 0x00, 0x0b, 0x00, 0x09,
+            0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31,
+        };
+        tls_writer_init(&w, buf, sizeof buf);
+        check_true("hs build: EncryptedExtensions wire (ALPN http/1.1)",
+                   tls_build_encrypted_extensions(&w, h11, sizeof h11) == 1
+                   && tls_writer_finish(&w, &out_len) == 1
+                   && out_len == sizeof expect_ee_alpn
+                   && memcmp(buf, expect_ee_alpn, out_len) == 0);
+    }
 
     tls_writer_init(&w, buf, sizeof buf);
     check_true("hs build: Certificate wire",
@@ -855,6 +878,68 @@ static const uint8_t KAT_HRR_CLIENT_AP_KEY[32] = {
 };
 static const uint8_t KAT_HRR_CLIENT_AP_IV[12] = {
     0x29, 0x78, 0x47, 0x1c, 0x5e, 0x51, 0x8d, 0x97, 0xde, 0x56, 0x82, 0x66,
+};
+
+/* ===== ALPN flow, from the independent alpn_oracle.py =====
+ * KAT_CH_ALPN is a ClientHello that additionally offers ALPN ["http/1.1"]. The
+ * server must echo it in EncryptedExtensions (KAT_EE_ALPN), which changes the
+ * transcript, so the keys below differ from the no-ALPN base handshake. */
+static const uint8_t KAT_CH_ALPN[159] = {
+    0x01, 0x00, 0x00, 0x9b, 0x03, 0x03, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1, 0xc1,
+    0xc1, 0xc1, 0x20, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+    0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x00,
+    0x02, 0x13, 0x03, 0x01, 0x00, 0x00, 0x50, 0x00, 0x2b, 0x00, 0x03, 0x02,
+    0x03, 0x04, 0x00, 0x0a, 0x00, 0x04, 0x00, 0x02, 0x00, 0x1d, 0x00, 0x0d,
+    0x00, 0x04, 0x00, 0x02, 0x08, 0x07, 0x00, 0x10, 0x00, 0x0b, 0x00, 0x09,
+    0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31, 0x00, 0x33, 0x00,
+    0x26, 0x00, 0x24, 0x00, 0x1d, 0x00, 0x20, 0x79, 0xa6, 0x31, 0xee, 0xde,
+    0x1b, 0xf9, 0xc9, 0x8f, 0x12, 0x03, 0x2c, 0xde, 0xad, 0xd0, 0xe7, 0xa0,
+    0x79, 0x39, 0x8f, 0xc7, 0x86, 0xb8, 0x8c, 0xc8, 0x46, 0xec, 0x89, 0xaf,
+    0x85, 0xa5, 0x1a,
+};
+static const uint8_t KAT_EE_ALPN[21] = {
+    0x08, 0x00, 0x00, 0x11, 0x00, 0x0f, 0x00, 0x10, 0x00, 0x0b, 0x00, 0x09,
+    0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31,
+};
+static const uint8_t KAT_ALPN_SERVER_HS_KEY[32] = {
+    0x1b, 0xf4, 0xe2, 0x8d, 0xa9, 0x1b, 0x70, 0xfc, 0xf6, 0xe8, 0x8d, 0xae,
+    0x42, 0x28, 0xd5, 0x9c, 0x45, 0xdd, 0x53, 0xbe, 0x19, 0xa7, 0x99, 0x5a,
+    0x4d, 0xcc, 0x92, 0xd4, 0xc5, 0xa9, 0x2b, 0x1a,
+};
+static const uint8_t KAT_ALPN_SERVER_HS_IV[12] = {
+    0xb4, 0x83, 0x2c, 0x15, 0x83, 0x14, 0x27, 0x4c, 0x46, 0xa8, 0x0b, 0x74,
+};
+static const uint8_t KAT_ALPN_CLIENT_HS_KEY[32] = {
+    0x87, 0x9e, 0x5d, 0x5d, 0x0c, 0x20, 0x03, 0xa2, 0x6b, 0x78, 0xb2, 0x32,
+    0x85, 0xdb, 0x0d, 0xff, 0x7c, 0xb9, 0x03, 0xed, 0x63, 0x01, 0x85, 0x49,
+    0x42, 0x39, 0xec, 0xc4, 0x96, 0x7d, 0x30, 0xc3,
+};
+static const uint8_t KAT_ALPN_CLIENT_HS_IV[12] = {
+    0x8d, 0x58, 0xeb, 0xa8, 0xf9, 0xb5, 0xb6, 0xa3, 0x93, 0x4a, 0x3a, 0xcc,
+};
+static const uint8_t KAT_ALPN_CLIENT_FINISHED_VD[32] = {
+    0x87, 0x30, 0xc4, 0xcb, 0x1b, 0xb3, 0x1a, 0x7e, 0x3c, 0x9f, 0x04, 0x3c,
+    0x81, 0x2e, 0x14, 0xd8, 0x2a, 0x0b, 0x9b, 0x39, 0xd5, 0xb9, 0x2c, 0x7f,
+    0xdb, 0x43, 0x2f, 0x03, 0x84, 0x34, 0xce, 0x39,
+};
+static const uint8_t KAT_ALPN_SERVER_AP_KEY[32] = {
+    0xa5, 0x09, 0x77, 0xde, 0xac, 0xda, 0x87, 0x57, 0x86, 0x48, 0x29, 0x79,
+    0x48, 0xb2, 0x95, 0xe8, 0x0b, 0xe8, 0xec, 0xe7, 0x42, 0xe4, 0xe3, 0xfa,
+    0x7d, 0x3d, 0x97, 0x0e, 0x67, 0x27, 0x24, 0x6d,
+};
+static const uint8_t KAT_ALPN_SERVER_AP_IV[12] = {
+    0x9a, 0x72, 0x0b, 0xbf, 0xd5, 0xe7, 0xab, 0xc9, 0x31, 0xd5, 0xe4, 0x5d,
+};
+static const uint8_t KAT_ALPN_CLIENT_AP_KEY[32] = {
+    0x79, 0xc5, 0x0a, 0x47, 0xdb, 0xab, 0x32, 0xdb, 0x61, 0xa4, 0x4f, 0x4c,
+    0x77, 0xd3, 0x8b, 0xb1, 0xb0, 0x2f, 0x59, 0x66, 0x96, 0x8a, 0x9d, 0xd4,
+    0xfc, 0xe8, 0x29, 0x27, 0xf5, 0xc9, 0x28, 0x37,
+};
+static const uint8_t KAT_ALPN_CLIENT_AP_IV[12] = {
+    0xe1, 0x8f, 0x7d, 0x8c, 0x95, 0x0d, 0x9a, 0xdb, 0x1a, 0xac, 0x59, 0x19,
 };
 
 /* Find the first occurrence of `needle` in `hay` (portable; avoids memmem). */
@@ -1255,6 +1340,81 @@ static void test_tls_hrr(void) {
                && tls_server_hs_alert(&hs) == TLS_ALERT_UNEXPECTED_MESSAGE);
 }
 
+/* ALPN (RFC 7301), checked against alpn_oracle.py. A ClientHello offering
+ * ["http/1.1"] gets it echoed in EncryptedExtensions — which changes the transcript,
+ * so the keys differ from the base handshake and matching them proves the ALPN EE is
+ * bound correctly. A client offering ALPN with no acceptable protocol is aborted
+ * with no_application_protocol. (The no-ALPN case — empty EE — is covered by
+ * test_server_handshake, whose KATs are unchanged by this feature.) */
+static void test_tls_alpn(void) {
+    tls_server_hs_t hs;
+    tls_server_config_t cfg;
+    uint8_t out[2048];
+    size_t out_len = 0, sh_len, rec_off, flen = 0, rec_len = 0;
+    uint8_t flight[512], rec[128];
+    uint8_t ctype = 0;
+    uint8_t sk[32], siv[12], ck[32], civ[12];
+
+    memset(&cfg, 0, sizeof cfg);
+    cfg.cert_der = KAT_CERT;
+    cfg.cert_len = sizeof KAT_CERT;
+    cfg.ed25519_seed = KAT_ED_SEED;
+    cfg.ed25519_pub = KAT_ED_PUB;
+    cfg.server_eph_sk = KAT_SERVER_EPH;
+    cfg.server_random = KAT_SERVER_RND;
+
+    /* ===== Part A: ALPN negotiated (http/1.1) ===== */
+    tls_server_hs_init(&hs);
+    check_true("alpn: ClientHello offering http/1.1 accepted",
+               tls_server_hs_read_client_hello(&hs, &cfg, KAT_CH_ALPN, sizeof KAT_CH_ALPN,
+                                               out, sizeof out, &out_len) == 1);
+    check_true("alpn: phase -> WAIT_FINISHED",
+               tls_server_hs_phase(&hs) == TLS_SERVER_HS_WAIT_FINISHED);
+    sh_len = ((size_t)out[3] << 8) | out[4];
+    rec_off = 5 + sh_len;
+    check_true("alpn: flight opens under the ALPN-oracle key schedule",
+               out[0] == 0x16 && rec_off < out_len && out[rec_off] == 0x17
+               && tls_record_open(KAT_ALPN_SERVER_HS_KEY, KAT_ALPN_SERVER_HS_IV, 0,
+                                  out + rec_off, out_len - rec_off, flight, sizeof flight,
+                                  &flen, &ctype) == 1
+               && ctype == TLS_CONTENT_HANDSHAKE);
+    check_true("alpn: EncryptedExtensions echoes ALPN http/1.1 (oracle byte match)",
+               flen >= sizeof KAT_EE_ALPN
+               && memcmp(flight, KAT_EE_ALPN, sizeof KAT_EE_ALPN) == 0);
+
+    seal_client_finished_with(KAT_ALPN_CLIENT_FINISHED_VD, KAT_ALPN_CLIENT_HS_KEY,
+                              KAT_ALPN_CLIENT_HS_IV, rec, sizeof rec, &rec_len);
+    check_true("alpn: client Finished verified -> DONE",
+               tls_server_hs_read_client_finished(&hs, rec, rec_len) == 1
+               && tls_server_hs_phase(&hs) == TLS_SERVER_HS_DONE);
+    check_true("alpn: app keys released after DONE",
+               tls_server_hs_app_keys(&hs, sk, siv, ck, civ) == 1);
+    check_true("alpn: server app key matches oracle", memcmp(sk, KAT_ALPN_SERVER_AP_KEY, 32) == 0);
+    check_true("alpn: server app iv matches oracle",  memcmp(siv, KAT_ALPN_SERVER_AP_IV, 12) == 0);
+    check_true("alpn: client app key matches oracle", memcmp(ck, KAT_ALPN_CLIENT_AP_KEY, 32) == 0);
+    check_true("alpn: client app iv matches oracle",  memcmp(civ, KAT_ALPN_CLIENT_AP_IV, 12) == 0);
+
+    /* ===== Part B: ALPN offered but no acceptable protocol -> no_application_protocol ===== */
+    {
+        uint8_t ch[sizeof KAT_CH_ALPN];
+        static const uint8_t h11[8] = { 'h','t','t','p','/','1','.','1' };
+        long off;
+        memcpy(ch, KAT_CH_ALPN, sizeof KAT_CH_ALPN);
+        off = find_bytes(ch, sizeof ch, h11, sizeof h11);
+        if (off < 0) {
+            check_true("alpn: (anchor) http/1.1 located in CH", 0);
+        } else {
+            ch[off] ^= 0x20;   /* 'h' -> 'H': same length, no longer the registered id */
+            tls_server_hs_init(&hs);
+            check_true("alpn: ALPN with no supported protocol -> no_application_protocol",
+                       tls_server_hs_read_client_hello(&hs, &cfg, ch, sizeof ch,
+                                                       out, sizeof out, &out_len) == 0
+                       && tls_server_hs_phase(&hs) == TLS_SERVER_HS_FAILED
+                       && tls_server_hs_alert(&hs) == TLS_ALERT_NO_APPLICATION_PROTOCOL);
+        }
+    }
+}
+
 static void test_tls_khannection(void) {
     static uint8_t out[40000];
     static uint8_t app[40000];
@@ -1559,6 +1719,7 @@ int main(void) {
     test_hs_build();
     test_server_handshake();
     test_tls_hrr();
+    test_tls_alpn();
     test_tls_khannection();
     test_tls_khannection_hrr();
 


### PR DESCRIPTION
## What

The pure-C TLS 1.3 server now negotiates **ALPN** (RFC 7301):

- ClientHello offers ALPN including `http/1.1` → the server echoes `http/1.1` in **EncryptedExtensions**.
- ClientHello offers ALPN but **no** protocol we support (e.g. only `h2`) → abort with **`no_application_protocol`** (alert 120), rather than completing the handshake and then failing on a protocol we never agreed to speak.
- ClientHello offers **no** ALPN → unchanged: the EncryptedExtensions block stays empty.

This is the "ALPN if required for HTTP/1.1" item from [Milestone #1](https://github.com/kamrankhan78694/modern-c-web-library/milestone/1), and it makes the server's behavior toward `h2`-only clients correct (clean refusal) instead of a broken HTTP/2 attempt.

## Design

- **Parser** (`handshake.c`): a new `EXT_ALPN` (0x0010) case reads the `ProtocolNameList` in full — bounded and fail-closed exactly like the existing extension cases — and records whether `http/1.1` was offered (exact, case-sensitive match).
- **EE builder** (`handshake.c`): `tls_build_encrypted_extensions` gains an optional `(alpn, alpn_len)`. With `alpn == NULL` it emits the same empty block as before (so the existing flight KATs are unchanged); otherwise one ALPN extension carrying the selected `ProtocolName`.
- **State machine** (`server_handshake.c`): `select_alpn()` offers only `http/1.1`; both the 1-RTT and post-HRR paths negotiate it and thread the choice through `emit_server_flight` into the EE.

## Independent verification

A separate Python oracle (`alpn_oracle.py`) predicts the ALPN EncryptedExtensions and the **entire post-ALPN key schedule** from the ALPN-augmented transcript. `test_tls_parse` gains **13 assertions**:
- the EE echoes `http/1.1` matching the oracle **byte-for-byte**;
- the **application keys** — which depend on the ALPN-augmented transcript — match the oracle;
- a direct EE-builder wire check (empty vs `http/1.1`);
- the negative case: ALPN offered with no supported protocol → `no_application_protocol`.

## Verification matrix

- TLS build: **13/13** ✅
- Default (TLS-off) build: **6/6** ✅, byte-identical (`nm`: no ALPN symbols leak)
- Zero warnings (`-Wall -Wextra -pedantic`) ✅
- **ASan/UBSan** clean over the ALPN parse path and the fuzzer (which now exercises the new parse branch) ✅
- **Negative control**: breaking the parser's `http/1.1` match fails the ALPN accept/echo/app-key assertions, proving they pin real behavior ✅
- **Adversarial gate** (3 lenses: parser memory-safety/termination, negotiation logic, EE-builder bounds/no-regression), each finding adversarially refuted — **no confirmed findings**.

## Follow-up (not this PR)

Optional middlebox-compat ChangeCipherSpec *emission* (§D.4); browser-interop documentation + honest security-labeling review. Known bound unchanged: Ed25519-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)