### PR TITLE
bench: make the benchmarking suite actually produce numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The benchmarking suite now produces numbers.** `src/benchmark.c` has shipped
+  since v0.9.0 with nothing calling it — no example, no test, no CI job — so the
+  advertised "Benchmarking Suite" had never yielded a figure and no baseline
+  existed to detect a regression against. `examples/benchmark_server` starts a
+  server, drives `benchmark_run()` against a plain-text and a JSON route, and
+  prints throughput plus p50/p95/p99. `tests/benchmark_tls.sh` measures the TLS
+  path with a real `openssl s_client`, which is the only option: the library is
+  TLS **server-side only**, so there is no in-process TLS client to benchmark
+  with. First baseline (Apple M5, loopback) recorded in
+  [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md), along with what the numbers
+  explicitly do *not* claim — they are a single-client latency floor, not a
+  capacity or concurrency measurement. Neither tool is a ctest suite: they are
+  measurement tools, not gates, and an ungated performance number in CI is noise
+  that also costs wall time.
+
 ### Fixed
 
 - **`examples/worker_example.c` now defines the Worker lifecycle exports**

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,104 @@
+# Benchmarks
+
+**Version 2.0.0**
+
+The library has shipped a benchmarking module (`src/benchmark.c`) since v0.9.0.
+Until now nothing called it — no example, no test, no CI job — so the
+"Benchmarking Suite" feature produced numbers for nobody, and no baseline
+existed to detect a regression against. This document records the first one.
+
+## How to reproduce
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build --parallel
+./build/examples/benchmark_server                     # defaults: 2000 requests
+./build/examples/benchmark_server --requests 5000 --port 9100
+```
+
+TLS is measured separately, by an external client (see *Why TLS is measured
+differently* below):
+
+```bash
+cmake -S . -B build-tls -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWEBLIB_ENABLE_TLS=ON
+cmake --build build-tls --parallel
+bash tests/benchmark_tls.sh ./build-tls/examples/tls_server 40
+```
+
+Neither is registered as a ctest suite. They are measurement tools, not
+correctness gates: `TlsInteropOpenssl` already gates handshake correctness, and
+an ungated performance number in CI is log noise that also costs wall time.
+Adding a performance *gate* would need a threshold policy and a stable runner —
+a separate decision, not a side effect of this tooling.
+
+## Baseline — 2026-07-28
+
+| Scenario | Throughput | avg | p50 | p95 | p99 | Failed |
+|---|---|---|---|---|---|---|
+| `GET /plain` (2-byte text body) | 21,464 req/s | 21.3 µs | 20 µs | 25 µs | 57 µs | 0 |
+| `GET /json` (small JSON object) | 20,685 req/s | 21.8 µs | 21 µs | 25 µs | 31 µs | 0 |
+
+3000 requests per scenario after a discarded 200-request warm-up.
+
+| TLS scenario | Rate | Mean | Failed |
+|---|---|---|---|
+| Full TLS 1.3 handshake + `GET /` | 86 handshakes/s | 11 ms | 0 of 40 |
+
+**Environment:** Apple M5, macOS 26.5, Apple clang 21.0.0, `RelWithDebInfo`,
+loopback. Numbers from a different machine or a Linux CI runner will differ —
+compare against a baseline you took yourself on the same host.
+
+### What these numbers are, and are not
+
+`benchmark_run()` opens **a fresh TCP connection per request** and sends one
+`GET`, **sequentially, from a single thread, over loopback**. So the figures are:
+
+- a **per-request latency floor** — real networks add far more than 21 µs;
+- a **single-client throughput ceiling** — not a capacity number.
+
+Nothing here measures concurrent clients, keep-alive connection reuse, large
+bodies, or behaviour under load. The threaded server runs a 16-worker pool that
+this benchmark never exercises in parallel. Treat a regression in these figures
+as a signal worth investigating, not as a production SLO, and do not quote them
+as "the library handles N requests per second".
+
+One observation worth keeping: JSON serialisation costs essentially nothing
+against the plain-text route (within run-to-run noise), which says the JSON path
+is not doing anything pathological with allocation.
+
+### Why TLS is measured differently
+
+The in-process benchmark client speaks plain HTTP over a raw socket and **cannot
+be extended to HTTPS**: this library implements TLS 1.3 **server-side only** —
+there is no TLS client anywhere in the tree, and writing one is out of scope
+(see [`../src/tls/README.md`](../src/tls/README.md)). The only way to exercise
+the TLS path is to drive it with a real external client, which is exactly what
+`tests/interop_openssl.sh` already does for correctness.
+
+`tests/benchmark_tls.sh` therefore spawns a fresh `openssl s_client` per
+iteration. Each one performs a complete handshake — X25519 key exchange, Ed25519
+signature, the key schedule — plus one `GET` over the encrypted channel.
+
+**That rate includes `openssl` process spawn (fork + exec + init), which
+dominates it.** Read 86 handshakes/s as a conservative floor and a regression
+signal, not as the speed of the C crypto code. Removing that overhead would
+require an in-process TLS client, which does not exist.
+
+The TLS layer remains **EXPERIMENTAL and UNAUDITED**; performance figures say
+nothing about its security.
+
+## Known gaps
+
+These are deliberate omissions, not oversights:
+
+- **No concurrency benchmark.** The most useful missing number: how the 16-worker
+  pool behaves under parallel load.
+- **No keep-alive benchmark.** Every request pays a fresh TCP connect, so
+  connection reuse — which the server supports — is unmeasured.
+- **Async mode is unmeasured by this runner.** `http_server_listen()` runs the
+  event loop on the calling thread and never returns, so a single-process runner
+  has no thread left to drive the client. Run `examples/async_server` in one
+  terminal and a client in another.
+- **No CI trend.** Nothing stores these over time, so a slow drift across many
+  commits would go unnoticed even though a sudden regression would be visible to
+  anyone who runs the tool.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ The HTTP, WebSocket and middleware core is the stable, supported surface of the 
 ### Advanced Topics
 - **[Debugging Guide](DEBUGGING.md)** — Debug tools and techniques
 - **[Technical Debt](TECHNICAL_DEBT.md)** — Known limitations and future work
+- **[Benchmarks](BENCHMARKS.md)** — throughput/latency baseline, how to reproduce, and what the numbers do *not* claim
 - **[Changelog](../CHANGELOG.md)** — What changed in each release, including the source-breaking changes in 2.0.0
 - **[Cloudflare Workers API](WORKER_API.md)** — Worker request/response, the fetch handler, and the KV, R2, D1 and Queues bindings
 - **[Experimental TLS 1.3 Layer](../src/tls/README.md)** — what the hand-written pure-C TLS server does and does not give you (EXPERIMENTAL · UNAUDITED; off by default, native builds only)
@@ -191,7 +192,8 @@ Designed for high performance:
 - **LRU Cache**: Fast in-memory caching
 - **Compression**: Optional gzip for bandwidth savings
 
-Stress-test results are in [STRESS_TESTS.md](../STRESS_TESTS.md) — originally written against v0.9.0, with its test counts and per-test descriptions re-checked against 2.0.0. It is a pass/fail and static-limits report; it carries no throughput or latency numbers.
+Throughput and latency figures, with the caveats that belong on them, are in
+[BENCHMARKS.md](BENCHMARKS.md). Stress-test results are in [STRESS_TESTS.md](../STRESS_TESTS.md) — originally written against v0.9.0, with its test counts and per-test descriptions re-checked against 2.0.0. It is a pass/fail and static-limits report; it carries no throughput or latency numbers.
 
 ## Code Quality
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,6 +21,11 @@ if(NOT EMSCRIPTEN)
     add_executable(rest_api_server rest_api_server.c)
     target_link_libraries(rest_api_server weblib ${PLATFORM_LIBS})
 
+    # Throughput/latency benchmark runner (drives src/benchmark.c, which
+    # previously had no caller anywhere in the tree)
+    add_executable(benchmark_server benchmark_server.c)
+    target_link_libraries(benchmark_server weblib ${PLATFORM_LIBS})
+
     # HTTPS example — only when the experimental pure-C TLS layer is enabled
     if(WEBLIB_ENABLE_TLS)
         add_executable(tls_server tls_server.c)
@@ -28,7 +33,7 @@ if(NOT EMSCRIPTEN)
     endif()
 
     # Installation
-    install(TARGETS simple_server async_server websocket_echo_server async_websocket_echo_server rest_api_server DESTINATION bin)
+    install(TARGETS simple_server async_server websocket_echo_server async_websocket_echo_server rest_api_server benchmark_server DESTINATION bin)
 endif()
 
 # Worker example (runs on both native and WASM builds)

--- a/examples/benchmark_server.c
+++ b/examples/benchmark_server.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 
 #define DEFAULT_PORT      18080
 #define DEFAULT_REQUESTS  2000
@@ -59,6 +60,33 @@ static void handle_json(http_request_t *req, http_response_t *res) {
     json_object_set(json, "version", json_string_create(WEBLIB_VERSION));
     http_response_send_json(res, HTTP_OK, json);
     json_value_free(json);
+}
+
+/* ---------- Argument parsing ---------- */
+
+/*
+ * atoi() cannot fail: it returns 0 for "abc" and silently wraps on overflow, so
+ * `--port -1` would become 65535 and `--port abc` would become 0. Parse strictly
+ * instead - reject anything that is not a complete, in-range decimal number.
+ */
+static bool parse_ull(const char *s, unsigned long long lo,
+                      unsigned long long hi, unsigned long long *out) {
+    char *end = NULL;
+    unsigned long long v;
+
+    if (!s || *s == '\0' || *s == '-') {   /* strtoull silently accepts "-1" */
+        return false;
+    }
+    errno = 0;
+    v = strtoull(s, &end, 10);
+    if (errno != 0 || end == s || *end != '\0') {
+        return false;
+    }
+    if (v < lo || v > hi) {
+        return false;
+    }
+    *out = v;
+    return true;
 }
 
 /* ---------- Runner ---------- */
@@ -116,18 +144,28 @@ int main(int argc, char **argv) {
     uint64_t requests = DEFAULT_REQUESTS;
 
     for (int i = 1; i < argc; i++) {
+        unsigned long long v;
         if (strcmp(argv[i], "--port") == 0 && i + 1 < argc) {
-            port = (uint16_t)atoi(argv[++i]);
+            /* 1-65535: port 0 asks the OS to pick, which this runner cannot then connect to. */
+            if (!parse_ull(argv[++i], 1, 65535, &v)) {
+                fprintf(stderr, "invalid --port '%s' (expected 1-65535)\n\n", argv[i]);
+                usage(argv[0]);
+                return 1;
+            }
+            port = (uint16_t)v;
         } else if (strcmp(argv[i], "--requests") == 0 && i + 1 < argc) {
-            requests = strtoull(argv[++i], NULL, 10);
+            /* Upper bound is arbitrary but keeps the run finite and the latency
+             * sample array a sane size. */
+            if (!parse_ull(argv[++i], 1, 10000000ULL, &v)) {
+                fprintf(stderr, "invalid --requests '%s' (expected 1-10000000)\n\n", argv[i]);
+                usage(argv[0]);
+                return 1;
+            }
+            requests = v;
         } else {
             usage(argv[0]);
             return 1;
         }
-    }
-    if (port == 0 || requests == 0) {
-        usage(argv[0]);
-        return 1;
     }
 
     router_t *router = router_create();

--- a/examples/benchmark_server.c
+++ b/examples/benchmark_server.c
@@ -1,0 +1,176 @@
+/*
+ * benchmark_server.c - Self-contained throughput/latency benchmark
+ *
+ * The library has shipped a benchmarking module (src/benchmark.c) since v0.9.0,
+ * but nothing called it: no example, no test, no CI job. The "Benchmarking
+ * Suite" feature therefore produced numbers for nobody. This runner closes that
+ * gap - it starts a server, drives benchmark_run() against it, prints the
+ * results, and exits, so a baseline is one command away:
+ *
+ *     ./build/examples/benchmark_server
+ *     ./build/examples/benchmark_server --requests 5000 --port 9100
+ *
+ * WHAT THESE NUMBERS ARE, AND ARE NOT
+ *
+ * benchmark_run() opens a fresh TCP connection per request and sends one GET,
+ * sequentially, from a single thread over loopback. So the figures are a
+ * per-request latency floor and a single-client throughput ceiling. They are
+ * NOT a capacity or concurrency claim: nothing here measures parallel clients,
+ * keep-alive reuse, or behaviour under load. Treat a regression in these
+ * numbers as a signal worth investigating, not as a production SLO.
+ *
+ * NO TLS PATH. The benchmark client speaks plain HTTP only, and it cannot be
+ * extended to HTTPS in-process: this library implements TLS 1.3 server-side
+ * only - there is no TLS client (src/tls/README.md). Measuring the TLS layer
+ * needs an external driver; tests/benchmark_tls.sh does that with
+ * `openssl s_client`.
+ *
+ * Copyright (c) 2024 Modern C Web Library
+ * Licensed under MIT License
+ */
+
+#include "kamran.k"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define DEFAULT_PORT      18080
+#define DEFAULT_REQUESTS  2000
+#define WARMUP_REQUESTS   200
+
+/* ---------- Handlers: one trivial, one representative ---------- */
+
+/* Smallest useful response - isolates request parsing + socket cost. */
+static void handle_plain(http_request_t *req, http_response_t *res) {
+    (void)req;
+    http_response_send_text(res, HTTP_OK, "ok");
+}
+
+/* Builds and serialises a small JSON object - the common real workload. */
+static void handle_json(http_request_t *req, http_response_t *res) {
+    (void)req;
+    json_value_t *json = json_object_create();
+    if (!json) {
+        http_response_send_text(res, HTTP_INTERNAL_ERROR, "oom");
+        return;
+    }
+    json_object_set(json, "status", json_string_create("ok"));
+    json_object_set(json, "version", json_string_create(WEBLIB_VERSION));
+    http_response_send_json(res, HTTP_OK, json);
+    json_value_free(json);
+}
+
+/* ---------- Runner ---------- */
+
+static void usage(const char *argv0) {
+    fprintf(stderr,
+        "Usage: %s [--port N] [--requests N]\n"
+        "  --port N       listen port (default %d)\n"
+        "  --requests N   requests per scenario (default %d)\n"
+        "\n"
+        "Threaded mode only. Async mode cannot be driven from one process:\n"
+        "http_server_listen() runs the event loop on the calling thread and\n"
+        "never returns, leaving no thread to run the client. To measure async,\n"
+        "run examples/async_server in one terminal and a client in another.\n",
+        argv0, DEFAULT_PORT, DEFAULT_REQUESTS);
+}
+
+/*
+ * Benchmark one route and report. Returns 0 on success.
+ *
+ * A warm-up pass runs first and is discarded: the first requests against a
+ * fresh server pay one-off costs (thread-pool spin-up, first allocations) that
+ * would otherwise land in the max and p99 and make runs incomparable.
+ */
+static int bench_route(uint16_t port, const char *path, const char *label,
+                       uint64_t requests) {
+    benchmark_stats_t warm;
+    benchmark_stats_t stats;
+
+    if (benchmark_run(port, path, WARMUP_REQUESTS, &warm) != 0) {
+        fprintf(stderr, "warm-up failed for %s - is the server up?\n", path);
+        return -1;
+    }
+    if (benchmark_run(port, path, requests, &stats) != 0) {
+        fprintf(stderr, "benchmark failed for %s\n", path);
+        return -1;
+    }
+
+    printf("\n--- %s (GET %s) ---\n", label, path);
+    benchmark_print(stdout, &stats);
+
+    if (stats.failed > 0) {
+        fprintf(stderr,
+                "WARNING: %llu of %llu requests failed - the numbers above are "
+                "not meaningful.\n",
+                (unsigned long long)stats.failed,
+                (unsigned long long)stats.total_requests);
+        return -1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    uint16_t port = DEFAULT_PORT;
+    uint64_t requests = DEFAULT_REQUESTS;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--port") == 0 && i + 1 < argc) {
+            port = (uint16_t)atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--requests") == 0 && i + 1 < argc) {
+            requests = strtoull(argv[++i], NULL, 10);
+        } else {
+            usage(argv[0]);
+            return 1;
+        }
+    }
+    if (port == 0 || requests == 0) {
+        usage(argv[0]);
+        return 1;
+    }
+
+    router_t *router = router_create();
+    http_server_t *server = http_server_create();
+    if (!router || !server) {
+        fprintf(stderr, "failed to create server\n");
+        router_destroy(router);
+        http_server_destroy(server);
+        return 1;
+    }
+
+    router_add_route(router, HTTP_GET, "/plain", handle_plain);
+    router_add_route(router, HTTP_GET, "/json", handle_json);
+    http_server_set_router(server, router);
+
+    printf("=== Modern C Web Library - benchmark (threaded) ===\n");
+    printf("weblib %s  port %u  %llu requests/scenario "
+           "(+%d warm-up, discarded)\n",
+           weblib_version(), (unsigned)port,
+           (unsigned long long)requests, WARMUP_REQUESTS);
+    printf("Sequential, single client, one connection per request, loopback.\n"
+           "A latency floor - not a concurrency or capacity measurement.\n");
+
+    if (http_server_listen(server, port) != 0) {
+        fprintf(stderr, "failed to listen on port %u (in use?)\n", (unsigned)port);
+        http_server_destroy(server);
+        router_destroy(router);
+        return 1;
+    }
+
+    /* Give the accept thread a moment to reach accept() before the first connect. */
+    usleep(200000);
+
+    int rc = 0;
+    if (bench_route(port, "/plain", "plain text", requests) != 0) rc = 1;
+    if (bench_route(port, "/json", "JSON object", requests) != 0) rc = 1;
+
+    printf("\nNo TLS figures: the benchmark client speaks plain HTTP, and this\n"
+           "library has no TLS client to extend it with (server-side only).\n"
+           "Use tests/benchmark_tls.sh, which drives openssl s_client.\n");
+
+    http_server_stop(server);
+    http_server_destroy(server);
+    router_destroy(router);
+    return rc;
+}

--- a/tests/benchmark_tls.sh
+++ b/tests/benchmark_tls.sh
@@ -32,6 +32,16 @@ set -u
 
 SERVER="${1:?usage: benchmark_tls.sh <tls_server binary> [handshake-count]}"
 COUNT="${2:-50}"
+
+# Validate COUNT before anything else. Without this, a non-integer makes
+# `seq 1 "$COUNT"` expand to nothing: the loop runs zero times, fails stays 0,
+# and the script prints PASS having performed no handshakes at all - a gate that
+# passes without testing anything, which is precisely the defect PR #131 fixed
+# in the Valgrind step. Refuse rather than silently measure nothing.
+case "$COUNT" in
+    ''|*[!0-9]*) echo "FAIL: handshake-count must be a positive integer, got '$COUNT'" >&2; exit 1 ;;
+esac
+[ "$COUNT" -ge 1 ] 2>/dev/null || { echo "FAIL: handshake-count must be >= 1, got '$COUNT'" >&2; exit 1; }
 SRV_PID=""
 TMP=""
 
@@ -121,5 +131,7 @@ echo "Mean per handshake:   $(( ELAPSED_MS / (ok > 0 ? ok : 1) )) ms (incl. proc
 
 # Any failed handshake means the numbers describe a partly-broken run.
 [ "$fails" -eq 0 ] || fail "$fails of $COUNT handshakes did not return HTTP 200"
+# ...and a run that performed no handshakes is not a pass, whatever the counters say.
+[ "$ok" -ge 1 ] || fail "no handshakes were performed - nothing was measured"
 echo
 echo "PASS"

--- a/tests/benchmark_tls.sh
+++ b/tests/benchmark_tls.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# TLS handshake throughput benchmark for the experimental pure-C TLS 1.3 server.
+#
+# WHY THIS IS A SHELL SCRIPT AND NOT PART OF examples/benchmark_server.c
+#
+# The in-process benchmark client (src/benchmark.c) speaks plain HTTP over a raw
+# socket, and it cannot be extended to HTTPS: this library implements TLS 1.3
+# *server-side only* - there is no TLS client anywhere in the tree, and writing
+# one is explicitly out of scope (src/tls/README.md). So the only way to measure
+# the TLS path is to drive it with a real external client, exactly as
+# tests/interop_openssl.sh does for correctness.
+#
+# WHAT IS MEASURED
+#
+# Full TLS 1.3 handshakes per second: each iteration is a fresh `openssl
+# s_client` process doing X25519 key exchange, Ed25519 signature, the key
+# schedule, and one HTTP GET over the encrypted channel. That per-connection
+# cost is the number that matters for the server's crypto path.
+#
+# The figure INCLUDES openssl process spawn (fork+exec+init), which on most
+# hosts dominates. So read it as a conservative floor for handshakes/sec, and
+# as a regression signal - a large drop means the server's handshake got
+# slower - not as an absolute measure of the C code's speed. There is no
+# in-process TLS client available to remove that overhead.
+#
+# Skips (exit 0) when the environment cannot run it, matching interop_openssl.sh,
+# so it never produces a false failure.
+#
+# Usage: benchmark_tls.sh <path-to-tls_server-binary> [handshake-count]
+set -u
+
+SERVER="${1:?usage: benchmark_tls.sh <tls_server binary> [handshake-count]}"
+COUNT="${2:-50}"
+SRV_PID=""
+TMP=""
+
+skip() { echo "SKIP: $*"; exit 0; }
+fail() { echo "FAIL: $*"; [ -n "${TMP}" ] && [ -f "$TMP/srv.log" ] && { echo "--- server log ---"; cat "$TMP/srv.log"; }; exit 1; }
+
+cleanup() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null; wait "$SRV_PID" 2>/dev/null; [ -n "$TMP" ] && rm -rf "$TMP"; }
+trap cleanup EXIT
+
+command -v openssl >/dev/null 2>&1 || skip "openssl not found"
+[ -x "$SERVER" ] || skip "server binary '$SERVER' not found"
+openssl version 2>/dev/null | grep -qi "^OpenSSL " || skip "not OpenSSL (e.g. LibreSSL); TLS 1.3 / Ed25519 support differs"
+openssl s_client -help 2>&1 | grep -q -- "-tls1_3" || skip "this openssl s_client has no -tls1_3"
+
+TO=""
+command -v timeout >/dev/null 2>&1 && TO="timeout 10"
+
+TMP="$(mktemp -d)" || skip "mktemp failed"
+
+openssl genpkey -algorithm ed25519 -out "$TMP/key.pem" >/dev/null 2>&1 || skip "openssl lacks Ed25519"
+openssl req -x509 -new -key "$TMP/key.pem" -out "$TMP/cert.pem" -days 2 \
+    -subj "/CN=localhost" >/dev/null 2>&1 || skip "openssl req failed"
+
+# Start the server, retrying a few ports if one is taken.
+PORT=$(( ($$ % 2000) + 47000 ))
+started=0
+for _try in 1 2 3 4 5; do
+    "$SERVER" "$TMP/cert.pem" "$TMP/key.pem" "$PORT" >"$TMP/srv.log" 2>&1 &
+    SRV_PID=$!
+    for _i in $(seq 1 50); do
+        if grep -q "HTTPS server" "$TMP/srv.log" 2>/dev/null; then started=1; break; fi
+        kill -0 "$SRV_PID" 2>/dev/null || break
+        sleep 0.1
+    done
+    [ "$started" = 1 ] && break
+    kill "$SRV_PID" 2>/dev/null; wait "$SRV_PID" 2>/dev/null; SRV_PID=""
+    PORT=$((PORT + 1))
+done
+[ "$started" = 1 ] || fail "server did not become ready"
+
+# NOTE: the request must be piped from printf directly, never stashed in a
+# variable first. Command substitution strips trailing newlines, which would eat
+# the blank line that terminates the header block - the server would then wait
+# for more headers until its deadline, and every "handshake" would time out.
+send_request() {
+    printf 'GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' \
+        | $TO openssl s_client -quiet -connect "127.0.0.1:$PORT" -tls1_3 2>/dev/null
+}
+
+# Warm-up: the first handshake pays one-off costs on both sides.
+send_request >/dev/null 2>&1
+
+echo "=== pure-C TLS 1.3 handshake benchmark ==="
+echo "TLS_CHACHA20_POLY1305_SHA256 / X25519 / Ed25519 - EXPERIMENTAL, UNAUDITED"
+echo "$COUNT full handshakes, each a fresh openssl s_client process."
+echo "Includes process-spawn overhead: a conservative floor, and a regression signal."
+echo
+
+ok=0
+fails=0
+START_NS=$( { date +%s%N; } 2>/dev/null )
+case "$START_NS" in *N*) START_NS=""; esac   # macOS date has no %N
+[ -n "$START_NS" ] || START_S=$(date +%s)
+
+for _i in $(seq 1 "$COUNT"); do
+    RESP="$(send_request)"
+    case "$RESP" in
+        *"HTTP/1.1 200"*) ok=$((ok + 1)) ;;
+        *)                fails=$((fails + 1)) ;;
+    esac
+done
+
+if [ -n "$START_NS" ]; then
+    END_NS=$(date +%s%N)
+    ELAPSED_MS=$(( (END_NS - START_NS) / 1000000 ))
+else
+    ELAPSED_MS=$(( ($(date +%s) - START_S) * 1000 ))
+fi
+[ "$ELAPSED_MS" -gt 0 ] || ELAPSED_MS=1
+
+echo "Handshakes attempted: $COUNT"
+echo "Succeeded (HTTP 200): $ok"
+echo "Failed:               $fails"
+echo "Elapsed:              ${ELAPSED_MS} ms"
+echo "Rate:                 $(( ok * 1000 / ELAPSED_MS )) handshakes/s"
+echo "Mean per handshake:   $(( ELAPSED_MS / (ok > 0 ? ok : 1) )) ms (incl. process spawn)"
+
+# Any failed handshake means the numbers describe a partly-broken run.
+[ "$fails" -eq 0 ] || fail "$fails of $COUNT handshakes did not return HTTP 200"
+echo
+echo "PASS"


### PR DESCRIPTION
## The gap

`src/benchmark.c` has shipped since v0.9.0 — throughput, p50/p95/p99, the lot — and **nothing ever called it**. No example, no test, no CI job. The advertised "Benchmarking Suite" had never yielded a single figure, and no baseline existed to detect a regression against.

That mattered more after recent work: Valgrind now gates all six binaries (#131), the TLS suites gate (#129). Performance was the one dimension with no signal at all — nothing would catch a 2× slowdown.

## What landed

**`examples/benchmark_server`** — starts a server, drives `benchmark_run()` against a plain-text and a JSON route, prints results, exits. One command. A 200-request warm-up is discarded so thread-pool spin-up doesn't land in max/p99 and make runs incomparable.

**`tests/benchmark_tls.sh`** — the TLS path, driven by a real `openssl s_client`. Not a shortcut: the in-process client speaks plain HTTP over a raw socket and **cannot** be extended to HTTPS, because this library is TLS **server-side only** and there is no TLS client in the tree. An external driver is the only option, exactly as `tests/interop_openssl.sh` already does for correctness.

## First baseline

Apple M5, macOS 26.5, `RelWithDebInfo`, loopback — recorded in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md):

| Scenario | Throughput | p50 | p95 | p99 | Failed |
|---|---|---|---|---|---|
| `GET /plain` | 21,464 req/s | 20 µs | 25 µs | 57 µs | 0 |
| `GET /json` | 20,685 req/s | 21 µs | 25 µs | 31 µs | 0 |
| TLS 1.3 handshake + `GET` | 86 handshakes/s | — | — | — | 0 of 40 |

The doc states plainly what these are **not**: one connection per request, sequential, single-threaded, loopback — a per-request latency floor and a single-client ceiling, never a capacity claim. The 16-worker pool is never exercised in parallel. The TLS rate includes `openssl` process spawn, which dominates it, so it's a conservative floor and a regression signal rather than a measure of the C crypto code.

## Two bugs I wrote and then found

Worth naming, because they're the failure mode this project keeps hitting — code that looks right and cannot work:

1. `REQ="$(printf 'GET ...\r\n\r\n')"` — command substitution **strips trailing newlines**, eating the blank line that terminates the header block. The server correctly waited for more headers until its deadline, so every "handshake" timed out at 10 s. Now piped from `printf` directly, the way `interop_openssl.sh` does it.
2. No `timeout` wrapper, and `grep -q` in the pipeline exits on first match, closing the pipe under a client that doesn't reliably die on SIGPIPE. Both fixed.

## Deliberately not ctest suites

These are measurement tools, not correctness gates. `TlsInteropOpenssl` already gates handshake correctness, and an ungated performance number in CI is log noise that also costs wall time #131 just removed. Performance *gating* needs a threshold policy and a stable runner — a separate decision, not a side effect of this tooling.

## Gaps it does not close

Listed in the doc rather than left implied: no concurrency benchmark (the most useful missing number), no keep-alive benchmark, async mode unmeasurable by a single-process runner (`listen()` never returns), and no stored trend to catch slow drift.

## Verification

| Check | Result |
|---|---|
| Default build | 6/6 suites, 0 warnings |
| TLS build | 13/13 suites, 0 warnings |
| `benchmark_server` under macOS `leaks` | 0 leaks, 0 bytes |
| Both tools | run end to end, output above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)