### PR TITLE
tls: fix post-handshake read-path DoS (empty-record spin + slow-drip)

### DIFF
--- a/src/tls/tls_khannection.c
+++ b/src/tls/tls_khannection.c
@@ -20,6 +20,11 @@
 #define ALERT_LEVEL_WARNING       1
 #define ALERT_LEVEL_FATAL         2
 
+/* Cap on consecutive zero-length application_data records (RFC 8446 §5.1 allows
+ * empty records, but an unbounded run carries no data and only serves to spin a
+ * blocking reader — a well-behaved peer never sends anything close to this). */
+#define TLS_KHANNECTION_MAX_EMPTY_APP_RECORDS 32
+
 /* Append raw bytes to the output buffer. Returns 1 on success, 0 if they do not
  * fit (the caller turns that into a fatal internal_error). */
 static int out_append(uint8_t *out, size_t out_cap, size_t *out_len,
@@ -177,7 +182,18 @@ static tls_khannection_rc_t process_record(tls_khannection_t *c, const uint8_t *
 
         switch (inner_type) {
         case TLS_CONTENT_APPLICATION_DATA:
-            *app_len += plain_len;   /* expose the plaintext to the caller */
+            if (plain_len == 0) {
+                /* Empty application_data record: legal but data-free. Bound a run of
+                 * them so a peer cannot pin a blocking reader with an endless stream
+                 * of empties (they decrypt fine and advance recv_seq but yield no
+                 * app bytes, so the reader would otherwise loop forever). */
+                if (++c->empty_app_records > TLS_KHANNECTION_MAX_EMPTY_APP_RECORDS) {
+                    return conn_fail(c, out, out_cap, out_len, TLS_ALERT_UNEXPECTED_MESSAGE);
+                }
+                return TLS_KHANNECTION_RC_OK;
+            }
+            c->empty_app_records = 0;   /* real data resets the run */
+            *app_len += plain_len;      /* expose the plaintext to the caller */
             return TLS_KHANNECTION_RC_OK;
         case TLS_CONTENT_ALERT:
             /* The alert body was written at app+*app_len; consume it there without

--- a/src/tls/tls_khannection.h
+++ b/src/tls/tls_khannection.h
@@ -90,6 +90,13 @@ typedef struct {
     uint8_t recv_key[32], recv_iv[12];
     uint64_t send_seq, recv_seq;
     int keys_ready;
+
+    /* Consecutive zero-length application_data records received while ESTABLISHED.
+     * Empty records are legal (RFC 8446 §5.1, a traffic-analysis countermeasure) but
+     * a flood of them yields no application data and would otherwise spin the caller;
+     * too many in a row without real data is treated as abuse. Reset by any record
+     * that carries application bytes. */
+    uint32_t empty_app_records;
 } tls_khannection_t;
 
 /*

--- a/src/tls/tls_transport.c
+++ b/src/tls/tls_transport.c
@@ -23,6 +23,19 @@
 #define TLS_SEND_FLAGS 0
 #endif
 
+/* Monotonic seconds for the wall-clock deadlines below — immune to wall-clock
+ * (NTP) steps that an attacker or the system could otherwise use to slip past or
+ * prematurely trip a deadline. Falls back to time() if CLOCK_MONOTONIC is absent. */
+static time_t tls_monotonic_seconds(void) {
+#if defined(CLOCK_MONOTONIC)
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        return ts.tv_sec;
+    }
+#endif
+    return time(NULL);
+}
+
 /* Tear down: wipe the engine's key material AND the decrypted application
  * plaintext buffered here (the strictly-more-sensitive secret — cookies, auth
  * headers, request bodies), so neither lingers in the freed struct / a core dump.
@@ -118,10 +131,12 @@ int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *
     t->app_off = 0;
     t->app_len = 0;
     t->eof = 0;
-    start = time(NULL);
+    /* Reuse the handshake budget to bound each post-handshake read too. */
+    t->read_timeout_seconds = timeout_seconds;
+    start = tls_monotonic_seconds();
 
     while (tls_khannection_state(&t->conn) == TLS_KHANNECTION_HANDSHAKE) {
-        if (timeout_seconds > 0 && (long)(time(NULL) - start) >= (long)timeout_seconds) {
+        if (timeout_seconds > 0 && (long)(tls_monotonic_seconds() - start) >= (long)timeout_seconds) {
             transport_wipe(t);   /* slow-loris: handshake exceeded its wall-clock budget */
             return -1;
         }
@@ -151,18 +166,31 @@ int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *
 
 ssize_t tls_transport_read(tls_transport_t *t, void *buf, size_t len) {
     size_t avail, n;
+    time_t start;
     if (t == NULL || buf == NULL) {
         return -1;
     }
     if (len == 0) {
         return 0;
     }
+    start = tls_monotonic_seconds();
     /* Serve from the buffer; pump the socket until some application data arrives or
      * the stream ends. */
     while (t->app_off == t->app_len) {
         int r;
         if (t->eof || tls_khannection_state(&t->conn) == TLS_KHANNECTION_CLOSED) {
             return 0;
+        }
+        /* Aggregate wall-clock guard: a peer that keeps the socket fed but never
+         * completes a record (slow-drip) — or floods sub-limit empty records — could
+         * otherwise spin this pump loop indefinitely, never returning control to the
+         * HTTP layer that enforces the whole-request deadline. Bound each call so
+         * that deadline is always reached. Fail closed (wipe + -1); conn_read maps a
+         * -1 to a clean end-of-stream, so the connection is dropped. */
+        if (t->read_timeout_seconds > 0 &&
+            (long)(tls_monotonic_seconds() - start) >= (long)t->read_timeout_seconds) {
+            transport_wipe(t);
+            return -1;
         }
         r = transport_pump(t);
         if (r < 0) {

--- a/src/tls/tls_transport.c
+++ b/src/tls/tls_transport.c
@@ -181,12 +181,15 @@ ssize_t tls_transport_read(tls_transport_t *t, void *buf, size_t len) {
         if (t->eof || tls_khannection_state(&t->conn) == TLS_KHANNECTION_CLOSED) {
             return 0;
         }
-        /* Aggregate wall-clock guard: a peer that keeps the socket fed but never
-         * completes a record (slow-drip) — or floods sub-limit empty records — could
-         * otherwise spin this pump loop indefinitely, never returning control to the
-         * HTTP layer that enforces the whole-request deadline. Bound each call so
-         * that deadline is always reached. Fail closed (wipe + -1); conn_read maps a
-         * -1 to a clean end-of-stream, so the connection is dropped. */
+        /* Aggregate wall-clock guard, checked between pumps: a peer that keeps the
+         * socket fed but never completes a record (slow-drip) — or floods sub-limit
+         * empty records — would otherwise spin this loop, never returning control to
+         * the HTTP layer that enforces the whole-request deadline. This bounds the
+         * *fed-socket* case. The complementary case — the peer going silent so recv()
+         * blocks inside transport_pump — is bounded by SO_RCVTIMEO, which the server
+         * sets no larger than this budget (http_server caps it at request_timeout),
+         * so recv() returns and this check runs within the budget. Fail closed
+         * (wipe + -1); conn_read maps the -1 to a clean end-of-stream. */
         if (t->read_timeout_seconds > 0 &&
             (long)(tls_monotonic_seconds() - start) >= (long)t->read_timeout_seconds) {
             transport_wipe(t);

--- a/src/tls/tls_transport.h
+++ b/src/tls/tls_transport.h
@@ -63,6 +63,11 @@ typedef struct {
     size_t  app_off;
     size_t  app_len;
     int     eof;   /* peer closed (close_notify or TCP EOF); reads return 0 */
+    /* Wall-clock budget (seconds, 0 = none) bounding a single tls_transport_read
+     * call, so a slow-drip or empty-record peer cannot pin the pump loop between the
+     * HTTP layer's own request-deadline checks. Set from tls_transport_accept's
+     * timeout. */
+    int     read_timeout_seconds;
 } tls_transport_t;
 
 /*

--- a/src/tls/tls_transport.h
+++ b/src/tls/tls_transport.h
@@ -82,6 +82,9 @@ typedef struct {
  * limit). Per-recv socket timeouts (SO_RCVTIMEO) only bound a single read, so a
  * slow-drip client dribbling a byte at a time could otherwise pin this call
  * indefinitely; this aggregate deadline is the slow-loris guard for the handshake.
+ * It is ALSO retained (see tls_transport_t.read_timeout_seconds) as the per-call
+ * budget for each subsequent tls_transport_read, applying the same guard to the
+ * post-handshake read path.
  */
 int tls_transport_accept(tls_transport_t *t, int fd, const tls_server_config_t *cfg,
                          int timeout_seconds);

--- a/tests/test_tls_parse.c
+++ b/tests/test_tls_parse.c
@@ -1703,6 +1703,39 @@ static void test_tls_khannection_hrr(void) {
     }
 }
 
+/* Audit finding #1 regression: a flood of zero-length application_data records
+ * (legal per RFC 8446 §5.1 but data-free) must be rejected once it exceeds the
+ * engine's consecutive-empty bound, so a blocking reader cannot be pinned. A single
+ * non-empty record in between resets the run. */
+static void test_tls_khannection_empty_flood(void) {
+    static uint8_t out[2048], app[256];
+    tls_server_config_t cfg;
+    tls_khannection_t c;
+    size_t ol = 0, al = 0;
+    tls_khannection_rc_t rc = TLS_KHANNECTION_RC_OK;
+    int i, rejected = 0;
+
+    conn_set_cfg(&cfg);
+    conn_establish(&c, &cfg);   /* inits c internally; leaves recv_seq at 0 */
+    check_true("conn/empty: established", tls_khannection_state(&c) == TLS_KHANNECTION_ESTABLISHED);
+
+    for (i = 0; i < 128; i++) {
+        uint8_t rec[64];
+        size_t rl = 0;
+        if (!tls_record_seal(KAT_CLIENT_AP_KEY, KAT_CLIENT_AP_IV, (uint64_t)i,
+                             TLS_CONTENT_APPLICATION_DATA, NULL, 0, 0,
+                             rec, sizeof rec, &rl)) {
+            break;   /* seal of an empty record should always succeed; guard anyway */
+        }
+        rc = tls_khannection_recv(&c, rec, rl, out, sizeof out, &ol, app, sizeof app, &al);
+        if (rc == TLS_KHANNECTION_RC_ERROR) { rejected = 1; break; }
+        if (al != 0) { break; }   /* an empty record must never surface app bytes */
+    }
+    check_true("conn/empty: an empty-record flood is rejected (no reader spin)",
+               rejected && tls_khannection_state(&c) == TLS_KHANNECTION_FAILED);
+    check_true("conn/empty: rejected within the bound (not unbounded)", i <= 40);
+}
+
 int main(void) {
 #ifndef WEBLIB_TLS
     printf("FAIL: test_tls_parse built without WEBLIB_TLS defined\n");
@@ -1722,6 +1755,7 @@ int main(void) {
     test_tls_alpn();
     test_tls_khannection();
     test_tls_khannection_hrr();
+    test_tls_khannection_empty_flood();
 
     if (g_failures == 0) {
         printf("All TLS parse tests passed.\n");

--- a/tests/test_tls_transport.c
+++ b/tests/test_tls_transport.c
@@ -163,6 +163,29 @@ static int read_record(int fd, uint8_t *buf, size_t cap) {
     return (int)(TLS_RECORD_HEADER_LEN + body);
 }
 
+/* Drive the client half of the KAT handshake to completion (CH, read flight, CCS,
+ * Finished). Returns 0 once the server is established, -1 on any socket error. */
+static int client_do_handshake(int cfd) {
+    uint8_t ch[TLS_RECORD_HEADER_LEN + sizeof KAT_CH];
+    uint8_t sh[600], flight[2048], rec[128], finmsg[4 + 32];
+    static const uint8_t ccs[6] = { 0x14, 0x03, 0x03, 0x00, 0x01, 0x01 };
+    size_t rl = 0;
+
+    ch[0] = TLS_CONTENT_HANDSHAKE; ch[1] = 0x03; ch[2] = 0x03;
+    ch[3] = (uint8_t)((sizeof KAT_CH) >> 8); ch[4] = (uint8_t)(sizeof KAT_CH);
+    memcpy(ch + TLS_RECORD_HEADER_LEN, KAT_CH, sizeof KAT_CH);
+    if (write_all_c(cfd, ch, sizeof ch) != 0) return -1;
+    if (read_record(cfd, sh, sizeof sh) <= 0) return -1;
+    if (read_record(cfd, flight, sizeof flight) <= 0) return -1;
+    if (write_all_c(cfd, ccs, sizeof ccs) != 0) return -1;
+    finmsg[0] = TLS_HS_FINISHED; finmsg[1] = 0x00; finmsg[2] = 0x00; finmsg[3] = 0x20;
+    memcpy(finmsg + 4, KAT_CLIENT_FINISHED_VD, 32);
+    if (!tls_record_seal(KAT_CLIENT_HS_KEY, KAT_CLIENT_HS_IV, 0, TLS_CONTENT_HANDSHAKE,
+                         finmsg, sizeof finmsg, 0, rec, sizeof rec, &rl)) return -1;
+    if (write_all_c(cfd, rec, rl) != 0) return -1;
+    return 0;
+}
+
 /* ---- server side, run on its own thread ---- */
 typedef struct {
     int fd;
@@ -485,6 +508,90 @@ static void test_tls_transport_handshake_timeout(void) {
                res.accept_rc != 0);
     close(sv[0]);
 }
+
+/* Server that establishes, then does a single read with a 1-second aggregate read
+ * budget (from the accept timeout). Records the read's return value. */
+typedef struct { int fd; int accept_rc; long read_rc; } srv_read_t;
+
+static void *server_thread_read_timeout(void *arg) {
+    static tls_transport_t t;
+    srv_read_t *r = (srv_read_t *)arg;
+    tls_server_config_t cfg;
+    struct timeval tv;
+    char buf[64];
+
+    memset(&cfg, 0, sizeof cfg);
+    cfg.cert_der = KAT_CERT;
+    cfg.cert_len = sizeof KAT_CERT;
+    cfg.ed25519_seed = KAT_ED_SEED;
+    cfg.ed25519_pub = KAT_ED_PUB;
+    cfg.server_eph_sk = KAT_SERVER_EPH;
+    cfg.server_random = KAT_SERVER_RND;
+    /* Per-recv timeout well above the drip interval so recv returns between drips
+     * (each drip counts as progress); the 1-second AGGREGATE read deadline must fire. */
+    tv.tv_sec = 3;
+    tv.tv_usec = 0;
+    setsockopt(r->fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    r->accept_rc = tls_transport_accept(&t, r->fd, &cfg, 1);   /* handshake+read budget = 1s */
+    r->read_rc = 1;   /* sentinel: read not reached / returned >0 */
+    if (r->accept_rc == 0) {
+        r->read_rc = (long)tls_transport_read(&t, buf, sizeof buf);
+    }
+    tls_transport_close(&t);
+    return NULL;
+}
+
+/*
+ * Post-handshake slow-loris guard (audit #2): after a completed handshake, a peer
+ * that opens an application record with a large declared body and then dribbles
+ * bytes (never completing it) must be cut off by tls_transport_read's aggregate
+ * wall-clock deadline, not pin the worker thread forever.
+ */
+static void test_tls_transport_read_timeout(void) {
+    int sv[2];
+    pthread_t tid;
+    srv_read_t res;
+    int cfd, i;
+    /* Application record header declaring a 256-byte body we will never finish. */
+    static const uint8_t apphdr[5] = { 0x17, 0x03, 0x03, 0x01, 0x00 };
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+        check_true("readloris: socketpair created", 0);
+        return;
+    }
+    res.fd = sv[0];
+    res.accept_rc = 999;
+    res.read_rc = 1;
+    cfd = sv[1];
+    if (pthread_create(&tid, NULL, server_thread_read_timeout, &res) != 0) {
+        check_true("readloris: server thread started", 0);
+        close(sv[0]);
+        close(sv[1]);
+        return;
+    }
+    if (client_do_handshake(cfd) != 0) {
+        check_true("readloris: client completed the handshake", 0);
+        close(cfd);
+        pthread_join(tid, NULL);
+        close(sv[0]);
+        return;
+    }
+    /* Now dribble an application record that never completes. */
+    write_all_c(cfd, apphdr, sizeof apphdr);
+    for (i = 0; i < 20; i++) {
+        uint8_t b = (uint8_t)i;
+        if (write_all_c(cfd, &b, 1) != 0) {
+            break;   /* server tore the connection down when its read deadline fired */
+        }
+        usleep(150000);   /* 150 ms between drips — the record never completes */
+    }
+    close(cfd);
+    pthread_join(tid, NULL);
+    check_true("readloris: handshake still completed", res.accept_rc == 0);
+    check_true("readloris: dribbled post-handshake read aborted by the wall-clock deadline",
+               res.read_rc <= 0);
+    close(sv[0]);
+}
 #endif /* WEBLIB_TLS */
 
 int main(void) {
@@ -496,6 +603,7 @@ int main(void) {
     test_tls_transport_halfclose();
     test_tls_transport_wipe();
     test_tls_transport_handshake_timeout();
+    test_tls_transport_read_timeout();
     if (g_failures == 0) {
         printf("All TLS transport tests passed.\n");
     }

--- a/tests/test_tls_transport.c
+++ b/tests/test_tls_transport.c
@@ -588,8 +588,12 @@ static void test_tls_transport_read_timeout(void) {
     close(cfd);
     pthread_join(tid, NULL);
     check_true("readloris: handshake still completed", res.accept_rc == 0);
+    /* Strictly -1 (deadline/fail-closed), not 0: a 0 would mean a clean EOF, which
+     * here could only come from the client's post-loop close and would NOT prove the
+     * deadline fired. The 1s read budget expires (~1s) well before the client stops
+     * dribbling (~3s), so the read must return -1. */
     check_true("readloris: dribbled post-handshake read aborted by the wall-clock deadline",
-               res.read_rc <= 0);
+               res.read_rc < 0);
     close(sv[0]);
 }
 #endif /* WEBLIB_TLS */


### PR DESCRIPTION
## What

Fixes **two HIGH-severity DoS findings** from the whole-stack security audit, both on the **post-handshake TLS read path** (they share one root cause: the ESTABLISHED read loop had neither the wall-clock deadline the *handshake* path already enforces, nor a bound on no-progress records).

| # | Vector |
|---|--------|
| 1 | **Empty-record flood.** A zero-length `application_data` record decrypts to 0 app bytes (legal, RFC 8446 §5.1) but yields nothing. The engine returned `RC_OK` and `transport_pump` reported "progress", so `tls_transport_read`'s `while (app_off == app_len)` loop spun forever — 100% CPU on a fast stream, or a cheaply-pinned thread on a trickle. |
| 2 | **Slow-drip.** A peer dribbling record bytes just under `SO_RCVTIMEO` but never completing a record kept `transport_pump` returning "progress", so `tls_transport_read` never returned to the HTTP layer where the whole-request deadline (checked only between `conn_read` calls) lives. |

Either way a peer that completed the handshake could pin a worker thread and, across the bounded pool, deny service — evading the slow-loris guard the code enforces everywhere else (the handshake loop and the plaintext request loop both already bound this).

## Fix (two layers)

- **Engine** (`tls_khannection.c`): bound consecutive zero-length `application_data` records — `TLS_KHANNECTION_MAX_EMPTY_APP_RECORDS = 32`, reset by any record carrying real data; over the bound → fail closed. Kills the CPU spin at the protocol layer while still allowing the occasional empty record the RFC permits.
- **Transport** (`tls_transport.c`): give `tls_transport_read` the same aggregate wall-clock budget `tls_transport_accept` already has (stored at accept from the request timeout), checked each pump iteration → fail closed on expiry. `conn_read` maps the `-1` to a clean EOF, dropping the connection. Both deadlines now use a **monotonic** clock (immune to NTP steps), matching `http_server`'s request-deadline choice.

Why the two layers are both needed and non-overlapping: the empty-record bound kills the fast CPU spin instantly (the deadline only bounds its total time); the deadline handles the slow-drip of *partial* records (which are never "empty records", so the counter never trips). An attacker can't evade by alternating a real byte with empties — a real byte makes `app_len > 0`, so `tls_transport_read` *returns* to the caller (HTTP-layer progress) instead of spinning.

## Regression tests

- **Engine** (`test_tls_parse.c`): an empty-record flood is rejected within the bound — deterministic.
- **Transport** (`test_tls_transport.c`): a post-handshake slow-drip over a real socketpair is aborted by the read deadline (~1s), mirroring the existing handshake slow-loris test.

## Verification

- TLS build **13/13** ✅ · default (TLS-off) **6/6** ✅, byte-identical (`nm`: no new symbols leak)
- Zero warnings ✅ · **ASan/UBSan** clean on `test_tls_parse`, `test_tls_transport`, `test_tls_fuzz` ✅
- **Adversarial gate** (3 lenses: closes-both-vectors, no-regression, correctness) — **no confirmed findings**.

Remaining audit items (separate PRs): crypto leaf-scratch secret wiping (low), a stale `no HRR` doc comment (low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)