### PR TITLE
release: v2.0.1

### DIFF
--- a/ACHIEVEMENTS.md
+++ b/ACHIEVEMENTS.md
@@ -2,7 +2,7 @@
 
 **Modern C Web Library** - A Pure C Web Framework
 
-*Last Updated: July 2026 (v2.0.0)*
+*Last Updated: July 2026 (v2.0.1)*
 
 ---
 
@@ -429,7 +429,7 @@ The Modern C Web Library has successfully achieved its core mission: **proving t
 
 With a 100% test pass rate, zero security warnings, comprehensive tooling, and a clear roadmap, the project is positioned for growth as both an educational resource and — for plain-HTTP workloads — a production-ready framework.
 
-**Status**: v2.0.0 released — the plain-HTTP core is production-ready for deployment, with comprehensive tutorials and documentation. The new TLS 1.3 layer is experimental and unaudited, ships off by default, and should not be deployed until it has had an external cryptographic audit.
+**Status**: v2.0.1 released — the plain-HTTP core is production-ready for deployment, with comprehensive tutorials and documentation. The new TLS 1.3 layer is experimental and unaudited, ships off by default, and should not be deployed until it has had an external cryptographic audit.
 
 ---
 
@@ -442,4 +442,4 @@ With a 100% test pass rate, zero security warnings, comprehensive tooling, and a
 - **Contributing**: See CONTRIBUTING.md for development guidelines
 - **Author**: Kamran Khan
 
-*This document represents the technical achievements and business value of the Modern C Web Library project as of the v2.0.0 release (July 2026).*
+*This document represents the technical achievements and business value of the Modern C Web Library project as of the v2.0.1 release (July 2026).*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [2.0.1] - 2026-07-28
+
+A maintenance release. No library API change — the fixes are in CI, the test
+suite and the examples. Notably, this is the first release in which the Valgrind
+leak gate actually gates.
+
 ### Fixed
 
 - **`examples/worker_example.c` now defines the Worker lifecycle exports**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(ModernCWebLibrary VERSION 2.0.0 LANGUAGES C)
+project(ModernCWebLibrary VERSION 2.0.1 LANGUAGES C)
 
 # Set C standard
 set(CMAKE_C_STANDARD 11)

--- a/DOCKER_PACKAGE.md
+++ b/DOCKER_PACKAGE.md
@@ -39,16 +39,16 @@ docker run -d -p 8080:8080 --name weblib ghcr.io/kamrankhan78694/modern-c-web-li
 
 ## Available Images
 
-- `latest` - Latest stable release (currently 2.0.0)
-- `2.0.0` - Exact release version
+- `latest` - Latest stable release (currently 2.0.1)
+- `2.0.1` - Exact release version
 - `2.0` - Major.minor version
 - `2` - Major version only
 
-The tags CI publishes carry **no `v` prefix**: `.github/workflows/docker-publish.yml` uses `docker/metadata-action` with `type=semver,pattern={{version}}`, which strips the `v` from the git tag. Pull `...:2.0.0`, not `...:v2.0.0` — the latter is not a tag CI creates, and will normally come back as `manifest unknown`. (The older `publish-package.sh` helper does push a `v`-prefixed tag, so a stale `v`-prefixed tag may still linger in the registry; see [PUBLISH_GUIDE.md](PUBLISH_GUIDE.md).)
+The tags CI publishes carry **no `v` prefix**: `.github/workflows/docker-publish.yml` uses `docker/metadata-action` with `type=semver,pattern={{version}}`, which strips the `v` from the git tag. Pull `...:2.0.1`, not `...:v2.0.1` — the latter is not a tag CI creates, and will normally come back as `manifest unknown`. (The older `publish-package.sh` helper does push a `v`-prefixed tag, so a stale `v`-prefixed tag may still linger in the registry; see [PUBLISH_GUIDE.md](PUBLISH_GUIDE.md).)
 
 ## Features
 
-### What's in the Image (2.0.0)
+### What's in the Image (2.0.1)
 
 ✅ **WebSocket Support** (RFC 6455)
 - Automatic ping/pong handling
@@ -184,7 +184,8 @@ The repository has no published throughput or latency benchmarks. If numbers mat
 
 ## Version History
 
-- **v2.0.0** (2026-07-27) - Current release
+- **v2.0.1** (2026-07-28) - Current release
+- **v2.0.0** (2026-07-27) - Pure-C TLS 1.3, WASM & Workers, security hardening
 - **v1.0.0** (2026-02-22) - First stable release
 - **v0.9.0** (2026-02-20) - Performance and observability (cache, metrics, gzip, async WebSocket)
 - **v0.3.0** (2025-11-14) - WebSocket frame processing (threaded mode)

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -9,7 +9,7 @@ FROM gcc:11 AS builder
 
 LABEL org.opencontainers.image.source="https://github.com/kamrankhan78694/modern-c-web-library"
 LABEL org.opencontainers.image.description="Modern C Web Library - Production-ready HTTP and WebSocket server"
-LABEL org.opencontainers.image.version="2.0.0"
+LABEL org.opencontainers.image.version="2.0.1"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Install build dependencies
@@ -38,7 +38,7 @@ FROM debian:bullseye-slim
 
 LABEL org.opencontainers.image.source="https://github.com/kamrankhan78694/modern-c-web-library"
 LABEL org.opencontainers.image.description="Modern C Web Library - Production-ready HTTP and WebSocket server"
-LABEL org.opencontainers.image.version="2.0.0"
+LABEL org.opencontainers.image.version="2.0.1"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Install only runtime dependencies

--- a/PUBLISH_GUIDE.md
+++ b/PUBLISH_GUIDE.md
@@ -21,7 +21,7 @@ The workflow is already set up! It will run automatically when you:
 
 **This is the easiest method!** ⭐
 
-> **A manual run does not produce a version tag.** The `type=semver` patterns in `docker-publish.yml` only fire on a tag ref, so a `workflow_dispatch` run from `main` pushes `main`, `sha-<sha>` and `latest` — but no `2.0.0` / `2.0` / `2`. Push the `v2.0.0` git tag (or publish the GitHub release) when you want the versioned tags.
+> **A manual run does not produce a version tag.** The `type=semver` patterns in `docker-publish.yml` only fire on a tag ref, so a `workflow_dispatch` run from `main` pushes `main`, `sha-<sha>` and `latest` — but no `2.0.0` / `2.0` / `2`. Push the `v2.0.1` git tag (or publish the GitHub release) when you want the versioned tags.
 
 ---
 
@@ -34,7 +34,7 @@ If you have Docker running locally:
 open -a Docker  # macOS
 
 # Then run the publish script
-./publish-package.sh 2.0.0
+./publish-package.sh 2.0.1
 ```
 
 You'll need a GitHub Personal Access Token with `write:packages` permission:
@@ -55,7 +55,7 @@ open -a Docker  # macOS
 
 # 2. Build the image (tags are unprefixed, matching what CI publishes)
 docker build -f Dockerfile.release \
-  -t ghcr.io/kamrankhan78694/modern-c-web-library:2.0.0 \
+  -t ghcr.io/kamrankhan78694/modern-c-web-library:2.0.1 \
   -t ghcr.io/kamrankhan78694/modern-c-web-library:latest \
   .
 
@@ -63,11 +63,11 @@ docker build -f Dockerfile.release \
 echo $GITHUB_TOKEN | docker login ghcr.io -u kamrankhan78694 --password-stdin
 
 # 4. Push the images
-docker push ghcr.io/kamrankhan78694/modern-c-web-library:2.0.0
+docker push ghcr.io/kamrankhan78694/modern-c-web-library:2.0.1
 docker push ghcr.io/kamrankhan78694/modern-c-web-library:latest
 ```
 
-Keep the version in step 2 in sync with `CMakeLists.txt`, `include/kamran.k` and the `org.opencontainers.image.version` labels in `Dockerfile.release` (currently `2.0.0`).
+Keep the version in step 2 in sync with `CMakeLists.txt`, `include/kamran.k` and the `org.opencontainers.image.version` labels in `Dockerfile.release` (currently `2.0.1`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Release](https://img.shields.io/github/v/release/kamrankhan78694/modern-c-web-library)](https://github.com/kamrankhan78694/modern-c-web-library/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> **Version 2.0.0** — pure C web framework with zero external dependencies. The HTTP,
+> **Version 2.0.1** — pure C web framework with zero external dependencies. The HTTP,
 > WebSocket, and middleware stack is stable; the new pure-C TLS 1.3
 > server that ships in 2.0.0 is **experimental and unaudited** — see
 > [TLS 1.3 / HTTPS](#experimental-tls-13--https-off-by-default).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Modern C Web Library Documentation
 
-**Version 2.0.0**  
+**Version 2.0.1**  
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18793559.svg)](https://doi.org/10.5281/zenodo.18793559)
 
 Welcome to the documentation for Modern C Web Library, a pure C web framework with zero external dependencies.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -67,8 +67,9 @@ Compile-time macros and their runtime accessors. Use the encoded number for
 #define WEBLIB_VERSION_PATCH 1
 #define WEBLIB_VERSION       "2.0.1"
 
-/* "weblib/2.0.1 (author:kamran)" — sent as the Server header on every response */
-#define WEBLIB_VERSION_STRING
+/* Sent as the Server header on every response, e.g. "weblib/2.0.1 (author:kamran)" */
+#define WEBLIB_VERSION_STRING \
+    "weblib/" WEBLIB_VERSION " (author:" WEBLIB_AUTHOR_KAMRAN ")"
 
 /* Encode a triplet for comparison: WEBLIB_VERSION_ENCODE(1, 2, 3) → 10203 */
 #define WEBLIB_VERSION_ENCODE(major, minor, patch)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,6 +1,6 @@
 # Modern C Web Library - API Reference
 
-**Version 2.0.0**
+**Version 2.0.1**
 
 This is the API reference for the Modern C Web Library: the public surface declared
 in `include/kamran.k`, plus the pooled-database API in `include/db_pool.h`. Every
@@ -64,17 +64,17 @@ Compile-time macros and their runtime accessors. Use the encoded number for
 ```c
 #define WEBLIB_VERSION_MAJOR 2
 #define WEBLIB_VERSION_MINOR 0
-#define WEBLIB_VERSION_PATCH 0
-#define WEBLIB_VERSION       "2.0.0"
+#define WEBLIB_VERSION_PATCH 1
+#define WEBLIB_VERSION       "2.0.1"
 
-/* "weblib/2.0.0 (author:kamran)" — sent as the Server header on every response */
+/* "weblib/2.0.1 (author:kamran)" — sent as the Server header on every response */
 #define WEBLIB_VERSION_STRING
 
 /* Encode a triplet for comparison: WEBLIB_VERSION_ENCODE(1, 2, 3) → 10203 */
 #define WEBLIB_VERSION_ENCODE(major, minor, patch)
 #define WEBLIB_VERSION_NUMBER   /* the current version, encoded */
 
-const char *weblib_version(void);            // "2.0.0"
+const char *weblib_version(void);            // "2.0.1"
 const char *weblib_kamran_signature(void);   // Server header string
 void weblib_version_components(int *major, int *minor, int *patch);
 ```

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Modern C Web Library
 
-**Version 2.0.0**
+**Version 2.0.1**
 
 Welcome to the Modern C Web Library! This tutorial walks you from an empty directory
 to a running HTTP server, a JSON API, middleware, and — at the end — an experimental

--- a/docs/tutorials/rest-api.md
+++ b/docs/tutorials/rest-api.md
@@ -1,6 +1,6 @@
 # Building a REST API with Modern C Web Library
 
-**Version 2.0.0**
+**Version 2.0.1**
 
 ## Introduction
 

--- a/docs/tutorials/websocket.md
+++ b/docs/tutorials/websocket.md
@@ -1,6 +1,6 @@
 # Real-Time Applications with WebSocket
 
-**Version 2.0.0**
+**Version 2.0.1**
 
 ## Introduction
 

--- a/include/kamran.k
+++ b/include/kamran.k
@@ -34,10 +34,10 @@ extern "C" {
  */
 #define WEBLIB_VERSION_MAJOR 2
 #define WEBLIB_VERSION_MINOR 0
-#define WEBLIB_VERSION_PATCH 0
+#define WEBLIB_VERSION_PATCH 1
 
 /** Full version string in "MAJOR.MINOR.PATCH" form. */
-#define WEBLIB_VERSION "2.0.0"
+#define WEBLIB_VERSION "2.0.1"
 
 /** Server identity string embedded in HTTP Server header. */
 #define WEBLIB_VERSION_STRING "weblib/" WEBLIB_VERSION " (author:" WEBLIB_AUTHOR_KAMRAN ")"
@@ -60,7 +60,7 @@ extern "C" {
 const char *weblib_kamran_signature(void);
 
 /**
- * Return the library version string (e.g. "2.0.0").
+ * Return the library version string (e.g. "2.0.1").
  */
 const char *weblib_version(void);
 

--- a/publish-package.sh
+++ b/publish-package.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION=${1:-"2.0.0"}
+VERSION=${1:-"2.0.1"}
 REGISTRY="ghcr.io"
 IMAGE_NAME="kamrankhan78694/modern-c-web-library"
 FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"


### PR DESCRIPTION
## Context: 2.0.0 was never actually released

The tree declared `2.0.0` and `CHANGELOG.md` dated it `2026-07-27` — but **no `v2.0.0` tag and no GitHub release existed**. The latest published release was still v1.0.0 from February, with 280 commits and 79 merges of unreleased work behind it. Anyone reading the CHANGELOG believed 2.0.0 had shipped.

[v2.0.0 is now tagged](https://github.com/kamrankhan78694/modern-c-web-library/releases/tag/v2.0.0) retroactively at `ba15537` — the commit that declared it — so its contents and date match the `[2.0.0]` entry exactly.

## What this release contains

Everything that landed *after* that tag:

- **[#131](https://github.com/kamrankhan78694/modern-c-web-library/pull/131)** — the Valgrind gate that reported every binary but only *gated* on the last one, the 25 `cache_get()` leaks it had been hiding, and CI wall time halved (~6.5 → ~3.0 min)
- **[#132](https://github.com/kamrankhan78694/modern-c-web-library/pull/132)** — the Worker lifecycle exports `worker.js` had always called but the example never defined, plus a 32-byte leak it had carried from the start

## Why PATCH, not MINOR

No public API changed. `include/kamran.k` gains no declaration — every fix is in CI, the test suite, or the examples.

The one behavioural change a user could observe is `examples/simple_server` reporting the real version instead of a hardcoded `"1.0.0"` — a bug fix, not a feature.

## Version sites

Enumerated rather than grepped for one pattern, since that failure mode has bitten this repo repeatedly:

| Site | |
|---|---|
| `CMakeLists.txt` | `project(... VERSION 2.0.1)` |
| `include/kamran.k` | `MAJOR`/`MINOR`/`PATCH` macros, version string, doc-comment example |
| `Dockerfile.release` | both `org.opencontainers.image.version` LABELs |
| `publish-package.sh` | CLI default |
| markdown banners | 6 files |

## Verification

| Check | Result |
|---|---|
| Default build | 6/6 suites, 0 warnings |
| TLS build | 13/13 suites, 0 warnings |
| `test_kamran_header` | reports 2.0.1, semver self-test passes |
| `simple_server` at runtime | `{"status":"success","version":"2.0.1",...}` |

Note [#133](https://github.com/kamrankhan78694/modern-c-web-library/pull/133) (benchmarks) is deliberately **not** in this release and will go into the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)