### PR TITLE
examples: define the Worker lifecycle exports worker.js actually calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- **`examples/worker_example.c` now defines the Worker lifecycle exports**
+  (`worker_init`, `worker_fetch`, `worker_cleanup`), so the `emcc` command
+  printed in `examples/worker.js` links as written — at 2.0.0 that command
+  failed because the example had only `main()` (see the 2.0.0 notes below).
+  The native demo is unchanged; `main()` now drives the same three functions
+  the JS glue calls. Also fixed a 32-byte leak the example had carried from
+  the start: the `worker_d1_exec()` DDL result was discarded, the same
+  owned-return class PR #75 fixed in the D1 tests.
+- **`examples/worker.js` header corrected**: it pointed at a `wrangler.toml`
+  "in this directory" that has never shipped (you write your own), and it now
+  states its real limitation outright — the glue accepts `env` but never
+  passes it into WASM, so a deployed Worker sees the library's in-memory
+  binding simulations, not the services bound in the Cloudflare dashboard.
+- **CI wall time halved (~6.5 → ~3.0 min)**: the four secondary jobs no longer
+  wait on `primary-checks` — the staging saved nothing on a public repository
+  (Actions minutes are free) and doubled every run. All five jobs run in
+  parallel; the concurrency group still cancels superseded runs.
+- **The Valgrind CI step now genuinely gates**: it previously reported every
+  binary but only the last one's exit status could fail the job, and it could
+  pass having tested nothing (empty glob, failed `cd`). It now accumulates
+  every binary's status, hard-fails if zero binaries matched, and prints how
+  many it checked. The `cache_get()` leaks it had been hiding (25 test call
+  sites) are fixed via helpers that make the ownership impossible to miss.
 
 ## [2.0.0] - 2026-07-27
 

--- a/examples/worker.js
+++ b/examples/worker.js
@@ -2,16 +2,22 @@
  * worker.js - Cloudflare Worker JavaScript Glue
  *
  * Bridges the Cloudflare Workers fetch event to the C/WASM library.
- * The WASM module is compiled from worker_example.c (or your own C code)
- * using Emscripten.
+ * The WASM module is compiled from worker_example.c - which defines the
+ * worker_init / worker_fetch / worker_cleanup exports this glue calls -
+ * or from your own C file providing the same three functions (the Worker
+ * Quick Start in README.md shows the pattern).
  *
- * Build the WASM module:
+ * Build the WASM module (after `emcmake cmake` + `emmake make` in ../build-wasm):
  *   emcc -o worker.wasm.js worker_example.c -I../include -L../build-wasm -lweblib \
  *        -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,allocateUTF8,UTF8ToString \
  *        -sEXPORTED_FUNCTIONS=_worker_init,_worker_fetch,_worker_cleanup,_worker_response_get_status,_worker_response_get_body,_worker_response_destroy,_malloc,_free \
  *        -sWASM=1 -sMODULARIZE=1 -sEXPORT_NAME=createModule
  *
- * Deploy with wrangler (see wrangler.toml in this directory).
+ * Deploying needs a wrangler.toml you write yourself - none ships in this
+ * repo.  KNOWN LIMITATION: this glue accepts `env` in fetch() but never
+ * passes it into WASM, so the KV/R2/D1/Queues bindings your Worker sees are
+ * the library's in-memory simulations (set up in worker_init()), not the
+ * real Cloudflare services bound in the dashboard.
  *
  * Copyright (c) 2024 Modern C Web Library
  * Licensed under MIT License

--- a/examples/worker_example.c
+++ b/examples/worker_example.c
@@ -1,14 +1,23 @@
 /*
  * worker_example.c - Cloudflare Worker with KV, R2, D1, and Queues
  *
- * Demonstrates how to use the library's Worker runtime bindings to
- * build a Cloudflare Worker that accesses KV, R2, D1, and Queues.
+ * Demonstrates the library's Worker runtime bindings AND the three
+ * lifecycle exports that the JavaScript glue (examples/worker.js) drives:
  *
- * In a real deployment this would be compiled to WASM and loaded by
- * a JavaScript glue layer in the Worker.  This native-build example
- * simulates the Worker lifecycle using in-memory service backends.
+ *   worker_init()                 - create bindings, seed data, register the
+ *                                   fetch handler (called once at startup)
+ *   worker_fetch(method, url)     - handle one fetch event; returns a
+ *                                   worker_response_t* the caller destroys
+ *   worker_cleanup()              - tear everything down
  *
- * Usage: ./worker_example
+ * These are WASM_EXPORTed, so the emcc command in worker.js's header links
+ * against this file as printed.  The native build wraps the same three
+ * functions in a main() that simulates the Worker lifecycle using the
+ * in-memory service backends (which are the implementation in every build -
+ * no glue to the real Cloudflare services ships in this repo; worker.js
+ * does not pass its `env` into WASM).
+ *
+ * Usage (native): ./worker_example
  *
  * Copyright (c) 2024 Modern C Web Library
  * Licensed under MIT License
@@ -18,6 +27,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* ---------- Worker state (set up by worker_init, freed by worker_cleanup) ---------- */
+
+static worker_kv_t        *g_kv;
+static worker_r2_bucket_t *g_bucket;
+static worker_d1_t        *g_db;
+static worker_queue_t     *g_queue;
+static worker_env_t       *g_env;
 
 /* ---------- Fetch Handler ---------- */
 
@@ -91,21 +108,26 @@ static worker_response_t *handle_fetch(worker_request_t *req,
     return res;
 }
 
-/* ---------- Main ---------- */
+/* ---------- Lifecycle exports (the contract worker.js drives) ---------- */
 
-int main(void) {
-    printf("=== Cloudflare Worker Example (native simulation) ===\n\n");
+/*
+ * Create the service bindings, seed the D1 table, and register the fetch
+ * handler.  Safe to call once; worker.js calls it on the first request.
+ */
+WASM_EXPORT void worker_init(void) {
+    g_kv = worker_kv_create("CACHE");
+    g_bucket = worker_r2_bucket_create("LOGS");
+    g_db = worker_d1_create("APP_DB");
+    g_queue = worker_queue_create("EVENTS");
 
-    /* Create services */
-    worker_kv_t *kv = worker_kv_create("CACHE");
-    worker_r2_bucket_t *bucket = worker_r2_bucket_create("LOGS");
-    worker_d1_t *db = worker_d1_create("APP_DB");
-    worker_queue_t *queue = worker_queue_create("EVENTS");
+    /* Set up D1 schema and seed data.  worker_d1_exec() returns an owned
+     * result even for DDL - discard it and it leaks (the same class PR #75
+     * fixed in the D1 tests). */
+    worker_d1_result_t *ddl = worker_d1_exec(g_db,
+        "CREATE TABLE users (id, name, email)");
+    worker_d1_result_destroy(ddl);
 
-    /* Set up D1 schema and seed data */
-    worker_d1_exec(db, "CREATE TABLE users (id, name, email)");
-
-    worker_d1_stmt_t *ins = worker_d1_prepare(db,
+    worker_d1_stmt_t *ins = worker_d1_prepare(g_db,
         "INSERT INTO users (id, name, email) VALUES (?, ?, ?)");
     worker_d1_stmt_bind(ins, 1, "1");
     worker_d1_stmt_bind(ins, 2, "Alice");
@@ -114,7 +136,7 @@ int main(void) {
     worker_d1_result_destroy(r);
     worker_d1_stmt_destroy(ins);
 
-    ins = worker_d1_prepare(db,
+    ins = worker_d1_prepare(g_db,
         "INSERT INTO users (id, name, email) VALUES (?, ?, ?)");
     worker_d1_stmt_bind(ins, 1, "2");
     worker_d1_stmt_bind(ins, 2, "Bob");
@@ -124,35 +146,81 @@ int main(void) {
     worker_d1_stmt_destroy(ins);
 
     /* Create Worker environment with all bindings */
-    worker_env_t *env = worker_env_create();
-    worker_env_add_binding(env, "CACHE", WORKER_BINDING_KV, kv);
-    worker_env_add_binding(env, "LOGS", WORKER_BINDING_R2, bucket);
-    worker_env_add_binding(env, "APP_DB", WORKER_BINDING_D1, db);
-    worker_env_add_binding(env, "EVENTS", WORKER_BINDING_QUEUE, queue);
+    g_env = worker_env_create();
+    worker_env_add_binding(g_env, "CACHE", WORKER_BINDING_KV, g_kv);
+    worker_env_add_binding(g_env, "LOGS", WORKER_BINDING_R2, g_bucket);
+    worker_env_add_binding(g_env, "APP_DB", WORKER_BINDING_D1, g_db);
+    worker_env_add_binding(g_env, "EVENTS", WORKER_BINDING_QUEUE, g_queue);
 
     /* Register handler */
     worker_set_fetch_handler(handle_fetch);
+}
 
-    /* Simulate incoming requests */
+/*
+ * Handle one fetch event.  worker.js allocates `method` and `url` in WASM
+ * memory and frees them after this returns; the response pointer is read via
+ * worker_response_get_status()/get_body() and freed by the caller with
+ * worker_response_destroy().  Returns NULL on failure (the glue maps that to
+ * a 500).
+ */
+WASM_EXPORT worker_response_t *worker_fetch(const char *method,
+                                            const char *url) {
+    worker_request_t *req = worker_request_create(method, url);
+    if (!req) {
+        return NULL;
+    }
+    worker_response_t *res = worker_handle_fetch(req, g_env);
+    worker_request_destroy(req);
+    return res;
+}
+
+/* Tear down everything worker_init() created. */
+WASM_EXPORT void worker_cleanup(void) {
+    worker_set_fetch_handler(NULL);
+    worker_env_destroy(g_env);
+    worker_queue_destroy(g_queue);
+    worker_d1_destroy(g_db);
+    worker_r2_bucket_destroy(g_bucket);
+    worker_kv_destroy(g_kv);
+    g_env = NULL;
+    g_queue = NULL;
+    g_db = NULL;
+    g_bucket = NULL;
+    g_kv = NULL;
+}
+
+/* ---------- Main (native simulation of the Worker lifecycle) ---------- */
+
+#ifdef __EMSCRIPTEN__
+/*
+ * Under Emscripten the JavaScript glue drives the Worker entirely through the
+ * exports above; main() is not part of the contract, but Emscripten links a
+ * trivial one so the printed emcc command works without extra flags.
+ */
+int main(void) {
+    return 0;
+}
+#else
+int main(void) {
+    printf("=== Cloudflare Worker Example (native simulation) ===\n\n");
+
+    /* Same call sequence the JS glue performs */
+    worker_init();
+
+    /* Simulate incoming fetch events through the exported entry point */
     printf("--- Request 1 ---\n");
-    worker_request_t *req1 = worker_request_create("GET",
-        "https://example.com/");
-    worker_response_t *res1 = worker_handle_fetch(req1, env);
+    worker_response_t *res1 = worker_fetch("GET", "https://example.com/");
     printf("  Response: %d\n\n", worker_response_get_status(res1));
-    worker_request_destroy(req1);
     worker_response_destroy(res1);
 
     printf("--- Request 2 ---\n");
-    worker_request_t *req2 = worker_request_create("GET",
-        "https://example.com/about");
-    worker_response_t *res2 = worker_handle_fetch(req2, env);
+    worker_response_t *res2 = worker_fetch("GET", "https://example.com/about");
     printf("  Response: %d\n\n", worker_response_get_status(res2));
-    worker_request_destroy(req2);
     worker_response_destroy(res2);
 
-    /* Consume queued events */
+    /* Consume queued events (native demo only - the glue has no consumer) */
     printf("--- Consuming Queue Events ---\n");
-    worker_queue_batch_t *batch = worker_queue_consume(queue, 10, 0);
+    worker_queue_batch_t *batch = worker_queue_consume(g_queue, 10, 0);
     if (batch) {
         printf("  Consumed %d events:\n", batch->count);
         for (int i = 0; i < batch->count; i++) {
@@ -164,13 +232,13 @@ int main(void) {
 
     /* Verify KV state */
     printf("\n--- Final KV State ---\n");
-    char *vc = worker_kv_get(kv, "visit_count");
+    char *vc = worker_kv_get(g_kv, "visit_count");
     printf("  visit_count = %s\n", vc ? vc : "(null)");
     free(vc);
 
     /* Verify R2 state */
     printf("\n--- Final R2 State ---\n");
-    worker_r2_object_t *obj = worker_r2_head(bucket, "access.log");
+    worker_r2_object_t *obj = worker_r2_head(g_bucket, "access.log");
     if (obj) {
         printf("  access.log: %zu bytes, type=%s\n",
                obj->size, obj->content_type ? obj->content_type : "?");
@@ -179,13 +247,7 @@ int main(void) {
 
     printf("\n=== Done ===\n");
 
-    /* Cleanup */
-    worker_set_fetch_handler(NULL);
-    worker_env_destroy(env);
-    worker_queue_destroy(queue);
-    worker_d1_destroy(db);
-    worker_r2_bucket_destroy(bucket);
-    worker_kv_destroy(kv);
-
+    worker_cleanup();
     return 0;
 }
+#endif /* __EMSCRIPTEN__ */


### PR DESCRIPTION
## The gap

`examples/worker.js`'s printed `emcc` command compiles `worker_example.c` and exports `_worker_init`, `_worker_fetch`, `_worker_cleanup` — but `worker_example.c` defined none of them (only `main()`). The command failed at link as printed, and the only place those three functions existed was as prose in the README Quick Start. This is the follow-up the 2.0.0 CHANGELOG promised (task #30).

## The fix

`worker_example.c` now defines all three, `WASM_EXPORT`ed:

| Export | Does |
|---|---|
| `worker_init()` | create KV/R2/D1/Queue bindings, seed D1, build the env, register the fetch handler — extracted verbatim from the old `main()` |
| `worker_fetch(method, url)` | the exact shape the glue calls: request in, `worker_handle_fetch()`, owned response out (`NULL` → the glue's 500 path) |
| `worker_cleanup()` | teardown, pointers nulled |

The native demo is behaviourally unchanged — `main()` now **drives the same three functions the JS glue calls**, so the two paths cannot drift apart again. Under `__EMSCRIPTEN__`, `main()` is a trivial `return 0` so the printed command links with no extra flags.

## Found while in the file

A 32-byte leak the example had carried from the start: `worker_d1_exec()` returns an owned result even for DDL, and the `CREATE TABLE` call discarded it — the same owned-return-discarded class PR #75 fixed in the D1 *tests* and #131 fixed for `cache_get()`. macOS `leaks`: 1 leak / 32 bytes before, **0 / 0 after**. (Note: examples are not under the CI Valgrind gate, which globs `tests/test_*`.)

## worker.js header corrections

- "see `wrangler.toml` in this directory" — none has ever shipped; now says you write your own
- the `env` limitation stated outright: `fetch()` accepts `env` and never passes it into WASM, so a deployed Worker sees the in-memory simulations, not dashboard-bound services
- build comment now names the `emcmake`/`emmake` prerequisite for `-L../build-wasm -lweblib`

## CHANGELOG

Recorded under `[Unreleased]`, together with the CI changes from #131 that had landed without an entry (parallel jobs, the Valgrind gate). The 2.0.0 section's description of the breakage is untouched — it was true at 2.0.0, and released history stays as written.

## Verification

| Check | Result |
|---|---|
| Default build | 6/6 suites, 0 warnings |
| TLS build | 13/13 suites, 0 warnings |
| Example output | identical to old version (visit counter, D1 rows, queue depth, R2 state) |
| macOS `leaks` on the example | 0 leaks, 0 bytes |
| WASM link | **not executed locally — no emcc on this host.** The claim is structural: all six `-sEXPORTED_FUNCTIONS` symbols now exist |

🤖 Generated with [Claude Code](https://claude.com/claude-code)