### PR TITLE
tls: resolve two low-severity audit findings (scratch wipe + doc)

### DIFF
--- a/src/tls/field25519.c
+++ b/src/tls/field25519.c
@@ -69,6 +69,12 @@ void pack25519(uint8_t *o, const gf n) {
         o[2 * i]     = (uint8_t)(t[i] & 0xff);
         o[2 * i + 1] = (uint8_t)(t[i] >> 8);
     }
+    /* `t`/`m` hold the fully-reduced field element being packed — for X25519 that is
+     * the ECDHE shared secret in limb form. Wipe them so the secret does not survive
+     * in this leaf's stack frame after the caller (which wipes its own copy and `o`)
+     * returns. Called ~once per operation, so the cost is negligible. */
+    secure_zero(m, sizeof(m));
+    secure_zero(t, sizeof(t));
 }
 
 void unpack25519(gf o, const uint8_t *n) {
@@ -112,6 +118,13 @@ void mul25519(gf o, const gf a, const gf b) {
     }
     car25519(o);
     car25519(o);
+    /* Every field and curve-point operation bottoms out here, so `t` holds products
+     * of secret operands (the X25519 scalar/coordinate, the Ed25519 nonce). Wipe the
+     * accumulator so no secret-derived limb product survives in this leaf's frame
+     * once the operation returns. The output `o` is the caller's and is wiped by the
+     * caller when it is secret. The extra zeroing is a small fixed cost dwarfed by
+     * the 16x16 multiply this function already performs. */
+    secure_zero(t, sizeof(t));
 }
 
 void sq25519(gf o, const gf a) {

--- a/src/tls/tls_khannection.h
+++ b/src/tls/tls_khannection.h
@@ -24,8 +24,10 @@
  *
  * SCOPE / LIMITATIONS (documented, none silent):
  *   - Server side only, one profile (TLS_CHACHA20_POLY1305_SHA256 + X25519 +
- *     Ed25519), full 1-RTT handshake (inherits server_handshake.h's limits: no HRR,
- *     no client auth).
+ *     Ed25519), 1-RTT handshake plus a single HelloRetryRequest when the client
+ *     offers X25519 without a key_share — the engine routes the second ClientHello
+ *     back through the handshake and drops an interleaved middlebox CCS. Inherits
+ *     server_handshake.h's remaining limits (no client auth).
  *   - The ClientHello must arrive within a single record (handshake-message
  *     reassembly across records is not implemented); real curl/OpenSSL clients do
  *     this. Other handshake messages the engine consumes (the client Finished) are


### PR DESCRIPTION
Closes the two **low-severity** findings from the whole-stack audit (the two HIGH DoS findings were fixed in #126).

## #3 — secret-hygiene: un-wiped field-arithmetic scratch

The Curve25519/Ed25519 field leaves left secret-derived limbs on the stack: `x25519()` and `ed25519_sign()` wipe their own locals, but the callee frames that hold the same value did not. Fix (both in `field25519.c`):
- **`pack25519`** — `secure_zero` its `m`/`t`; they hold the fully-reduced field element, which for X25519 is the **ECDHE shared secret** in limb form.
- **`mul25519`** — `secure_zero` its 31-limb accumulator; every field and curve-point operation bottoms out here, so it holds products of the secret scalar/coordinate and the Ed25519 nonce.

Behaviour-preserving — the X25519/Ed25519 **RFC known-answer tests are unchanged** — and the extra zeroing is dwarfed by the arithmetic itself (a whole handshake's field ops add well under a millisecond). The caller still owns and wipes the final output; this eliminates the shared-secret / nonce **product and packed** residue the audit located in the arithmetic leaves. (Defense-in-depth: exploiting the old state required a separate memory-disclosure primitive.)

## #4 — doc drift

`tls_khannection.h`'s SCOPE said the engine offers a *"full 1-RTT handshake (… no HRR …)"* — stale since HelloRetryRequest landed. Corrected to state HRR **is** supported (single retry, with CH2 re-routing and interleaved-CCS drop), keeping the genuine remaining limit (no client auth).

## Verification

- TLS **13/13**, default (TLS-off) **6/6** byte-identical, zero warnings.
- **ASan/UBSan** clean on the crypto + parse tests; the X25519/Ed25519 KATs confirm no behavior change.

This clears the audit backlog: no planned work and no unresolved review concerns remain for the TLS milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)