### PR TITLE
release: v2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,9 +239,21 @@ jobs:
       - name: Run tests
         run: cd build && ctest --output-on-failure --timeout 120
 
-  # Production Docker image — validates that the release image builds
-  # and contains working executables.  Only runs when Dockerfiles or
-  # source code change (skipped for docs-only / CI-only edits).
+  # Production Docker image — validates that the RELEASE image builds and
+  # contains working executables.
+  #
+  # It must build Dockerfile.release, not Dockerfile: the published image comes
+  # from Dockerfile.release (docker-publish.yml), and the two differ materially
+  # — the release file builds -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF,
+  # ships websocket_echo_server (its default entrypoint), drops privileges to a
+  # non-root user and carries the version LABELs. Pointing this job at the plain
+  # Dockerfile meant a green "Production Docker Image" check proved nothing
+  # about the artifact being released: the first build of Dockerfile.release
+  # happened inside the publish workflow, after the tag was already pushed.
+  #
+  # This job runs on every push and PR. An earlier comment here claimed it was
+  # path-filtered to Dockerfile/source changes, but no `paths:` filter or `if:`
+  # ever existed to implement that.
   docker-image-check:
     name: Production Docker Image
     runs-on: ubuntu-latest
@@ -259,7 +271,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile.release
           load: true
           tags: modern-c-weblib:latest
           cache-from: type=gha
@@ -267,8 +279,24 @@ jobs:
 
       - name: Verify production image
         run: |
+          # websocket_echo_server is included deliberately: it is the release
+          # image's default entrypoint, and the old check (which built the plain
+          # Dockerfile) never looked for it.
           docker run --rm modern-c-weblib:latest /bin/bash -c '
-            echo "Checking simple_server..." && test -x /app/simple_server && echo "  OK" &&
-            echo "Checking async_server..."  && test -x /app/async_server  && echo "  OK" &&
+            echo "Checking simple_server..."         && test -x /app/simple_server         && echo "  OK" &&
+            echo "Checking async_server..."          && test -x /app/async_server          && echo "  OK" &&
+            echo "Checking websocket_echo_server..." && test -x /app/websocket_echo_server && echo "  OK" &&
             echo "Production image verified successfully"
           '
+
+      - name: Verify the image version LABEL matches CMakeLists.txt
+        run: |
+          # The release image carries org.opencontainers.image.version. It went
+          # stale before (DOCKER_PACKAGE.md shipped a 2.0.0 badge through two
+          # releases), so bind it to the build files rather than to review.
+          want="$(sed -n 's/^project(.*VERSION \([0-9][0-9.]*\).*/\1/p' CMakeLists.txt | head -1)"
+          got="$(docker image inspect modern-c-weblib:latest \
+                 --format '{{ index .Config.Labels "org.opencontainers.image.version" }}')"
+          echo "CMakeLists.txt: $want / image LABEL: $got"
+          test -n "$want" || { echo "could not read version from CMakeLists.txt"; exit 1; }
+          test "$want" = "$got" || { echo "image version LABEL disagrees with CMakeLists.txt"; exit 1; }

--- a/ACHIEVEMENTS.md
+++ b/ACHIEVEMENTS.md
@@ -2,7 +2,7 @@
 
 **Modern C Web Library** - A Pure C Web Framework
 
-*Last Updated: July 2026 (v2.0.1)*
+*Last Updated: July 2026 (v2.1.0)*
 
 ---
 
@@ -430,7 +430,7 @@ The Modern C Web Library has successfully achieved its core mission: **proving t
 
 With a 100% test pass rate, zero security warnings, comprehensive tooling, and a clear roadmap, the project is positioned for growth as both an educational resource and — for plain-HTTP workloads — a production-ready framework.
 
-**Status**: v2.0.1 released — the plain-HTTP core is production-ready for deployment, with comprehensive tutorials and documentation. The new TLS 1.3 layer is experimental and unaudited, ships off by default, and should not be deployed until it has had an external cryptographic audit.
+**Status**: v2.1.0 released — the plain-HTTP core is production-ready for deployment, with comprehensive tutorials and documentation. The new TLS 1.3 layer is experimental and unaudited, ships off by default, and should not be deployed until it has had an external cryptographic audit.
 
 ---
 
@@ -443,4 +443,4 @@ With a 100% test pass rate, zero security warnings, comprehensive tooling, and a
 - **Contributing**: See CONTRIBUTING.md for development guidelines
 - **Author**: Kamran Khan
 
-*This document represents the technical achievements and business value of the Modern C Web Library project as of the v2.0.1 release (July 2026).*
+*This document represents the technical achievements and business value of the Modern C Web Library project as of the v2.1.0 release (July 2026).*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [2.1.0] - 2026-07-29
+
+A dev server drove this release: running the library in a browser surfaced wiring
+defects that 166 unit tests, Valgrind and ASan had all missed, and fixing them
+produced a post-handler router phase, an end-to-end test suite, four bug fixes
+with regression coverage, and five new public APIs. Additive only — no breaking
+changes; the one observable behaviour change is `send_text` replacing (not
+appending) `Content-Type`, which no correct caller could have relied on.
+
 ### Added
 
 - **`http_response_send_html()`** — sends with `Content-Type: text/html;
@@ -259,6 +270,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI's "Production Docker Image" job now builds the image that is actually
+  released.** It built `./Dockerfile`, while the published image comes from
+  `./Dockerfile.release` — so a green check proved nothing about the release
+  artifact, and the first build of `Dockerfile.release` happened inside the
+  publish workflow, *after* the tag was pushed. The two differ materially
+  (`-DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF`, the `websocket_echo_server`
+  entrypoint, a non-root user, the version LABELs). The verify step now also
+  checks `websocket_echo_server`, which the old one never looked for, and a new
+  step asserts the image's `org.opencontainers.image.version` LABEL equals the
+  version in `CMakeLists.txt`. A comment claiming the job was path-filtered to
+  Dockerfile/source changes was removed: no `paths:` filter or `if:` ever
+  implemented it.
+- **`tools/check-consistency.sh` checks present-tense version claims in
+  markdown (check [6]).** Check [1] binds the four *build* files to
+  `CMakeLists.txt`, and the script's own header cites `"currently 2.0.0" in
+  DOCKER_PACKAGE.md` as a motivating failure — yet that file's version **badge**
+  then shipped `2.0.0` through both 2.0.1 and 2.1.0, because nothing ever read
+  markdown. The instance named in review was fixed; the class was not. The new
+  check caught six more stale claims a manual sweep for this release had missed,
+  including `**Version 2.0.1**` banners in `docs/api/README.md` and all three
+  tutorials. It matches only forms that can only mean "this is current" (a
+  shields.io version badge, a release-tag badge link, `currently X.Y.Z`, a
+  `**Version X.Y.Z**` banner), and strips backticked and double-quoted spans
+  first — its first run flagged a *correct* line that quotes the historical bad
+  strings while explaining this exact failure, and a checker that cries wolf
+  gets disabled. Verified to fail on a reintroduced stale badge.
 - **The examples wire metrics with `metrics_register()` alone.** Adding the
   middleware as well is supported and does not double-count, but it counts the
   total on the way *in*, so a `/metrics` scrape includes itself in
@@ -994,7 +1031,9 @@ All planned phases (4-10) are complete with comprehensive documentation and tuto
 - **0.2.x**: WebSocket support (RFC 6455 compliant)
 - **0.1.x**: Initial HTTP server implementation with event loop
 
-[Unreleased]: https://github.com/kamrankhan78694/modern-c-web-library/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/kamrankhan78694/modern-c-web-library/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/kamrankhan78694/modern-c-web-library/compare/v2.0.1...v2.1.0
+[2.0.1]: https://github.com/kamrankhan78694/modern-c-web-library/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/kamrankhan78694/modern-c-web-library/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/kamrankhan78694/modern-c-web-library/compare/v0.9.0...v1.0.0
 [0.9.0]: https://github.com/kamrankhan78694/modern-c-web-library/compare/v0.8.0...v0.9.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(ModernCWebLibrary VERSION 2.0.1 LANGUAGES C)
+project(ModernCWebLibrary VERSION 2.1.0 LANGUAGES C)
 
 # Set C standard
 set(CMAKE_C_STANDARD 11)

--- a/DOCKER_PACKAGE.md
+++ b/DOCKER_PACKAGE.md
@@ -1,7 +1,7 @@
 # Modern C Web Library - Docker Package
 
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue)](https://github.com/kamrankhan78694/modern-c-web-library/pkgs/container/modern-c-web-library)
-[![Version](https://img.shields.io/badge/version-2.0.0-green)](https://github.com/kamrankhan78694/modern-c-web-library/releases/tag/v2.0.0)
+[![Version](https://img.shields.io/badge/version-2.1.0-green)](https://github.com/kamrankhan78694/modern-c-web-library/releases/tag/v2.1.0)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 Docker image for the Modern C Web Library. It ships the project's three bundled example servers — a WebSocket echo server and two HTTP servers — built from `Dockerfile.release` with `-DCMAKE_BUILD_TYPE=Release`, running as a non-root user behind a health check. They are working demonstrations of the library rather than a finished application: use them to try it out, or as the starting point for your own binary.
@@ -39,16 +39,16 @@ docker run -d -p 8080:8080 --name weblib ghcr.io/kamrankhan78694/modern-c-web-li
 
 ## Available Images
 
-- `latest` - Latest stable release (currently 2.0.1)
-- `2.0.1` - Exact release version
-- `2.0` - Major.minor version
+- `latest` - Latest stable release (currently 2.1.0)
+- `2.1.0` - Exact release version
+- `2.1` - Major.minor version
 - `2` - Major version only
 
-The tags CI publishes carry **no `v` prefix**: `.github/workflows/docker-publish.yml` uses `docker/metadata-action` with `type=semver,pattern={{version}}`, which strips the `v` from the git tag. Pull `...:2.0.1`, not `...:v2.0.1` — the latter is not a tag CI creates, and will normally come back as `manifest unknown`. (The older `publish-package.sh` helper does push a `v`-prefixed tag, so a stale `v`-prefixed tag may still linger in the registry; see [PUBLISH_GUIDE.md](PUBLISH_GUIDE.md).)
+The tags CI publishes carry **no `v` prefix**: `.github/workflows/docker-publish.yml` uses `docker/metadata-action` with `type=semver,pattern={{version}}`, which strips the `v` from the git tag. Pull `...:2.1.0`, not `...:v2.1.0` — the latter is not a tag CI creates, and will normally come back as `manifest unknown`. (The older `publish-package.sh` helper does push a `v`-prefixed tag, so a stale `v`-prefixed tag may still linger in the registry; see [PUBLISH_GUIDE.md](PUBLISH_GUIDE.md).)
 
 ## Features
 
-### What's in the Image (2.0.1)
+### What's in the Image (2.1.0)
 
 ✅ **WebSocket Support** (RFC 6455)
 - Automatic ping/pong handling
@@ -184,7 +184,8 @@ The repository has no published throughput or latency benchmarks. If numbers mat
 
 ## Version History
 
-- **v2.0.1** (2026-07-28) - Current release
+- **v2.1.0** (2026-07-29) - Current release — response hooks (#136), HEAD per RFC 9110, dev server + end-to-end suite, BUG-11..14 fixed
+- **v2.0.1** (2026-07-28) - Maintenance: CI, test suite and examples; first release where the Valgrind gate gates
 - **v2.0.0** (2026-07-27) - Pure-C TLS 1.3, WASM & Workers, security hardening
 - **v1.0.0** (2026-02-22) - First stable release
 - **v0.9.0** (2026-02-20) - Performance and observability (cache, metrics, gzip, async WebSocket)

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -9,7 +9,7 @@ FROM gcc:11 AS builder
 
 LABEL org.opencontainers.image.source="https://github.com/kamrankhan78694/modern-c-web-library"
 LABEL org.opencontainers.image.description="Modern C Web Library - Production-ready HTTP and WebSocket server"
-LABEL org.opencontainers.image.version="2.0.1"
+LABEL org.opencontainers.image.version="2.1.0"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Install build dependencies
@@ -38,7 +38,7 @@ FROM debian:bullseye-slim
 
 LABEL org.opencontainers.image.source="https://github.com/kamrankhan78694/modern-c-web-library"
 LABEL org.opencontainers.image.description="Modern C Web Library - Production-ready HTTP and WebSocket server"
-LABEL org.opencontainers.image.version="2.0.1"
+LABEL org.opencontainers.image.version="2.1.0"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Install only runtime dependencies

--- a/NEXT_PHASE.md
+++ b/NEXT_PHASE.md
@@ -183,7 +183,7 @@ Phase 12 — DELIVERED in v2.0.0 (planned as v1.2.0): TLS 1.3 Handshake & HTTPS
    └── [ ] Browser page-load — NOT achieved; Ed25519-only server certs have limited and
            inconsistent browser support. See Phase 21.
 
-Phase 13 (v2.1.0): HTTP/2 Protocol
+Phase 13 (v2.2.0): HTTP/2 Protocol
    ├── Binary framing layer (RFC 7540)
    ├── HPACK header compression (RFC 7541, static table)
    ├── Stream multiplexing with priority
@@ -192,7 +192,7 @@ Phase 13 (v2.1.0): HTTP/2 Protocol
    ├── `http_server_enable_http2()` API
    └── h2 + h2c (cleartext) support
 
-Phase 14 (v2.2.0): Persistent Storage Engine
+Phase 14 (v2.3.0): Persistent Storage Engine
    ├── B-tree key-value store (on-disk, memory-mapped)
    ├── Write-ahead log (WAL) for crash recovery
    ├── Transaction support (begin/commit/rollback)
@@ -201,7 +201,7 @@ Phase 14 (v2.2.0): Persistent Storage Engine
    ├── `storage_open()` / `storage_close()` lifecycle
    └── Integration with session store + cache persistence
 
-Phase 15 (v2.3.0): Advanced Middleware & Content
+Phase 15 (v2.4.0): Advanced Middleware & Content
    ├── Directory listing (auto-generated HTML indexes)
    ├── Server-Sent Events (SSE) for streaming
    ├── Content negotiation (Accept header parsing)
@@ -210,7 +210,7 @@ Phase 15 (v2.3.0): Advanced Middleware & Content
    ├── Regex-based route matching
    └── ETag generation improvements (weak/strong)
 
-Phase 16 (v2.4.0): Multi-Process Architecture
+Phase 16 (v2.5.0): Multi-Process Architecture
    ├── Master-worker process model (fork-based)
    ├── Worker supervision and auto-restart
    ├── SO_REUSEPORT per-worker accept
@@ -219,7 +219,7 @@ Phase 16 (v2.4.0): Multi-Process Architecture
    ├── `http_server_set_workers(n)` API
    └── Per-worker metrics aggregation
 
-Phase 17 (v2.5.0): Cross-Platform Hardening
+Phase 17 (v2.6.0): Cross-Platform Hardening
    ├── Platform abstraction layer (`src/platform.h`)
    ├── Windows IOCP event loop backend
    ├── Windows named pipes for IPC
@@ -228,7 +228,7 @@ Phase 17 (v2.5.0): Cross-Platform Hardening
    ├── CI matrix: Linux (GCC/Clang) + macOS (Clang) + Windows (MSVC) + FreeBSD
    └── Platform compatibility documentation
 
-Phase 18 (v2.6.0): Developer Experience & Configuration
+Phase 18 (v2.7.0): Developer Experience & Configuration
    ├── INI configuration file parser
    ├── Plugin/extension architecture (compile-time modules)
    ├── Multiple template formats (Mustache-style, includes, inheritance)
@@ -237,7 +237,7 @@ Phase 18 (v2.6.0): Developer Experience & Configuration
    ├── API versioning support (URL prefix + header-based)
    └── Configuration validation and hot-reload
 
-Phase 19 (v2.7.0): HTTP/3 & QUIC
+Phase 19 (v2.8.0): HTTP/3 & QUIC
    ├── UDP socket layer
    ├── QUIC transport protocol (RFC 9000)
    ├── QUIC handshake (integrates Phase 11-12 TLS 1.3)
@@ -312,7 +312,7 @@ Phase 21 (unscheduled): Security Residuals & TLS Hardening
 with them browser interop), SNI, session resumption, client mode, async-mode TLS, WebSocket-over-TLS,
 external audit.
 
-### Phase 13: HTTP/2 Protocol — v2.1.0 (5 weeks)
+### Phase 13: HTTP/2 Protocol — v2.2.0 (5 weeks)
 
 | Week | Milestone | Deliverables | Dependencies |
 |------|-----------|-------------|--------------|
@@ -322,7 +322,7 @@ external audit.
 | **W16** | HTTP/2 Server Integration | `http_server_enable_http2()` API; connection preface handling; settings negotiation; integration with existing router; server push API; h2c upgrade support | W13–W15, Phase 12 (ALPN) |
 | **W17** | HTTP/2 Testing | `curl --http2` validation; multiplexed request tests; flow control tests; HPACK bomb protection; 50+ HTTP/2 unit tests; performance comparison vs HTTP/1.1 | W13–W16 |
 
-### Phase 14: Persistent Storage Engine — v2.2.0 (5 weeks)
+### Phase 14: Persistent Storage Engine — v2.3.0 (5 weeks)
 
 | Week | Milestone | Deliverables | Dependencies |
 |------|-----------|-------------|--------------|
@@ -332,7 +332,7 @@ external audit.
 | **W21** | Iterator & Query Interface | `storage_iterator_t` — forward/reverse iteration; range queries (start_key, end_key); prefix scan; cursor-based pagination | W18 |
 | **W22** | Integration & Persistence APIs | `storage_open(path)` / `storage_close()` lifecycle; `storage_get()` / `storage_put()` / `storage_delete()`; session store backend; cache persistence backend; 40+ storage tests | W18–W21 |
 
-### Phase 15: Advanced Middleware & Content — v2.3.0 (4 weeks)
+### Phase 15: Advanced Middleware & Content — v2.4.0 (4 weeks)
 
 | Week | Milestone | Deliverables | Dependencies |
 |------|-----------|-------------|--------------|
@@ -341,7 +341,7 @@ external audit.
 | **W25** | Route Groups & Regex Routes | `router_group_create(prefix)` — scoped middleware per group; `router_add_regex_route()` — POSIX `regcomp()`/`regexec()` based pattern matching; named captures | None |
 | **W26** | Testing & Integration | 30+ middleware tests; SSE example (`examples/sse_server.c`); directory listing example; streaming upload example; backward-compatible with existing router API | W23–W25 |
 
-### Phase 16: Multi-Process Architecture — v2.4.0 (5 weeks)
+### Phase 16: Multi-Process Architecture — v2.5.0 (5 weeks)
 
 | Week | Milestone | Deliverables | Dependencies |
 |------|-----------|-------------|--------------|
@@ -351,7 +351,7 @@ external audit.
 | **W30** | Metrics Aggregation | Per-worker metrics collection; master aggregates via shared memory or pipe; `/metrics` endpoint serves combined JSON; worker health monitoring | W27, Phase 9 (metrics) |
 | **W31** | Testing & Stabilization | `http_server_set_workers(n)` API; multi-worker stress tests (10 workers, 10K requests); graceful shutdown of all workers; Valgrind on single-worker mode; 25+ worker tests | W27–W30 |
 
-### Phase 17: Cross-Platform Hardening — v2.5.0 (4 weeks)
+### Phase 17: Cross-Platform Hardening — v2.6.0 (4 weeks)
 
 | Week | Milestone | Deliverables | Dependencies |
 |------|-----------|-------------|--------------|
@@ -360,7 +360,7 @@ external audit.
 | **W34** | BSD & CI Matrix | FreeBSD/OpenBSD CI runners (or cross-compilation); BSD-specific `kqueue` flags; `arc4random_buf()` for random bytes; platform compatibility matrix documentation | W32 |
 | **W35** | MSVC Build & Testing | CMake MSVC generator support; `#pragma` warning suppression mapping; Windows-specific test adaptations; end-to-end CI: Linux (GCC/Clang) + macOS (Clang) + Windows (MSVC) + FreeBSD | W32–W34 |
 
-### Phase 18: Developer Experience & Configuration — v2.6.0 (5 weeks)
+### Phase 18: Developer Experience & Configuration — v2.7.0 (5 weeks)
 
 | Week | Milestone | Deliverables | Dependencies |
 |------|-----------|-------------|--------------|
@@ -370,7 +370,7 @@ external audit.
 | **W39** | Debug Mode & API Versioning | `http_server_set_debug(true)` — verbose request/response logging with headers, timing per middleware, memory allocation tracking; `router_version_group("v1", router_v1)` — URL-prefix and `Accept-Version` header-based API versioning | None |
 | **W40** | Testing & Documentation | 35+ developer experience tests; configuration example; plugin example; advanced template example; debug mode documentation; API versioning tutorial | W36–W39 |
 
-### Phase 19: HTTP/3 & QUIC — v2.7.0 (6 weeks)
+### Phase 19: HTTP/3 & QUIC — v2.8.0 (6 weeks)
 
 | Week | Milestone | Deliverables | Dependencies |
 |------|-----------|-------------|--------------|
@@ -1051,13 +1051,13 @@ the version column moved.
 |-------|-----------------|----------------|----------|-----------|-----------------|
 | Phase 11 | v1.1.0 | **✅ shipped in v2.0.0** | 6 weeks | W1–W6 | Crypto primitives — SHA-256/512, HMAC, HKDF, ChaCha20-Poly1305, X25519, Ed25519 (**no AES-GCM**) |
 | Phase 12 | v1.2.0 | **✅ shipped in v2.0.0** | 6 weeks | W7–W12 | TLS 1.3 **server** handshake + HTTPS — EXPERIMENTAL · UNAUDITED |
-| Phase 13 | v1.3.0 | v2.1.0 | 5 weeks | W13–W17 | HTTP/2 protocol (framing, HPACK, streams, push) |
-| Phase 14 | v1.4.0 | v2.2.0 | 5 weeks | W18–W22 | Persistent storage engine (B-tree, WAL, transactions) |
-| Phase 15 | v1.5.0 | v2.3.0 | 4 weeks | W23–W26 | Advanced middleware (directory listing, SSE, route groups) |
-| Phase 16 | v1.6.0 | v2.4.0 | 5 weeks | W27–W31 | Multi-process architecture (fork, reload, metrics) |
-| Phase 17 | v1.7.0 | v2.5.0 | 4 weeks | W32–W35 | Cross-platform (Windows IOCP, BSD, MSVC, CI matrix) |
-| Phase 18 | v1.8.0 | v2.6.0 | 5 weeks | W36–W40 | Developer experience (config, plugins, templates, debug) |
-| Phase 19 | v1.9.0 | v2.7.0 | 6 weeks | W41–W46 | HTTP/3 & QUIC (UDP, transport, handshake, streams) |
+| Phase 13 | v1.3.0 | v2.2.0 | 5 weeks | W13–W17 | HTTP/2 protocol (framing, HPACK, streams, push) |
+| Phase 14 | v1.4.0 | v2.3.0 | 5 weeks | W18–W22 | Persistent storage engine (B-tree, WAL, transactions) |
+| Phase 15 | v1.5.0 | v2.4.0 | 4 weeks | W23–W26 | Advanced middleware (directory listing, SSE, route groups) |
+| Phase 16 | v1.6.0 | v2.5.0 | 5 weeks | W27–W31 | Multi-process architecture (fork, reload, metrics) |
+| Phase 17 | v1.7.0 | v2.6.0 | 4 weeks | W32–W35 | Cross-platform (Windows IOCP, BSD, MSVC, CI matrix) |
+| Phase 18 | v1.8.0 | v2.7.0 | 5 weeks | W36–W40 | Developer experience (config, plugins, templates, debug) |
+| Phase 19 | v1.9.0 | v2.8.0 | 6 weeks | W41–W46 | HTTP/3 & QUIC (UDP, transport, handshake, streams) |
 | Phase 20 | v2.0.0 | v3.0.0 | 4 weeks | W47–W50 | Release engineering (CLI, observability, fuzz, release) |
 | Phase 21 | — (new) | unscheduled | 8 weeks | W51–W58 | Security residuals & TLS hardening — external audit, RSA/ECDSA certs, AES-GCM, async/WS TLS, resumption, client mode, PBKDF2, request-ID and IP-access middleware |
 | **Total** | | | **58 weeks** | | **W1–W12 delivered in v2.0.0 (2026-07-27); W13–W58 (~11 months) remain, re-baselined from that date** |
@@ -1093,18 +1093,19 @@ the version column moved.
 | 2.0 | 2026-02-19 | Complete rewrite for Phases 7–10: first-principles design, adversarial review, atomic task breakdown, security threat model |
 | 3.0 | 2026-03-02 | Phase 10.1 delivered (security utilities, headers middleware, secure secrets); Phase 11 planned (TLS, password hashing, HKDF, fuzz testing) |
 | 4.0 | 2026-07-27 | Roadmap re-baselined against shipped work for the **v2.0.0** release. WebAssembly/Emscripten and Cloudflare Workers (KV, R2, D1, Queues) targets shipped Apr 2026 — supersedes the "WebAssembly compilation target" non-goal in §2. Phases 11 and 12 delivered together in v2.0.0 as an experimental pure-C TLS 1.3 **server**: EXPERIMENTAL · UNAUDITED, native-only, threaded-mode only, OFF by default behind `WEBLIB_ENABLE_TLS`; `TLS_CHACHA20_POLY1305_SHA256` / X25519 / Ed25519 only; `http_server_enable_tls()`; `openssl s_client` interop, deterministic fuzzer, `tls-check` CI job with ASan/UBSan. Narrower than planned: no AES-GCM, no SHA-384, no RSA/ECDSA certificate verification, no client side, no session resumption, no SNI; manual checkpoint M1 (browser page-load) **not met**. That residual scope is carried forward as the new **Phase 21**, and the version targets for Phases 13–20 were re-baselined onto v2.1.0–v3.0.0. Note "4.0" is this *document's* revision number, not a project version |
+| 4.1 | 2026-07-29 | **v2.1.0 was consumed by an unplanned release** — the router response-hook phase (#136), the dev server + end-to-end suite, RFC 9110 HEAD handling, and BUG-11..14, all additive public API and therefore a semver MINOR. Phase content is unchanged; the targets for Phases 13–19 shift one minor to v2.2.0–v2.8.0 (Phase 20 keeps v3.0.0). Weeks and durations are unaffected |
 
 ---
 
 **Maintained by**: MCWL Core Team
-**Last Updated**: 2026-07-27
+**Last Updated**: 2026-07-29
 **Status**: Phases 11–12 delivered in **v2.0.0** — the hand-written pure-C **TLS 1.3 server**
 (server-side only; `TLS_CHACHA20_POLY1305_SHA256` + X25519 + Ed25519) is **EXPERIMENTAL · UNAUDITED**,
 opt-in via `-DWEBLIB_ENABLE_TLS=ON`, threaded-mode and native-only — see
 [`src/tls/README.md`](src/tls/README.md). Not for production without an external cryptographic audit.
 Still open from those phases (now **Phase 21**): external audit, RSA/ECDSA certificates and browser
 interop, AES-GCM, TLS in async mode, WebSocket over TLS, session resumption, SNI, client mode,
-PBKDF2 password hashing, request-ID and IP-access middleware. Next protocol phase: HTTP/2 (Phase 13, v2.1.0).
+PBKDF2 password hashing, request-ID and IP-access middleware. Next protocol phase: HTTP/2 (Phase 13, v2.2.0).
 **License**: MIT (see LICENSE file)
 
 For questions or discussions about this roadmap, please open an issue on GitHub or contact the maintainers.

--- a/PUBLISH_GUIDE.md
+++ b/PUBLISH_GUIDE.md
@@ -21,7 +21,7 @@ The workflow is already set up! It will run automatically when you:
 
 **This is the easiest method!** ⭐
 
-> **A manual run does not produce a version tag.** The `type=semver` patterns in `docker-publish.yml` only fire on a tag ref, so a `workflow_dispatch` run from `main` pushes `main`, `sha-<sha>` and `latest` — but no `2.0.0` / `2.0` / `2`. Push the `v2.0.1` git tag (or publish the GitHub release) when you want the versioned tags.
+> **A manual run does not produce a version tag.** The `type=semver` patterns in `docker-publish.yml` only fire on a tag ref, so a `workflow_dispatch` run from `main` pushes `main`, `sha-<sha>` and `latest` — but no `2.0.0` / `2.0` / `2`. Push the `v2.1.0` git tag (or publish the GitHub release) when you want the versioned tags.
 
 ---
 
@@ -34,7 +34,7 @@ If you have Docker running locally:
 open -a Docker  # macOS
 
 # Then run the publish script
-./publish-package.sh 2.0.1
+./publish-package.sh 2.1.0
 ```
 
 You'll need a GitHub Personal Access Token with `write:packages` permission:
@@ -55,7 +55,7 @@ open -a Docker  # macOS
 
 # 2. Build the image (tags are unprefixed, matching what CI publishes)
 docker build -f Dockerfile.release \
-  -t ghcr.io/kamrankhan78694/modern-c-web-library:2.0.1 \
+  -t ghcr.io/kamrankhan78694/modern-c-web-library:2.1.0 \
   -t ghcr.io/kamrankhan78694/modern-c-web-library:latest \
   .
 
@@ -63,11 +63,11 @@ docker build -f Dockerfile.release \
 echo $GITHUB_TOKEN | docker login ghcr.io -u kamrankhan78694 --password-stdin
 
 # 4. Push the images
-docker push ghcr.io/kamrankhan78694/modern-c-web-library:2.0.1
+docker push ghcr.io/kamrankhan78694/modern-c-web-library:2.1.0
 docker push ghcr.io/kamrankhan78694/modern-c-web-library:latest
 ```
 
-Keep the version in step 2 in sync with `CMakeLists.txt`, `include/kamran.k` and the `org.opencontainers.image.version` labels in `Dockerfile.release` (currently `2.0.1`).
+Keep the version in step 2 in sync with `CMakeLists.txt`, `include/kamran.k` and the `org.opencontainers.image.version` labels in `Dockerfile.release` (currently `2.1.0`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Release](https://img.shields.io/github/v/release/kamrankhan78694/modern-c-web-library)](https://github.com/kamrankhan78694/modern-c-web-library/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> **Version 2.0.1** — pure C web framework with zero external dependencies. The HTTP,
+> **Version 2.1.0** — pure C web framework with zero external dependencies. The HTTP,
 > WebSocket, and middleware stack is stable; the new pure-C TLS 1.3
 > server that ships in 2.0.0 is **experimental and unaudited** — see
 > [TLS 1.3 / HTTPS](#experimental-tls-13--https-off-by-default).

--- a/TODO.md
+++ b/TODO.md
@@ -55,7 +55,7 @@ This document tracks planned features, enhancements, and improvements for the Mo
     - [ ] ALPN `h2` — waits on Phase 13
     - [ ] TLS 1.2 fallback — currently rejected by design; reopening it would need a new decision record
 
-- [ ] 🔧 **HTTP/2 Support** - Implement HTTP/2 protocol *(Phase 13, v2.1.0)*
+- [ ] 🔧 **HTTP/2 Support** - Implement HTTP/2 protocol *(Phase 13, v2.2.0)*
   - Binary framing layer (RFC 7540, all 10 frame types)
   - HPACK header compression (RFC 7541, static + dynamic tables)
   - Stream multiplexing with priority and flow control
@@ -63,7 +63,7 @@ This document tracks planned features, enhancements, and improvements for the Mo
   - `http_server_enable_http2()` API
   - h2 (TLS) + h2c (cleartext) support
 
-- [ ] 💡 **HTTP/3 / QUIC Support** - Next-generation HTTP protocol *(Phase 19, v2.7.0)*
+- [ ] 💡 **HTTP/3 / QUIC Support** - Next-generation HTTP protocol *(Phase 19, v2.8.0)*
   - UDP socket layer with batch I/O
   - QUIC transport protocol (RFC 9000) with connection migration
   - HTTP/3 framing (RFC 9114) over QUIC streams
@@ -130,7 +130,7 @@ This document tracks planned features, enhancements, and improvements for the Mo
   - ETag support
   - Cache headers
 
-- [ ] 🔧 **Directory Listing** - Auto-generate directory indexes *(Phase 15, v2.3.0)*
+- [ ] 🔧 **Directory Listing** - Auto-generate directory indexes *(Phase 15, v2.4.0)*
   - Configurable templates
   - File size formatting
   - Sorting options
@@ -143,7 +143,7 @@ This document tracks planned features, enhancements, and improvements for the Mo
   - Context-based rendering
   - HTTP response integration
 
-- [ ] 💡 **Multiple Template Formats** - Support various template languages *(Phase 18, v2.6.0)*
+- [ ] 💡 **Multiple Template Formats** - Support various template languages *(Phase 18, v2.7.0)*
   - Mustache templates (sections, partials, inheritance)
   - Auto-escaping (HTML/URL/JS context-aware)
   - Template includes and compiled template caching
@@ -156,7 +156,7 @@ This document tracks planned features, enhancements, and improvements for the Mo
   - Transaction management
   - Query builder helpers
 
-- [ ] 💡 **Custom File-Based Storage** - Simple data persistence *(Phase 14, v2.2.0)*
+- [ ] 💡 **Custom File-Based Storage** - Simple data persistence *(Phase 14, v2.3.0)*
   - B-tree key-value store (on-disk, memory-mapped)
   - Write-ahead log for crash recovery
   - Transaction support (begin/commit/rollback)
@@ -289,13 +289,13 @@ This document tracks planned features, enhancements, and improvements for the Mo
   - Cache invalidation
   - TTL support
 
-- [ ] 🔧 **Load Balancing** - Distribute traffic *(Phase 16, v2.4.0)*
+- [ ] 🔧 **Load Balancing** - Distribute traffic *(Phase 16, v2.5.0)*
   - Multi-process master-worker model (fork-based)
   - SO_REUSEPORT per-worker accept
   - Worker supervision and auto-restart
   - Per-worker health monitoring
 
-- [ ] 💡 **Worker Pool** - Process management *(Phase 16, v2.4.0)*
+- [ ] 💡 **Worker Pool** - Process management *(Phase 16, v2.5.0)*
   - Multi-process model via fork()
   - Process supervision with auto-restart
   - Zero-downtime hot reload (SIGHUP)
@@ -311,8 +311,8 @@ This document tracks planned features, enhancements, and improvements for the Mo
 
 ### Developer Experience
 
-- [ ] 🔧 **Hot Reload** - Automatic server restart on code changes *(Phase 16, v2.4.0)*
-- [ ] 🔧 **Debug Mode** - Enhanced debugging features *(Phase 18, v2.6.0)*
+- [ ] 🔧 **Hot Reload** - Automatic server restart on code changes *(Phase 16, v2.5.0)*
+- [ ] 🔧 **Debug Mode** - Enhanced debugging features *(Phase 18, v2.7.0)*
   - Verbose logging with request/response headers
   - Request/response inspection with per-middleware timing
   - Memory allocation tracking
@@ -364,7 +364,7 @@ This document tracks planned features, enhancements, and improvements for the Mo
   - GitHub Actions CI: `primary-checks` (Docker GCC build + full ctest + Valgrind), `clang-check`, `macos-check` (pull requests only), `docker-image-check`
   - `tls-check` — a RelWithDebInfo build with `-DWEBLIB_ENABLE_TLS=ON -DWEBLIB_TLS_TEST_HOOKS=ON` running all 13 suites, plus an ASan/UBSan build running the 7 TLS suites
   - Valgrind memory check gate in `primary-checks` (every test binary; a leak in any one fails the job)
-  - Platform coverage today is Linux (GCC + Clang) and macOS (Clang, pull requests only); Windows and BSD runners are still open *(Phase 17, v2.5.0)*
+  - Platform coverage today is Linux (GCC + Clang) and macOS (Clang, pull requests only); Windows and BSD runners are still open *(Phase 17, v2.6.0)*
 
 - [x] ✅ **Benchmarking Suite** - Performance benchmarks
   - Throughput tests (requests/sec)
@@ -373,13 +373,13 @@ This document tracks planned features, enhancements, and improvements for the Mo
 
 ### Cross-Platform
 
-- [ ] 🔧 **Windows Improvements** - Better Windows support *(Phase 17, v2.5.0)*
+- [ ] 🔧 **Windows Improvements** - Better Windows support *(Phase 17, v2.6.0)*
   - IOCP event loop backend (`src/event_loop_iocp.c`)
   - MSVC build support (CMake generator)
   - Windows-specific CI runner
   - Platform abstraction layer (`src/platform.h`)
 
-- [ ] 💡 **BSD Support** - Explicit BSD testing and support *(Phase 17, v2.5.0)*
+- [ ] 💡 **BSD Support** - Explicit BSD testing and support *(Phase 17, v2.6.0)*
   - FreeBSD CI testing
   - OpenBSD CI testing
   - NetBSD CI testing
@@ -473,16 +473,18 @@ For a detailed, phased implementation plan with timelines, priorities, and imple
 
 ### Planned Phases
 
-> Phases 11 and 12 shipped together in v2.0.0 rather than as separate v1.1.0 / v1.2.0 releases, so
-> the version targets below have been re-baselined. Phase numbers and scope are unchanged.
+> Phases 11 and 12 shipped together in v2.0.0 rather than as separate v1.1.0 / v1.2.0 releases, and
+> v2.1.0 was then consumed by an unplanned additive-API release (router response hooks, dev server +
+> end-to-end suite, BUG-11..14), so the version targets below have been re-baselined twice. Phase
+> numbers and scope are unchanged.
 
-- **Phase 13 (v2.1.0)**: 🎯 HTTP/2 Protocol — binary framing, HPACK compression, stream multiplexing, flow control, server push
-- **Phase 14 (v2.2.0)**: 🔧 Persistent Storage Engine — B-tree key-value store, write-ahead log, transactions, crash recovery, iterator API
-- **Phase 15 (v2.3.0)**: 🔧 Advanced Middleware & Content — directory listing, Server-Sent Events, content negotiation, route groups, regex routes
-- **Phase 16 (v2.4.0)**: 🔧 Multi-Process Architecture — master-worker fork model, SO_REUSEPORT, zero-downtime reload, per-worker metrics
-- **Phase 17 (v2.5.0)**: 🔧 Cross-Platform Hardening — platform abstraction layer, Windows IOCP, BSD testing, MSVC build, CI matrix expansion
-- **Phase 18 (v2.6.0)**: 🔧 Developer Experience & Configuration — INI config parser, plugin architecture, advanced templates, debug mode, API versioning
-- **Phase 19 (v2.7.0)**: 💡 HTTP/3 & QUIC — UDP transport, QUIC protocol (RFC 9000), connection migration, HTTP/3 framing, QPACK compression
+- **Phase 13 (v2.2.0)**: 🎯 HTTP/2 Protocol — binary framing, HPACK compression, stream multiplexing, flow control, server push
+- **Phase 14 (v2.3.0)**: 🔧 Persistent Storage Engine — B-tree key-value store, write-ahead log, transactions, crash recovery, iterator API
+- **Phase 15 (v2.4.0)**: 🔧 Advanced Middleware & Content — directory listing, Server-Sent Events, content negotiation, route groups, regex routes
+- **Phase 16 (v2.5.0)**: 🔧 Multi-Process Architecture — master-worker fork model, SO_REUSEPORT, zero-downtime reload, per-worker metrics
+- **Phase 17 (v2.6.0)**: 🔧 Cross-Platform Hardening — platform abstraction layer, Windows IOCP, BSD testing, MSVC build, CI matrix expansion
+- **Phase 18 (v2.7.0)**: 🔧 Developer Experience & Configuration — INI config parser, plugin architecture, advanced templates, debug mode, API versioning
+- **Phase 19 (v2.8.0)**: 💡 HTTP/3 & QUIC — UDP transport, QUIC protocol (RFC 9000), connection migration, HTTP/3 framing, QPACK compression
 - **Phase 20 (v3.0.0)**: 💡 Release Engineering & Ecosystem — CLI tools, Prometheus metrics, OpenTelemetry tracing, fuzz testing, v3.0.0 release
 - **Phase 21 (unscheduled)**: 🎯 Security Residuals & TLS Hardening — external cryptographic audit of `src/tls/`, RSA/ECDSA certificates + X.509 chain validation (and with them browser interop), AES-256-GCM, TLS in async mode, WebSocket over TLS, session resumption, SNI, TLS client mode, PBKDF2 password hashing, request-ID middleware, IP allowlist/denylist
 
@@ -510,5 +512,5 @@ Priorities may change based on community feedback and project direction.
 
 ---
 
-**Last Updated**: 2026-07-27 (v2.0.0)  
+**Last Updated**: 2026-07-29 (v2.1.0)  
 **Maintainer**: [@kamrankhan78694](https://github.com/kamrankhan78694)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-**Version 2.0.0**
+**Version 2.1.0**
 
 The library has shipped a benchmarking module (`src/benchmark.c`) since v0.9.0.
 Until now nothing called it — no example, no test, no CI job — so the

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Modern C Web Library Documentation
 
-**Version 2.0.1**  
+**Version 2.1.0**  
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18793559.svg)](https://doi.org/10.5281/zenodo.18793559)
 
 Welcome to the documentation for Modern C Web Library, a pure C web framework with zero external dependencies.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,6 +1,6 @@
 # Modern C Web Library - API Reference
 
-**Version 2.0.1**
+**Version 2.1.0**
 
 This is the API reference for the Modern C Web Library: the public surface declared
 in `include/kamran.k`, plus the pooled-database API in `include/db_pool.h`. Every

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Modern C Web Library
 
-**Version 2.0.1**
+**Version 2.1.0**
 
 Welcome to the Modern C Web Library! This tutorial walks you from an empty directory
 to a running HTTP server, a JSON API, middleware, and — at the end — an experimental

--- a/docs/tutorials/rest-api.md
+++ b/docs/tutorials/rest-api.md
@@ -1,6 +1,6 @@
 # Building a REST API with Modern C Web Library
 
-**Version 2.0.1**
+**Version 2.1.0**
 
 ## Introduction
 

--- a/docs/tutorials/websocket.md
+++ b/docs/tutorials/websocket.md
@@ -1,6 +1,6 @@
 # Real-Time Applications with WebSocket
 
-**Version 2.0.1**
+**Version 2.1.0**
 
 ## Introduction
 

--- a/include/kamran.k
+++ b/include/kamran.k
@@ -33,11 +33,11 @@ extern "C" {
  * Update these macros (and CMakeLists.txt project VERSION) when releasing.
  */
 #define WEBLIB_VERSION_MAJOR 2
-#define WEBLIB_VERSION_MINOR 0
-#define WEBLIB_VERSION_PATCH 1
+#define WEBLIB_VERSION_MINOR 1
+#define WEBLIB_VERSION_PATCH 0
 
 /** Full version string in "MAJOR.MINOR.PATCH" form. */
-#define WEBLIB_VERSION "2.0.1"
+#define WEBLIB_VERSION "2.1.0"
 
 /** Server identity string embedded in HTTP Server header. */
 #define WEBLIB_VERSION_STRING "weblib/" WEBLIB_VERSION " (author:" WEBLIB_AUTHOR_KAMRAN ")"

--- a/publish-package.sh
+++ b/publish-package.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION=${1:-"2.0.1"}
+VERSION=${1:-"2.1.0"}
 REGISTRY="ghcr.io"
 IMAGE_NAME="kamrankhan78694/modern-c-web-library"
 FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"

--- a/tools/check-consistency.sh
+++ b/tools/check-consistency.sh
@@ -297,6 +297,66 @@ else
 fi
 echo
 
+# ---------------------------------------------------------------------------
+# 6. Present-tense "the current version is X" claims in markdown must match.
+#    Check [1] binds the four BUILD files to CMakeLists.txt, which is why the
+#    header above cites `"currently 2.0.0" in DOCKER_PACKAGE.md` as a motivating
+#    failure — and yet that file's version BADGE then shipped 2.0.0 through both
+#    2.0.1 and 2.1.0, because no check ever read markdown. Checking the build
+#    files and calling the class closed is how it survived: the instance named in
+#    review was fixed, the class was not.
+#
+#    Only forms that can ONLY mean "this is the current version" are matched:
+#    a shields.io version badge, a release-tag badge link, "currently X.Y.Z",
+#    and a `**Version X.Y.Z**` banner. Historical prose ("shipped in 2.0.0",
+#    changelog entries, "fixed in 2.0.1") uses none of these, so it is not
+#    flagged — a checker that cries wolf gets disabled, and then protects
+#    nothing.
+#
+#    USE vs MENTION. Its first run flagged a correct line in
+#    copilot-instructions.md that QUOTES the historical bad strings while
+#    explaining this very failure: `docker push ...:2.0.0` and "currently
+#    2.0.0". Quoting a stale claim is not making one. Backticked and
+#    double-quoted spans are markdown's mention markers, so they are stripped
+#    before version literals are read. The cost is honest and small: a claim
+#    written entirely inside a code span — PUBLISH_GUIDE.md's
+#    "(currently `2.1.0`)" — is not checked here. Every claim that actually went
+#    stale (the badge, five `**Version X.Y.Z**` banners) is bare text and is.
+# ---------------------------------------------------------------------------
+echo "[6] present-tense version claims in markdown match CMakeLists.txt"
+
+if [ -z "$CMAKE_VER" ]; then
+    fail "no CMakeLists.txt version to check markdown against"
+else
+    bad=0
+    while IFS= read -r hit; do
+        [ -z "$hit" ] && continue
+        case "$hit" in CHANGELOG.md:*) continue ;; esac   # release-scoped by definition
+        # Strip mentions (see USE vs MENTION above) before reading versions.
+        used="$(printf '%s' "$hit" | sed 's/`[^`]*`//g; s/"[^"]*"//g')"
+        # Every version literal that survives must be the current one. These
+        # forms are current-version claims by construction, so a different
+        # number is stale, not history.
+        for v in $(printf '%s' "$used" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'); do
+            if [ "$v" != "$CMAKE_VER" ]; then
+                bad=$((bad + 1))
+                printf '          %s\n' "$hit"
+                printf '            ^ claims %s is current; CMakeLists.txt says %s\n' "$v" "$CMAKE_VER"
+                break
+            fi
+        done
+    done <<EOF
+$(git ls-files '*.md' | tr '\n' '\0' | xargs -0 grep -nE \
+    'img\.shields\.io/badge/version-[0-9]+\.[0-9]+\.[0-9]+|releases/tag/v[0-9]+\.[0-9]+\.[0-9]+\)|[Cc]urrently \`?[0-9]+\.[0-9]+\.[0-9]+|\*\*Version [0-9]+\.[0-9]+\.[0-9]+\*\*' 2>/dev/null || true)
+EOF
+    if [ "$bad" -eq 0 ]; then
+        pass "every current-version claim in markdown says $CMAKE_VER"
+    else
+        fail "$bad markdown claim(s) name a version other than $CMAKE_VER as current (listed above)"
+    fi
+fi
+echo
+
 echo "=== $((checks - fails))/$checks checks passed ==="
 if [ "$fails" -gt 0 ]; then
     echo "FAILED: $fails check(s). These are mechanical facts, not style opinions —" >&2


### PR DESCRIPTION
Cuts **v2.1.0** from `main` (everything through PR #140).

## Why MINOR, not PATCH

The release adds public API — `router_add_response_hook()`, `router_has_middleware()`, `http_response_send_html()`, `http_request_clear_params()`, `http_server_port()` — so semver says MINOR. It is additive only. The single observable behaviour change is `http_response_send_text()` **replacing** rather than appending `Content-Type`; the old behaviour emitted two `Content-Type` headers, which is invalid per RFC 9110, so no correct caller could have relied on it.

## What's in it

Everything came out of running the library in a browser rather than reading it — a dev server surfaced wiring defects that 166 unit tests, Valgrind and ASan had all missed.

- **`/metrics` status counters were always zero (#136)** — `metrics_record_status()` was public, unit-tested, and called by nothing. Fixed by giving the router a post-handler phase (`router_add_response_hook()`), which is generic on purpose: access logs, timing and tracing all needed it, and its absence is *why* the bug existed.
- **`HEAD` per RFC 9110 §9.3.2** — in both the threaded and async paths. The async writer leaked a body after HEAD headers, which on a keep-alive connection is a response-queue desync (the request-smuggling family).
- **BUG-11 … BUG-14 closed**, each with a regression test verified to fail against the pre-fix code.
- **`StressDemoApp`** — the first suite that exercises the assembled system over a real socket.

Full detail in the `[2.1.0]` section of [CHANGELOG.md](CHANGELOG.md).

## Roadmap re-baseline

`v2.1.0` was penciled for Phase 13 (HTTP/2). This unplanned release consumes it, so Phases 13–19 shift one minor to **v2.2.0–v2.8.0**; Phase 20 keeps v3.0.0. Scope and week counts are unchanged. Recorded as revision **4.1** in `NEXT_PHASE.md` — the 4.0 entry still says v2.1.0–v3.0.0, because that is what was true when it was written.

## Two release gates that were not gating

Found while preparing this release, both fixed here:

**CI's "Production Docker Image" job built the wrong file.** It built `./Dockerfile`; the published image comes from `./Dockerfile.release`. A green check proved nothing about the artifact being released, and `Dockerfile.release` was first built *inside the publish workflow, after the tag was pushed*. The two differ materially — Release build type, tests off, the `websocket_echo_server` entrypoint, a non-root user, the version LABELs. Now it builds the release file, verifies `websocket_echo_server` (never checked before), and asserts the image's `org.opencontainers.image.version` LABEL equals `CMakeLists.txt`. A comment claiming a `paths:` filter that never existed was removed.

**`DOCKER_PACKAGE.md`'s version badge shipped `2.0.0` through two releases.** `check-consistency.sh` exists *because of this exact class* — its header cites `"currently 2.0.0" in DOCKER_PACKAGE.md` as a motivating failure — but check [1] only reads the four build files, so nothing ever read markdown. The instance named in review got fixed; the class did not. New **check [6]** covers present-tense version claims in markdown, and immediately caught **six more stale claims this release's manual sweep had missed**, including `**Version 2.0.1**` banners in `docs/api/README.md` and all three tutorials.

It matches only forms that can *only* mean "this is current" (shields.io version badge, release-tag badge link, `currently X.Y.Z`, `**Version X.Y.Z**` banner) and strips backticked and double-quoted spans first — its first run flagged a **correct** line that quotes the historical bad strings while explaining this very failure, and a checker that cries wolf gets switched off. Verified to fail on a reintroduced stale badge.

## Verification

| Check | Result |
|---|---|
| Default build | 7/7 suites, 0 warnings |
| TLS build (`-DWEBLIB_ENABLE_TLS=ON -DWEBLIB_TLS_TEST_HOOKS=ON`) | 14/14 suites |
| Unit / stress tests | 177 / 38 |
| `test_weblib` under macOS `leaks` | 0 leaks, 0 bytes |
| Consistency checks | 15/15 (was 14, +check [6]) |
| Built binary at runtime | `demo_app` banner and `/api/info` both report `2.1.0` |

Also repaired the CHANGELOG reference links: `[2.0.1]` and `[2.1.0]` had no definitions, and `[Unreleased]` still compared from `v2.0.0`.

## After merge

Tag `v2.1.0` and publish the GitHub release — `docker-publish.yml`'s `type=semver` patterns only fire on a tag ref, so the versioned image tags (`2.1.0`, `2.1`, `2`) do not exist until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)