### PR TITLE
ci: make CI actually run the tests it reports as passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: cmake --build build-tls --parallel
 
       - name: Run full test suite (TLS on)
-        run: cd build-tls && ctest --output-on-failure --timeout 300
+        run: cd build-tls && ctest --output-on-failure --timeout 300 --no-tests=error
 
       - name: Configure (ASan + UBSan)
         run: |
@@ -159,12 +159,15 @@ jobs:
 
       # Only the TLS suites: the sanitizer signal we care about here is in the
       # crypto/parser/state-machine code.  halt_on_error makes UB fatal instead
-      # of merely logged, so a regression fails the job.
+      # of merely logged, so a regression fails the job.  --no-tests=error is
+      # essential with -R: ctest exits 0 when a filter matches nothing, so a
+      # rename or a dropped add_test() would silently stop running the suites
+      # while the job stayed green — the exact failure this whole job removes.
       - name: Run TLS suites under ASan/UBSan
         env:
           ASAN_OPTIONS: detect_leaks=0
           UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
-        run: cd build-tls-san && ctest --output-on-failure --timeout 300 -R '^Tls'
+        run: cd build-tls-san && ctest --output-on-failure --timeout 300 --no-tests=error -R '^Tls'
 
   # macOS cross-platform check — runs only on pull requests to avoid
   # burning expensive macOS minutes on every push to main.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,80 @@ jobs:
       - name: Run tests
         run: cd build && ctest --output-on-failure --timeout 120
 
+  # Experimental pure-C TLS 1.3 layer.  TLS is OFF by default, so the jobs
+  # above build and test the library with NONE of src/tls/ compiled — without
+  # this job the ~5,500 lines of hand-written crypto and the handshake state
+  # machine (7 ctest suites, incl. 86 crypto KATs and a real `openssl s_client`
+  # interop round-trip) would never run in CI at all.
+  #
+  # Two configurations, because they catch different failures:
+  #   1. Release-ish build + full suite — correctness and real-client interop.
+  #   2. ASan/UBSan build — memory safety and UB in hand-written crypto, which
+  #      the plain build cannot detect.  This mirrors the sanitizer gate applied
+  #      manually to every TLS change; running it here makes it enforceable.
+  #
+  # WEBLIB_TLS_TEST_HOOKS exposes a deterministic-RNG seam used only by
+  # TlsHttpTests; it is OFF in any production build.
+  tls-check:
+    name: TLS Build & Test (experimental layer)
+    needs: primary-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q cmake clang openssl
+
+      # openssl must be real OpenSSL with a TLS 1.3-capable s_client, otherwise
+      # the interop test self-skips rather than failing.  Log it so a silent
+      # skip is visible in the run rather than looking like a pass.
+      - name: Show openssl version (interop test prerequisite)
+        run: openssl version
+
+      - name: Configure (TLS on)
+        run: |
+          mkdir -p build-tls && cd build-tls
+          cmake .. \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DWEBLIB_ENABLE_TLS=ON \
+            -DWEBLIB_TLS_TEST_HOOKS=ON \
+            -DCMAKE_C_FLAGS="-Wall -Wextra -pedantic"
+
+      - name: Build (TLS on)
+        run: cmake --build build-tls --parallel
+
+      - name: Run full test suite (TLS on)
+        run: cd build-tls && ctest --output-on-failure --timeout 300
+
+      - name: Configure (ASan + UBSan)
+        run: |
+          mkdir -p build-tls-san && cd build-tls-san
+          cmake .. \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DWEBLIB_ENABLE_TLS=ON \
+            -DWEBLIB_TLS_TEST_HOOKS=ON \
+            -DCMAKE_C_FLAGS="-Wall -Wextra -pedantic -fsanitize=address,undefined -fno-omit-frame-pointer -g"
+
+      - name: Build (ASan + UBSan)
+        run: cmake --build build-tls-san --parallel
+
+      # Only the TLS suites: the sanitizer signal we care about here is in the
+      # crypto/parser/state-machine code.  halt_on_error makes UB fatal instead
+      # of merely logged, so a regression fails the job.
+      - name: Run TLS suites under ASan/UBSan
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: cd build-tls-san && ctest --output-on-failure --timeout 300 -R '^Tls'
+
   # macOS cross-platform check — runs only on pull requests to avoid
   # burning expensive macOS minutes on every push to main.
   macos-check:

--- a/tests/test_async_websocket.c
+++ b/tests/test_async_websocket.c
@@ -3,17 +3,33 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
+/*
+ * Assertion that survives NDEBUG.
+ *
+ * Bare CHECK() compiles to nothing when NDEBUG is defined, which CMake does for
+ * the Release / RelWithDebInfo configurations — and RelWithDebInfo is exactly what
+ * CI builds. This suite previously used CHECK() throughout, so in CI it passed
+ * unconditionally: it would have reported success even if every invariant below
+ * were false. CHECK() is always evaluated and makes main() return non-zero.
+ */
+static int g_failures = 0;
+#define CHECK(cond)                                                       \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("FAIL: %s (%s:%d)\n", #cond, __FILE__, __LINE__);      \
+            g_failures++;                                                 \
+        }                                                                 \
+    } while (0)
 
 static int test_create_destroy(void) {
     printf("Testing async_ws_manager (create/destroy)... ");
     
     event_loop_t *loop = event_loop_create();
-    assert(loop != NULL);
+    CHECK(loop != NULL);
     
     async_ws_manager_t *mgr = async_ws_manager_create(loop);
-    assert(mgr != NULL);
-    assert(async_ws_manager_count(mgr) == 0);
+    CHECK(mgr != NULL);
+    CHECK(async_ws_manager_count(mgr) == 0);
     
     async_ws_manager_destroy(mgr);
     event_loop_destroy(loop);
@@ -28,15 +44,15 @@ static int test_null_handling(void) {
     /* NULL event loop */
     async_ws_manager_t *mgr = async_ws_manager_create(NULL);
     (void)mgr;
-    assert(mgr == NULL);
+    CHECK(mgr == NULL);
     
     /* NULL manager operations */
     async_ws_manager_destroy(NULL);
     async_ws_manager_set_callbacks(NULL, NULL, NULL, NULL);
-    assert(async_ws_manager_add(NULL, NULL) == -1);
-    assert(async_ws_manager_remove(NULL, NULL) == -1);
-    assert(async_ws_send(NULL, NULL, WS_MESSAGE_TEXT, "test", 4) == -1);
-    assert(async_ws_manager_count(NULL) == 0);
+    CHECK(async_ws_manager_add(NULL, NULL) == -1);
+    CHECK(async_ws_manager_remove(NULL, NULL) == -1);
+    CHECK(async_ws_send(NULL, NULL, WS_MESSAGE_TEXT, "test", 4) == -1);
+    CHECK(async_ws_manager_count(NULL) == 0);
     
     printf("PASSED\n");
     return 0;
@@ -58,10 +74,10 @@ static int test_set_callbacks(void) {
     printf("Testing async_ws_manager (set callbacks)... ");
     
     event_loop_t *loop = event_loop_create();
-    assert(loop != NULL);
+    CHECK(loop != NULL);
     
     async_ws_manager_t *mgr = async_ws_manager_create(loop);
-    assert(mgr != NULL);
+    CHECK(mgr != NULL);
     
     /* Should not crash */
     async_ws_manager_set_callbacks(mgr, dummy_message_cb, dummy_close_cb, dummy_error_cb);
@@ -78,18 +94,18 @@ static int test_add_remove_invalid(void) {
     printf("Testing async_ws_manager (add/remove invalid)... ");
     
     event_loop_t *loop = event_loop_create();
-    assert(loop != NULL);
+    CHECK(loop != NULL);
     
     async_ws_manager_t *mgr = async_ws_manager_create(loop);
-    assert(mgr != NULL);
+    CHECK(mgr != NULL);
     
     /* Add NULL connection should fail */
-    assert(async_ws_manager_add(mgr, NULL) == -1);
+    CHECK(async_ws_manager_add(mgr, NULL) == -1);
     
     /* Remove non-existent connection should fail */
-    assert(async_ws_manager_remove(mgr, (websocket_connection_t *)0xDEADBEEF) == -1);
+    CHECK(async_ws_manager_remove(mgr, (websocket_connection_t *)0xDEADBEEF) == -1);
     
-    assert(async_ws_manager_count(mgr) == 0);
+    CHECK(async_ws_manager_count(mgr) == 0);
     
     async_ws_manager_destroy(mgr);
     event_loop_destroy(loop);
@@ -102,18 +118,18 @@ static int test_send_invalid(void) {
     printf("Testing async_ws_manager (send invalid)... ");
     
     event_loop_t *loop = event_loop_create();
-    assert(loop != NULL);
+    CHECK(loop != NULL);
     
     async_ws_manager_t *mgr = async_ws_manager_create(loop);
-    assert(mgr != NULL);
+    CHECK(mgr != NULL);
     
     /* Send with NULL data should fail */
-    assert(async_ws_send(mgr, (websocket_connection_t *)0xDEADBEEF, WS_MESSAGE_TEXT, NULL, 10) == -1);
+    CHECK(async_ws_send(mgr, (websocket_connection_t *)0xDEADBEEF, WS_MESSAGE_TEXT, NULL, 10) == -1);
     
     /* Send with NULL connection should fail */
     const char *msg = "test";
     (void)msg;
-    assert(async_ws_send(mgr, NULL, WS_MESSAGE_TEXT, msg, 4) == -1);
+    CHECK(async_ws_send(mgr, NULL, WS_MESSAGE_TEXT, msg, 4) == -1);
     
     async_ws_manager_destroy(mgr);
     event_loop_destroy(loop);
@@ -136,5 +152,5 @@ int main(void) {
     printf("Async WebSocket Tests: %d failed\n", failed);
     printf("===================================\n\n");
     
-    return failed;
+    return failed + g_failures;
 }

--- a/tests/test_async_websocket.c
+++ b/tests/test_async_websocket.c
@@ -4,13 +4,22 @@
 #include <stdlib.h>
 #include <string.h>
 /*
- * Assertion that survives NDEBUG.
+ * Assertions that survive NDEBUG.
  *
- * Bare CHECK() compiles to nothing when NDEBUG is defined, which CMake does for
- * the Release / RelWithDebInfo configurations — and RelWithDebInfo is exactly what
- * CI builds. This suite previously used CHECK() throughout, so in CI it passed
- * unconditionally: it would have reported success even if every invariant below
- * were false. CHECK() is always evaluated and makes main() return non-zero.
+ * This suite previously used the standard assert(), which the C library compiles
+ * to nothing when NDEBUG is defined — and CMake defines NDEBUG for the Release /
+ * RelWithDebInfo configurations, the latter being exactly what CI builds. Every
+ * assertion here was therefore removed by the preprocessor in CI, so the suite
+ * passed unconditionally: it would have reported success even if every invariant
+ * below were false.
+ *
+ * CHECK()   — always evaluated; records a failure and keeps going, so one broken
+ *             invariant does not hide the others.
+ * REQUIRE() — for preconditions that later statements depend on (chiefly non-NULL
+ *             pointers). Unlike CHECK() it returns immediately, because assert()
+ *             used to abort here: continuing past a failed pointer check would
+ *             dereference NULL, which is undefined behaviour rather than a
+ *             reported test failure.
  */
 static int g_failures = 0;
 #define CHECK(cond)                                                       \
@@ -20,15 +29,22 @@ static int g_failures = 0;
             g_failures++;                                                 \
         }                                                                 \
     } while (0)
+#define REQUIRE(cond)                                                     \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("FAIL (fatal): %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
 
 static int test_create_destroy(void) {
     printf("Testing async_ws_manager (create/destroy)... ");
     
     event_loop_t *loop = event_loop_create();
-    CHECK(loop != NULL);
+    REQUIRE(loop != NULL);
     
     async_ws_manager_t *mgr = async_ws_manager_create(loop);
-    CHECK(mgr != NULL);
+    REQUIRE(mgr != NULL);
     CHECK(async_ws_manager_count(mgr) == 0);
     
     async_ws_manager_destroy(mgr);
@@ -74,10 +90,10 @@ static int test_set_callbacks(void) {
     printf("Testing async_ws_manager (set callbacks)... ");
     
     event_loop_t *loop = event_loop_create();
-    CHECK(loop != NULL);
+    REQUIRE(loop != NULL);
     
     async_ws_manager_t *mgr = async_ws_manager_create(loop);
-    CHECK(mgr != NULL);
+    REQUIRE(mgr != NULL);
     
     /* Should not crash */
     async_ws_manager_set_callbacks(mgr, dummy_message_cb, dummy_close_cb, dummy_error_cb);
@@ -94,10 +110,10 @@ static int test_add_remove_invalid(void) {
     printf("Testing async_ws_manager (add/remove invalid)... ");
     
     event_loop_t *loop = event_loop_create();
-    CHECK(loop != NULL);
+    REQUIRE(loop != NULL);
     
     async_ws_manager_t *mgr = async_ws_manager_create(loop);
-    CHECK(mgr != NULL);
+    REQUIRE(mgr != NULL);
     
     /* Add NULL connection should fail */
     CHECK(async_ws_manager_add(mgr, NULL) == -1);
@@ -118,10 +134,10 @@ static int test_send_invalid(void) {
     printf("Testing async_ws_manager (send invalid)... ");
     
     event_loop_t *loop = event_loop_create();
-    CHECK(loop != NULL);
+    REQUIRE(loop != NULL);
     
     async_ws_manager_t *mgr = async_ws_manager_create(loop);
-    CHECK(mgr != NULL);
+    REQUIRE(mgr != NULL);
     
     /* Send with NULL data should fail */
     CHECK(async_ws_send(mgr, (websocket_connection_t *)0xDEADBEEF, WS_MESSAGE_TEXT, NULL, 10) == -1);
@@ -149,7 +165,7 @@ int main(void) {
     failed += test_send_invalid();
     
     printf("\n===================================\n");
-    printf("Async WebSocket Tests: %d failed\n", failed);
+    printf("Async WebSocket Tests: %d failed\n", failed + g_failures);
     printf("===================================\n\n");
     
     return failed + g_failures;

--- a/tests/test_kamran_header.c
+++ b/tests/test_kamran_header.c
@@ -3,13 +3,22 @@
 #include <string.h>
 
 /*
- * Assertion that survives NDEBUG.
+ * Assertions that survive NDEBUG.
  *
- * Bare CHECK() compiles to nothing when NDEBUG is defined, which CMake does for
- * the Release / RelWithDebInfo configurations — and RelWithDebInfo is exactly what
- * CI builds. This suite previously used CHECK() throughout, so in CI it passed
- * unconditionally: it would have reported success even if every invariant below
- * were false. CHECK() is always evaluated and makes main() return non-zero.
+ * This suite previously used the standard assert(), which the C library compiles
+ * to nothing when NDEBUG is defined — and CMake defines NDEBUG for the Release /
+ * RelWithDebInfo configurations, the latter being exactly what CI builds. Every
+ * assertion here was therefore removed by the preprocessor in CI, so the suite
+ * passed unconditionally: it would have reported success even if every invariant
+ * below were false.
+ *
+ * CHECK()   — always evaluated; records a failure and keeps going, so one broken
+ *             invariant does not hide the others.
+ * REQUIRE() — for preconditions that later statements depend on (chiefly non-NULL
+ *             pointers). Unlike CHECK() it returns immediately, because assert()
+ *             used to abort here: continuing past a failed pointer check would
+ *             dereference NULL, which is undefined behaviour rather than a
+ *             reported test failure.
  */
 static int g_failures = 0;
 #define CHECK(cond)                                                       \
@@ -19,11 +28,18 @@ static int g_failures = 0;
             g_failures++;                                                 \
         }                                                                 \
     } while (0)
+#define REQUIRE(cond)                                                     \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("FAIL (fatal): %s (%s:%d)\n", #cond, __FILE__, __LINE__); \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
 
 int main(void) {
     const char *signature = weblib_kamran_signature();
 
-    CHECK(signature != NULL);
+    REQUIRE(signature != NULL);
     CHECK(strstr(signature, WEBLIB_AUTHOR_KAMRAN) != NULL);
 
     /* ---- Semantic Versioning tests ---- */
@@ -55,7 +71,7 @@ int main(void) {
     CHECK(WEBLIB_VERSION_ENCODE(0, 9, 9) < WEBLIB_VERSION_ENCODE(1, 0, 0));
 
     /* Runtime version API */
-    CHECK(weblib_version() != NULL);
+    REQUIRE(weblib_version() != NULL);
     CHECK(strcmp(weblib_version(), WEBLIB_VERSION) == 0);
 
     /* weblib_version_components returns correct values */

--- a/tests/test_kamran_header.c
+++ b/tests/test_kamran_header.c
@@ -1,20 +1,37 @@
 #include "kamran.k"
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
+
+/*
+ * Assertion that survives NDEBUG.
+ *
+ * Bare CHECK() compiles to nothing when NDEBUG is defined, which CMake does for
+ * the Release / RelWithDebInfo configurations — and RelWithDebInfo is exactly what
+ * CI builds. This suite previously used CHECK() throughout, so in CI it passed
+ * unconditionally: it would have reported success even if every invariant below
+ * were false. CHECK() is always evaluated and makes main() return non-zero.
+ */
+static int g_failures = 0;
+#define CHECK(cond)                                                       \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            printf("FAIL: %s (%s:%d)\n", #cond, __FILE__, __LINE__);      \
+            g_failures++;                                                 \
+        }                                                                 \
+    } while (0)
 
 int main(void) {
     const char *signature = weblib_kamran_signature();
 
-    assert(signature != NULL);
-    assert(strstr(signature, WEBLIB_AUTHOR_KAMRAN) != NULL);
+    CHECK(signature != NULL);
+    CHECK(strstr(signature, WEBLIB_AUTHOR_KAMRAN) != NULL);
 
     /* ---- Semantic Versioning tests ---- */
 
     /* Macro sanity: components are non-negative integers */
-    assert(WEBLIB_VERSION_MAJOR >= 0);
-    assert(WEBLIB_VERSION_MINOR >= 0);
-    assert(WEBLIB_VERSION_PATCH >= 0);
+    CHECK(WEBLIB_VERSION_MAJOR >= 0);
+    CHECK(WEBLIB_VERSION_MINOR >= 0);
+    CHECK(WEBLIB_VERSION_PATCH >= 0);
 
     /* WEBLIB_VERSION string matches the individual components */
     {
@@ -22,41 +39,43 @@ int main(void) {
         snprintf(expected, sizeof(expected), "%d.%d.%d",
                  WEBLIB_VERSION_MAJOR, WEBLIB_VERSION_MINOR,
                  WEBLIB_VERSION_PATCH);
-        assert(strcmp(WEBLIB_VERSION, expected) == 0);
+        CHECK(strcmp(WEBLIB_VERSION, expected) == 0);
     }
 
     /* WEBLIB_VERSION_NUMBER encodes correctly */
-    assert(WEBLIB_VERSION_NUMBER ==
+    CHECK(WEBLIB_VERSION_NUMBER ==
            WEBLIB_VERSION_ENCODE(WEBLIB_VERSION_MAJOR,
                                  WEBLIB_VERSION_MINOR,
                                  WEBLIB_VERSION_PATCH));
 
     /* Version comparison helper works as expected */
-    assert(WEBLIB_VERSION_ENCODE(1, 0, 0) < WEBLIB_VERSION_ENCODE(1, 0, 1));
-    assert(WEBLIB_VERSION_ENCODE(1, 0, 0) < WEBLIB_VERSION_ENCODE(1, 1, 0));
-    assert(WEBLIB_VERSION_ENCODE(1, 0, 0) < WEBLIB_VERSION_ENCODE(2, 0, 0));
-    assert(WEBLIB_VERSION_ENCODE(0, 9, 9) < WEBLIB_VERSION_ENCODE(1, 0, 0));
+    CHECK(WEBLIB_VERSION_ENCODE(1, 0, 0) < WEBLIB_VERSION_ENCODE(1, 0, 1));
+    CHECK(WEBLIB_VERSION_ENCODE(1, 0, 0) < WEBLIB_VERSION_ENCODE(1, 1, 0));
+    CHECK(WEBLIB_VERSION_ENCODE(1, 0, 0) < WEBLIB_VERSION_ENCODE(2, 0, 0));
+    CHECK(WEBLIB_VERSION_ENCODE(0, 9, 9) < WEBLIB_VERSION_ENCODE(1, 0, 0));
 
     /* Runtime version API */
-    assert(weblib_version() != NULL);
-    assert(strcmp(weblib_version(), WEBLIB_VERSION) == 0);
+    CHECK(weblib_version() != NULL);
+    CHECK(strcmp(weblib_version(), WEBLIB_VERSION) == 0);
 
     /* weblib_version_components returns correct values */
     {
         int maj = -1, min = -1, pat = -1;
         weblib_version_components(&maj, &min, &pat);
-        assert(maj == WEBLIB_VERSION_MAJOR);
-        assert(min == WEBLIB_VERSION_MINOR);
-        assert(pat == WEBLIB_VERSION_PATCH);
+        CHECK(maj == WEBLIB_VERSION_MAJOR);
+        CHECK(min == WEBLIB_VERSION_MINOR);
+        CHECK(pat == WEBLIB_VERSION_PATCH);
     }
 
     /* NULL pointers are tolerated */
     weblib_version_components(NULL, NULL, NULL);
 
     /* Signature string contains the full semver version */
-    assert(strstr(signature, WEBLIB_VERSION) != NULL);
+    CHECK(strstr(signature, WEBLIB_VERSION) != NULL);
 
-    printf("kamran.k alias OK — version %s (semver tests passed)\n",
-           WEBLIB_VERSION);
-    return 0;
+    if (g_failures == 0) {
+        printf("kamran.k alias OK — version %s (semver tests passed)\n",
+               WEBLIB_VERSION);
+    }
+    return g_failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Two **independent false-greens** in CI, found while inventorying the repo against its roadmap. In both cases CI reported success without executing the code it claimed to cover.

## 1. The entire TLS layer never ran in CI

`ci.yml` configures cmake with no `-DWEBLIB_ENABLE_TLS=ON`, and [the option defaults `OFF`](../blob/main/CMakeLists.txt#L80). So `src/tls/` was **never compiled**, let alone tested.

| CI today | Reality |
|---|---|
| 6 suites run | 13 exist |
| `src/tls/` compiled | **never** |
| 86 crypto KATs · 166 parse checks · transport · fuzzer · end-to-end HTTPS · real `openssl s_client` interop | **never executed** |

That left ~5,500 lines of hand-written, explicitly-**unaudited** crypto plus the handshake state machine with **zero regression protection**. Every TLS PR (#116–#128) was green on a developer machine only; a future change could have broken a crypto primitive or the state machine with CI staying green.

**Fix:** a `tls-check` job with two configurations, because they fail differently:
- **RelWithDebInfo + full suite** — correctness and real-client interop.
- **ASan/UBSan over the TLS suites** — memory safety and UB in hand-written crypto, which the plain build cannot detect. This sanitizer pass was already applied *by hand* to every TLS change; this makes it enforceable.

`openssl version` is logged because the interop test **self-skips** on an inadequate openssl — and a silent skip is indistinguishable from a pass, which is the same failure mode this PR exists to remove.

## 2. 36 assertions were compiled out of existence

`test_kamran_header.c` (17) and `test_async_websocket.c` (19) used bare `assert()`. `NDEBUG` removes it — and CMake defines `NDEBUG` for `RelWithDebInfo`, **the configuration CI builds**. Both suites passed *unconditionally*: they would have reported success with every invariant false.

Replaced with an always-evaluated `CHECK()` macro that fails the run.

**Proven by negative control** — invariant deliberately broken, built exactly as CI builds:

```
before:  exit 0   (silent pass)
after:   FAIL: signature == NULL (test_kamran_header.c:26)   exit 1
```

Also removes the `-Wunused-variable` warning this exposed — the variable was unused *precisely because* its only use was inside a compiled-out assert. A warning that was itself a symptom of the bug.

## Verification

- Default build **6/6**, **zero warnings**
- TLS build **13/13**
- All 7 TLS suites pass under **ASan/UBSan** via the exact command the new job runs (64s, well inside the 20-min timeout)
- CI YAML validated; `ctest -R '^Tls'` confirmed to select exactly the 7 intended suites (a filter matching zero would itself be a silent green)

I ran the new job's commands locally rather than trusting the YAML — pushing an unexecuted CI job would repeat the original mistake in a different form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)